### PR TITLE
bump tap-postgres to 1.0.2

### DIFF
--- a/singer-connectors/tap-postgres/requirements.txt
+++ b/singer-connectors/tap-postgres/requirements.txt
@@ -1,1 +1,1 @@
-tap-postgres-koszti==1.0.1
+tap-postgres-koszti==1.0.2


### PR DESCRIPTION
Adds `filter_schemas` option to our tap-postgres fork. The current `filter_dbs` is filtering databases and not schemas. In tap-mysql it's fine because db and schema are synonyms but not in postgres.

Dist package published to PyPI in 1.0.2: https://pypi.org/project/tap-postgres-koszti/

Change in tap-postgres fork:
https://github.com/koszti/tap-postgres-koszti/commit/5bb36032b5a2938f701885d8e4db5812901d65f6