### PR TITLE
Optional grant-select-to argument to fastsync tables

### DIFF
--- a/fastsync/mysql-to-snowflake/mysql_to_snowflake/snowflake.py
+++ b/fastsync/mysql-to-snowflake/mysql_to_snowflake/snowflake.py
@@ -55,6 +55,7 @@ class Snowflake:
         sql = "CREATE SCHEMA IF NOT EXISTS {}".format(schema)
         self.query(sql)
 
+
     def copy_to_table(self, s3_key, target_schema, table_name, is_temporary):
         utils.log("SNOWFLAKE - Loading {} into Snowflake...".format(s3_key))
         table_dict = utils.tablename_to_dict(table_name)
@@ -72,6 +73,22 @@ class Snowflake:
 
         utils.log("SNOWFLAKE - Deleting {} from S3...".format(s3_key))
         self.s3.delete_object(Bucket=bucket, Key=s3_key)
+
+
+    def grant_select_on_table(self, target_schema, table_name, role, is_temporary):
+        # Grant role is not mandatory parameter, do nothing if not specified
+        if role:
+            table_dict = utils.tablename_to_dict(table_name)
+            target_table = table_dict.get('name') if not is_temporary else table_dict.get('temp_name')
+            sql = "GRANT SELECT ON {}.{} TO ROLE {}".format(target_schema, target_table, role)
+            self.query(sql)
+
+
+    def grant_select_on_schema(self, target_schema, role):
+        # Grant role is not mandatory parameter, do nothing if not specified
+        if role:
+            sql = "GRANT SELECT ON ALL TABLES IN SCHEMA {} TO ROLE {}".format(target_schema,role)
+            self.query(sql)
 
 
     def obfuscate_columns(self, target_schema, table_name):

--- a/fastsync/mysql-to-snowflake/mysql_to_snowflake/utils.py
+++ b/fastsync/mysql-to-snowflake/mysql_to_snowflake/utils.py
@@ -70,6 +70,8 @@ def parse_args(required_config_keys):
     --snowflake-config  Snowflake Config file
     --transform-config  Transformations Config file
     --tables            Tables to sync. (Separated by comma)
+    --target-schema     Target schema to load tables into
+    --grant-select-to   Grant select on all tables in target schema
     --export-dir        Directory to create temporary csv exports. Defaults to current work dir.
 
     Returns the parsed args object from argparse. For each argument that
@@ -109,6 +111,11 @@ def parse_args(required_config_keys):
         '--target-schema',
         help='Target schema in snowflake',
         required=True)
+
+    parser.add_argument(
+        '--grant-select-to',
+        help='Grant select on all tables in target schema'
+    )
 
     parser.add_argument(
         '--export-dir',

--- a/fastsync/postgres-to-snowflake/postgres_to_snowflake/utils.py
+++ b/fastsync/postgres-to-snowflake/postgres_to_snowflake/utils.py
@@ -31,6 +31,8 @@ def parse_args(required_config_keys):
     --snowflake-config  Snowflake Config file
     --transform-config  Transformations Config file
     --tables            Tables to sync. (Separated by comma)
+    --target-schema     Target schema to load tables into
+    --grant-select-to   Grant select on all tables in target schema
     --export-dir        Directory to create temporary csv exports. Defaults to current work dir.
 
     Returns the parsed args object from argparse. For each argument that
@@ -70,6 +72,11 @@ def parse_args(required_config_keys):
         '--target-schema',
         help='Target schema in snowflake',
         required=True)
+
+    parser.add_argument(
+        '--grant-select-to',
+        help='Grant select on all tables in target schema'
+    )
 
     parser.add_argument(
         '--export-dir',


### PR DESCRIPTION
optional `--grant-select-to` CLI argument. This grants permissions in two steps:

* `GRANT SELECT ON ALL TABLES IN SCHEMA {} TO ROLE {}` <- All tables when the sync completed

* `GRANT SELECT ON {}.{}_temp TO ROLE {}` <- grant select on individual temp tables at load time. Once the table is loaded the the `ALTER TABLE ... SWAP WITH ...` copies the permissions. This is required to give access to users before the full sync completed
