### PR TITLE
Local dev env with recent mariadb and postgres dbs with test data

### DIFF
--- a/.env
+++ b/.env
@@ -1,20 +1,23 @@
 # Development environment settings for docker compose
 
 # Test Postgres database credentials used as test source database
-DB_TAP_POSTGRES_PORT=15432
+DB_TAP_POSTGRES_PORT=5432
+DB_TAP_POSTGRES_PORT_ON_HOST=15432
 DB_TAP_POSTGRES_USER=pipelinewise
-DB_TAP_POSRTGRES_PASSWORD=secret
+DB_TAP_POSTGRES_PASSWORD=secret
 DB_TAP_POSTGRES_DB=postgres_source_db
 
 # Test MySQL database credentials used as test source database
-DB_TAP_MYSQL_PORT=13306
+DB_TAP_MYSQL_PORT=3306
+DB_TAP_MYSQL_PORT_ON_HOST=13306
 DB_TAP_MYSQL_ROOT_PASSWORD=secret
 DB_TAP_MYSQL_USER=pipelinewise
 DB_TAP_MYSQL_PASSWORD=secret
-DB_TAP_MYSQL_DATABASE=mysql_source_db
+DB_TAP_MYSQL_DB=mysql_source_db
 
 # Test Postgres database credentials used as target database
-DB_TARGET_POSTGRES_PORT=15433
+DB_TARGET_POSTGRES_PORT=5432
+DB_TARGET_POSTGRES_PORT_ON_HOST=15433
 DB_TARGET_POSTGRES_USER=pipelinewise
