### PR TITLE
accommodate MySQL convention of allowing numbers greater than 0 to present TRUE

### DIFF
--- a/fastsync/mysql-to-snowflake/mysql_to_snowflake/mysql.py
+++ b/fastsync/mysql-to-snowflake/mysql_to_snowflake/mysql.py
@@ -152,7 +152,7 @@ class MySql:
                             WHEN data_type IN ('datetime', 'timestamp', 'date')
                                     THEN concat('nullif(`', column_name, '`,"0000-00-00 00:00:00")')
                             WHEN column_type IN ('tinyint(1)')
-                                    THEN concat('CASE WHEN `' , column_name , '` is null THEN null WHEN `' , column_name , '` = 0 THEN 0 ELSE 1 END CASE)')
+                                    THEN concat('CASE WHEN `' , column_name , '` is null THEN null WHEN `' , column_name , '` = 0 THEN 0 ELSE 1 END')
                             WHEN column_name = 'raw_data_hash'
                                     THEN concat('hex(', column_name, ')')
                             ELSE concat('cast(`', column_name, '` AS char CHARACTER SET utf8)')


### PR DESCRIPTION
accommodate MySQL convention of allowing numbers greater than 0 to present TRUE