### PR TITLE
bump tap-salesforce version

### DIFF
--- a/singer-connectors/tap-salesforce/requirements.txt
+++ b/singer-connectors/tap-salesforce/requirements.txt
@@ -1,1 +1,1 @@
-tap-salesforce==1.4.23
+pipelinewise-tap-salesforce==1.0.0


### PR DESCRIPTION
Using the pipelinewise forked version of salesforce tap that includes the fix that allows INCREMENTAL load.