### PR TITLE
Use bash instead of sh on pipelinewise-docker

### DIFF
--- a/bin/pipelinewise-docker
+++ b/bin/pipelinewise-docker
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # This is a startup script when running pipelinewise docker executable image
 #
 # It is required to mount directories from host to read/write project YAML files.


### PR DESCRIPTION
The script uses specific bash constructions, like `[[ $# -gt 0 ]]`, which don't work in other shells like zsh. With this change, we specify that this script needs bash to run, so it works on zsh and others.