### PR TITLE
Serialise decimal incremental key position as float

### DIFF
--- a/fastsync/mysql-to-snowflake/mysql_to_snowflake/mysql.py
+++ b/fastsync/mysql-to-snowflake/mysql_to_snowflake/mysql.py
@@ -3,6 +3,7 @@ import gzip
 import csv
 import os
 import datetime
+import decimal
 
 import mysql_to_snowflake.utils as utils
 
@@ -118,6 +119,9 @@ class MySql:
 
             elif isinstance(mysql_key_value, datetime.date):
                 key_value = mysql_key_value.isoformat() + 'T00:00:00'
+
+            elif isinstance(postgres_key_value, decimal.Decimal):
+                key_value = float(postgres_key_value)
 
             return {
                 "key": replication_key,

--- a/fastsync/postgres-to-snowflake/postgres_to_snowflake/postgres.py
+++ b/fastsync/postgres-to-snowflake/postgres_to_snowflake/postgres.py
@@ -2,6 +2,7 @@ import psycopg2
 from psycopg2 import extras
 import gzip
 import datetime
+import decimal
 
 import postgres_to_snowflake.utils as utils
 
@@ -94,6 +95,9 @@ class Postgres:
 
             elif isinstance(postgres_key_value, datetime.date):
                 key_value = postgres_key_value.isoformat() + 'T00:00:00'
+
+            elif isinstance(postgres_key_value, decimal.Decimal):
+                key_value = float(postgres_key_value)
 
             return {
                 "key": replication_key,


### PR DESCRIPTION
When incremental key in source DB is a decimal (i.e. NUMERIC type in postgres) then fastsync was failing because it cannot serialise the decimal values to the JSON state files.

This caused an issue when added amljira db (https://github.com/transferwise/analytics-platform-config/pull/210). They use NUMERIC datatype in postgres with decimal point as the incremental key.

As a workaround I skipped the first fastsync and made initial sync with singer.
