### PR TITLE
lowest valid date in mysql with sql_mode=NO_ZERO_DATE

### DIFF
--- a/fastsync/mysql-to-snowflake/mysql_to_snowflake/mysql.py
+++ b/fastsync/mysql-to-snowflake/mysql_to_snowflake/mysql.py
@@ -150,7 +150,7 @@ class MySql:
                             WHEN data_type IN ('bit')
                                     THEN concat('cast(`', column_name, '` AS unsigned)')
                             WHEN data_type IN ('datetime', 'timestamp', 'date')
-                                    THEN concat('nullif(`', column_name, '`,"0000-00-00 00:00:00")')
+                                    THEN concat('nullif(`', column_name, '`,"1000-01-01 00:00:00")')
                             WHEN column_name = 'raw_data_hash'
                                     THEN concat('hex(', column_name, ')')
                             ELSE concat('cast(`', column_name, '` AS char CHARACTER SET utf8)')


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/5.7/en/datetime.html

One of the many MySQL idiosyncrasies, is that although the lowest valid datetime is '1000-01-01 00:00:00' , early versions allowed '0000-00-00 00:00:00' as a default value.

this is creating issues when sql_mode=NO_ZERO_DATE is set