### PR TITLE
AP-111: add BINARY and VARBINARY support 

### DIFF
--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
-tap-mysql-koszti==1.0.3
+tap-mysql-koszti==1.0.4


### PR DESCRIPTION
BINARY and VARBINARY support is added into our tap-mysql fork at https://github.com/koszti/tap-mysql-koszti/commit/6337fad7d2fa3bcdc5698995d85d4ad74d84ccbe The latest version has been published to pypi and it's now available to use by any python project.

PR with the same changes sent to the official tap-mysql repository but hasn't been merged. 