-DB_TARGET_POSRTGRES_PASSWORD=secret
+DB_TARGET_POSTGRES_PASSWORD=secret
 DB_TARGET_POSTGRES_DB=postgres_dwh

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you have [Docker](https://www.docker.com/) and [Docker Compose](https://docs.
 easily create a local development environment setup quickly that includes not only the PipelineWise executables but
 some open source databases for a more convenient development experience:
 * PipelineWise CLI with every supported tap and target connectors
-* MySQL test source database    (for tap-mysql)
+* MariaDB test source database  (for tap-mysql)
 * Postgres test source database (for tap-postgres)
 * Postgres test target database (for target-snowflake)
 
@@ -156,7 +156,7 @@ The docker environment
 | Database      | Port (from docker host) | Port (inside from CLI container) | Database Name      |
 |---------------|-------------------------|----------------------------------|--------------------|
 | Postgres (1)  | localhost:15432         | db_postgres_source:5432          | postgres_source_db |
-| MySQL         | localhost:13306         | db_mysql_source:3306             | mysql_source_db    |
+| MariaDB       | localhost:13306         | db_mysql_source:3306             | mysql_source_db    |
 | Postgres (2)  | localhost:15433         | db_postgres_dwh:5432             | postgres_dwh       |
 
 For user and passwords check the `.env` file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,26 @@ services:
     entrypoint: /usr/src/app/docker-entrypoint.sh
     environment:
       PIPELINEWISE_HOME: /usr/src/app
+      DB_TAP_MYSQL_HOST: db_mysql_source
       DB_TAP_MYSQL_PORT: ${DB_TAP_MYSQL_PORT}
+      DB_TAP_MYSQL_PORT_ON_HOST: ${DB_TAP_MYSQL_PORT_ON_HOST}
+      DB_TAP_MYSQL_USER: ${DB_TAP_MYSQL_USER}
+      DB_TAP_MYSQL_PASSWORD: ${DB_TAP_MYSQL_PASSWORD}
+      DB_TAP_MYSQL_DB: ${DB_TAP_MYSQL_DB}
+
+      DB_TAP_POSTGRES_HOST: db_postgres_source
       DB_TAP_POSTGRES_PORT: ${DB_TAP_POSTGRES_PORT}
+      DB_TAP_POSTGRES_PORT_ON_HOST: ${DB_TAP_POSTGRES_PORT_ON_HOST}
+      DB_TAP_POSTGRES_USER: ${DB_TAP_POSTGRES_USER}
+      DB_TAP_POSTGRES_PASSWORD: ${DB_TAP_POSTGRES_PASSWORD}
+      DB_TAP_POSTGRES_DB: ${DB_TAP_POSTGRES_DB}
+
+      DB_TARGET_POSTGRES_HOST: db_postgres_dwh
       DB_TARGET_POSTGRES_PORT: ${DB_TARGET_POSTGRES_PORT}
+      DB_TARGET_POSTGRES_PORT_ON_HOST: ${DB_TARGET_POSTGRES_PORT_ON_HOST}
+      DB_TARGET_POSTGRES_USER: ${DB_TARGET_POSTGRES_USER}
+      DB_TARGET_POSTGRES_PASSWORD: ${DB_TARGET_POSTGRES_PASSWORD}
+      DB_TARGET_POSTGRES_DB: ${DB_TARGET_POSTGRES_DB}
 
     volumes:
       - .:/usr/src/app
@@ -26,36 +43,37 @@ services:
   ### TAP (Data source) containers
   # PostgreSQL service container used as test source database
   db_postgres_source:
-    image: circleci/postgres:9.6.14
+    image: postgres:11.4
     container_name: pipelinewise_dev_postgres_source
     ports:
-      - ${DB_TAP_POSTGRES_PORT}:5432
+      - ${DB_TAP_POSTGRES_PORT_ON_HOST}:${DB_TAP_POSTGRES_PORT}
     environment:
       POSTGRES_USER: ${DB_TAP_POSTGRES_USER}
-      POSTGRES_PASSWORD: ${DB_TAP_POSRTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${DB_TAP_POSTGRES_PASSWORD}
       POSTGRES_DB: ${DB_TAP_POSTGRES_DB}
 
   # MySQL service container used as test source database
   db_mysql_source:
-    image: circleci/mysql:5.7.26
+    image: mariadb:10.2.26
     container_name: pipelinewise_dev_mysql_source
     ports:
-      - ${DB_TAP_MYSQL_PORT}:3306
+      - ${DB_TAP_MYSQL_PORT_ON_HOST}:${DB_TAP_MYSQL_PORT}
+    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_TAP_MYSQL_ROOT_PASSWORD}
       MYSQL_USER: ${DB_TAP_MYSQL_USER}
       MYSQL_PASSWORD: ${DB_TAP_MYSQL_PASSWORD}
-      MYSQL_DATABASE: ${DB_TAP_MYSQL_DATABASE}
+      MYSQL_DATABASE: ${DB_TAP_MYSQL_DB}
 
   ### Target containers
   # PostgreSQL service container used as test target database
   db_postgres_dwh:
-    image: circleci/postgres:9.6.14
+    image: postgres:11.4
     container_name: pipelinewise_dev_postgres_dwh
     ports:
-      - ${DB_TARGET_POSTGRES_PORT}:5432
+      - ${DB_TARGET_POSTGRES_PORT_ON_HOST}:${DB_TARGET_POSTGRES_PORT}
     environment:
       POSTGRES_USER: ${DB_TARGET_POSTGRES_USER}
-      POSTGRES_PASSWORD: ${DB_TARGET_POSRTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${DB_TARGET_POSTGRES_PASSWORD}
       POSTGRES_DB: ${DB_TARGET_POSTGRES_DB}
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# Install OS dependencies
+apt-get update
+apt-get install -y mariadb-client postgresql-client
+
+# Build test databasese
+tests/db/tap_mysql_test_db.sh
+tests/db/tap_postgres_test_db.sh
+
 # Install PipelineWise in the container
 ./install.sh --acceptlicenses --nousage --withtestextras
 if [[ $? != 0 ]]; then
@@ -20,9 +28,9 @@ echo "PipelineWise Dev environment is ready in Docker container(s)."
 echo
 echo "Running containers:"
 echo "   - PipelineWise CLI and connectors"
-echo "   - PostgreSQL server with test database  (From host: localhost:${DB_TAP_POSTGRES_PORT} - From CLI: db_postgres_source:5432)"
-echo "   - MySQL server with test database       (From host: localhost:${DB_TAP_MYSQL_PORT} - From CLI: db_mysql_source:3306)"
-echo "   - PostgreSQL server with empty database (From host: localhost:${DB_TARGET_POSTGRES_PORT} - From CLI: db_postgres_dwh:5432)"
+echo "   - PostgreSQL server with test database  (From host: localhost:${DB_TAP_POSTGRES_PORT_ON_HOST} - From CLI: ${DB_TAP_POSTGRES_HOST}:${DB_TAP_POSTGRES_PORT})"
+echo "   - MariaDB server with test database     (From host: localhost:${DB_TAP_MYSQL_PORT_ON_HOST} - From CLI: ${DB_TAP_MYSQL_HOST}:${DB_TAP_MYSQL_PORT})"
+echo "   - PostgreSQL server with empty database (From host: localhost:${DB_TARGET_POSTGRES_PORT_ON_HOST} - From CLI: ${DB_TARGET_POSTGRES_HOST}:${DB_TARGET_POSTGRES_PORT})"
 echo "(For database credentials check .env file)"
 echo
 echo

--- a/tests/db/tap_mysql_test_db.sh
+++ b/tests/db/tap_mysql_test_db.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+#
+# Building a test MySQL database for integration testing of tap-mysql 
+# The sample database available at https://github.com/ikostan/RESTAURANT-DATABASE
+
+TEST_DB_URL=https://raw.githubusercontent.com/ikostan/RESTAURANT-DATABASE/master/DB_backup/structure_and_data/grp24.sql
+TEST_DB_TMP_SQL=/tmp/test-mysql-db.sql
+echo "Building test MySQL database from ${TEST_DB_URL}..."
+
+# To run this script some environment variables must be set.
+# Normally it's defined in .circleci/config.yml
+if [[ -z "${DB_TAP_MYSQL_HOST}" || -z "${DB_TAP_MYSQL_PORT}" || -z "${DB_TAP_MYSQL_USER}" || -z "${DB_TAP_MYSQL_PASSWORD}" || -z "${DB_TAP_MYSQL_DB}" ]]; then
+    echo "ERROR: One or more required environment variable is not defined:"
+    echo "       - DB_TAP_MYSQL_HOST"
+    echo "       - DB_TAP_MYSQL_PORT"
+    echo "       - DB_TAP_MYSQL_USER"
+    echo "       - DB_TAP_MYSQL_PASSWORD"
+    echo "       - DB_TAP_MYSQL_DB"
+    exit 1
+fi
+
+# Pass environment variables to MySQL compatible ones
+export MYSQL_PWD=${DB_TAP_MYSQL_PASSWORD} 
+
+# Download the sample database and build it
+wget -O ${TEST_DB_TMP_SQL} ${TEST_DB_URL}
+mysql --protocol TCP --host ${DB_TAP_MYSQL_HOST} --port ${DB_TAP_MYSQL_PORT} --user ${DB_TAP_MYSQL_USER} ${DB_TAP_MYSQL_DB} < ${TEST_DB_TMP_SQL}
+rm -f ${TEST_DB_TMP_SQL}

--- a/tests/db/tap_postgres_test_db.sh
+++ b/tests/db/tap_postgres_test_db.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+#
+# Building a test PostgreSQL database for integration testing of tap-postgres 
+# The sample database available at https://github.com/morenoh149/postgresDBSamples
+
+TEST_DB_URL=https://raw.githubusercontent.com/morenoh149/postgresDBSamples/master/worldDB-1.0/world.sql
+TEST_DB_TMP_SQL=/tmp/test-postgres-db.sql
+echo "Building test PostgreSQL database from ${TEST_DB_URL}..."
+
+# To run this script some environment variables must be set.
+# Normally it's defined in .circleci/config.yml
+if [[ -z "${DB_TAP_POSTGRES_HOST}" || -z "${DB_TAP_POSTGRES_PORT}" || -z "${DB_TAP_POSTGRES_USER}" || -z "${DB_TAP_POSTGRES_PASSWORD}" || -z "${DB_TAP_POSTGRES_DB}" ]]; then
+    echo "ERROR: One or more required environment variable is not defined:"
+    echo "       - DB_TAP_POSTGRES_HOST"
+    echo "       - DB_TAP_POSTGRES_PORT"
+    echo "       - DB_TAP_POSTGRES_USER"
+    echo "       - DB_TAP_POSTGRES_PASSWORD"
+    echo "       - DB_TAP_POSTGRES_DB"
+    exit 1
+fi
+
+# Create a postgres password file for non-interaction connection
+PGPASSFILE=~/.pgpass
+echo ${DB_TAP_POSTGRES_HOST}:${DB_TAP_POSTGRES_PORT}:${DB_TAP_POSTGRES_DB}:${DB_TAP_POSTGRES_USER}:${DB_TAP_POSTGRES_PASSWORD} > ${PGPASSFILE}
+chmod 0600 ${PGPASSFILE}
+
+# Download the sample database and build it
+wget -O ${TEST_DB_TMP_SQL} ${TEST_DB_URL}
+
+# Drop target tables if exists, the test db sql works only if tables not exist
+psql -U ${DB_TAP_POSTGRES_USER} -h ${DB_TAP_POSTGRES_HOST} -c 'DROP TABLE IF EXISTS public.countrylanguage CASCADE;' ${DB_TAP_POSTGRES_DB}
+psql -U ${DB_TAP_POSTGRES_USER} -h ${DB_TAP_POSTGRES_HOST} -c 'DROP TABLE IF EXISTS public.country CASCADE;' ${DB_TAP_POSTGRES_DB}
+psql -U ${DB_TAP_POSTGRES_USER} -h ${DB_TAP_POSTGRES_HOST} -c 'DROP TABLE IF EXISTS public.city CASCADE;' ${DB_TAP_POSTGRES_DB}
+
+# Build the test DB
+psql -U ${DB_TAP_POSTGRES_USER} -h ${DB_TAP_POSTGRES_HOST} -f ${TEST_DB_TMP_SQL} -d ${DB_TAP_POSTGRES_DB}
+rm -f ${TEST_DB_TMP_SQL}


### PR DESCRIPTION
Creates a full dev env with recent docker images and test data. This allows running end to end tests locally and in circleci. Also, it can be used for local development.

Containers and items:
* MariaDB 10.2.26 (DB for tap_mysql)
* Postgres 11.4 ( 2 DBs for tap_postgres and target_postgres)
* Test databases with sample mysql and postgres databases

To build: `docker-compose up --build`

 