### PR TITLE
Soft and hard delete rows in targets (postgres and snowflake)

### DIFF
--- a/singer-connectors/target-postgres/target_postgres/db_sync.py
+++ b/singer-connectors/target-postgres/target_postgres/db_sync.py
@@ -291,6 +291,12 @@ class DbSync:
             for index in indices:
                 self.create_index(schema, index)
 
+    def delete_rows(self, stream):
+        table = self.table_name(stream, False)
+        query = "DELETE FROM {} WHERE _sdc_deleted_at IS NOT NULL RETURNING _sdc_deleted_at".format(table)
+        logger.info("Deleting rows from '{}' table... {}".format(table, query))
+        logger.info("DELETE {}".format(len(self.query(query))))
+
     def create_schema_if_not_exists(self):
         schema_name = self.connection_config['schema']
         schema_rows = self.query(

--- a/singer-connectors/target-snowflake/target_snowflake/db_sync.py
+++ b/singer-connectors/target-snowflake/target_snowflake/db_sync.py
@@ -301,6 +301,12 @@ class DbSync:
         elif isinstance(grantees, str):
             grant_method(schema, grantees)
 
+    def delete_rows(self, stream):
+        table = self.table_name(stream, False)
+        query = "DELETE FROM {} WHERE _sdc_deleted_at IS NOT NULL RETURNING _sdc_deleted_at".format(table)
+        logger.info("Deleting rows from '{}' table... {}".format(table, query))
+        logger.info("DELETE {}".format(len(self.query(query))))
+
     def create_schema_if_not_exists(self):
         schema_name = self.connection_config['schema']
         schema_rows = self.query(


### PR DESCRIPTION
DELETE events automatically captured by tap-mysql and tap-postgtres if Log-Based incremental load is enabled so when it's reading the Binary Log in the source DB to detect changes. Once a deleted row event detected it sends the information to every target connector by adding an extra `_sdc_deleted_at` key to the record in the following format:
 
```{"type": "RECORD", "stream": "test_table", "record": {"col1": "data 1-1xxy", "col2": "data 1-2", "col3": "data-1-3", "_sdc_deleted_at": "2018-11-22T12:51:30+00:00+00:00"}, "version": 1542801780649, "time_extracted": "2018-11-22T19:08:38.459001Z"}```

The postgres and snowflake target connectors currently ignoring this property and the delete events are skipped on target databases.  This PR adds two options to deal with the deleted events: **Soft Delete Mode** and **Hard Delete Mode**.

The logic is based on Deleted Records Handling and documented at  https://www.stitchdata.com/docs/replication/deleted-record-handling

**Soft Delete Mode**: Flags the deleted row in destination but doesn't remove the record from the destination. It adds metadata columns to the tables including the deleted flag and further statistics about the load. The complete list of metadata columns are detailed at https://www.stitchdata.com/docs/data-structure/integration-schemas#sdc-columns
Example:
![image](https://user-images.githubusercontent.com/643687/48919803-dfa89680-ee8c-11e8-8cf7-6cb09628f2a2.png)

To enable this mode add `"add_metadata_columns": true` to tap-postgres and/or tap-snowflake `config.json`


**Hard Delete Mode**: Completely removes the deleted record from the target table. It is an extended mode of the **Soft Delete Mode** and periodically running a `DELETE FROM ... WHERE _sdc_deleted_at IS NOT NULL` when loading a batch is finished. In case of PostgreSQL an index automatically will be created on `_sdc_deleted_at` columns to run the DELETE fast.  

To enable this mode add `"hard_delete": true` to tap-postgres and/or tap-snowflake `config.json`

