### PR TITLE
More logging

### DIFF
--- a/fastsync/mysql-to-snowflake/mysql_to_snowflake/__init__.py
+++ b/fastsync/mysql-to-snowflake/mysql_to_snowflake/__init__.py
@@ -209,6 +209,7 @@ def sync_table(table):
             snowflake.grant_select_on_schema(target_schema, grantee)
 
     except Exception as exc:
+        utils.log("CRITICAL - {}: {}".format(table, exc))
         return "{}: {}".format(table, exc)
 
 

--- a/fastsync/postgres-to-snowflake/postgres_to_snowflake/__init__.py
+++ b/fastsync/postgres-to-snowflake/postgres_to_snowflake/__init__.py
@@ -215,6 +215,7 @@ def sync_table(table):
             snowflake.grant_select_on_schema(target_schema, grantee)
 
     except Exception as exc:
+        utils.log("CRITICAL - {}: {}".format(table, exc))
         return "{}: {}".format(table, exc)
 
 


### PR DESCRIPTION
If we fast sync lot of tables and one of them fails then we need to wait until the entire process finishing to see exceptions in the summary table.

This PR logs the exception immediately into log file. 