### PR TITLE
bump version to 1.0.3

### DIFF
--- a/singer-connectors/tap-postgres/requirements.txt
+++ b/singer-connectors/tap-postgres/requirements.txt
@@ -1,1 +1,1 @@
-tap-postgres-koszti==1.0.2
+tap-postgres-koszti==1.0.3


### PR DESCRIPTION
change is in the forked tap-postgres at https://github.com/koszti/tap-postgres-koszti/commit/80a0b758ecc5a02fc72f75e395c9e914bbfaace6