### PR TITLE
Adds option to grant user/groups separately in Redshift

### DIFF
--- a/pipelinewise/fastsync/commons/target_postgres.py
+++ b/pipelinewise/fastsync/commons/target_postgres.py
@@ -96,7 +96,10 @@ class FastSyncTargetPostgres:
         #self.s3.delete_object(Bucket=bucket, Key=s3_key)
 
 
-    def grant_select_on_table(self, target_schema, table_name, role, is_temporary):
+    # grant_... functions are common functions called by utils.py: grant_privilege function
+    # "to_group" is not used here but exists for compatibility reasons with other database types
+    # "to_group" is for databases that can grant to users and groups separately like Amazon Redshift
+    def grant_select_on_table(self, target_schema, table_name, role, is_temporary, to_group=False):
         # Grant role is not mandatory parameter, do nothing if not specified
         if role:
             table_dict = utils.tablename_to_dict(table_name)
@@ -105,14 +108,14 @@ class FastSyncTargetPostgres:
             self.query(sql)
 
 
-    def grant_usage_on_schema(self, target_schema, role):
+    def grant_usage_on_schema(self, target_schema, role, to_group=False):
         # Grant role is not mandatory parameter, do nothing if not specified
         if role:
             sql = "GRANT USAGE ON SCHEMA {} TO GROUP {}".format(target_schema,role)
             self.query(sql)
 
 
-    def grant_select_on_schema(self, target_schema, role):
+    def grant_select_on_schema(self, target_schema, role, to_group=False):
         # Grant role is not mandatory parameter, do nothing if not specified
         if role:
             sql = "GRANT SELECT ON ALL TABLES IN SCHEMA {} TO GROUP {}".format(target_schema,role)

--- a/pipelinewise/fastsync/commons/target_redshift.py
+++ b/pipelinewise/fastsync/commons/target_redshift.py
@@ -114,26 +114,26 @@ class FastSyncTargetRedshift:
         self.s3.delete_object(Bucket=bucket, Key=s3_key)
 
 
-    def grant_select_on_table(self, target_schema, table_name, role, is_temporary):
+    def grant_select_on_table(self, target_schema, table_name, grantee, is_temporary, to_group=False):
         # Grant role is not mandatory parameter, do nothing if not specified
-        if role:
+        if grantee:
             table_dict = utils.tablename_to_dict(table_name)
             target_table = table_dict.get('table_name') if not is_temporary else table_dict.get('temp_table_name')
-            sql = "GRANT SELECT ON {}.{} TO GROUP {}".format(target_schema, target_table, role)
+            sql = "GRANT SELECT ON {}.{} TO {} {}".format(target_schema, target_table, 'GROUP' if to_group else '', grantee)
             self.query(sql)
 
 
-    def grant_usage_on_schema(self, target_schema, role):
+    def grant_usage_on_schema(self, target_schema, grantee, to_group=False):
         # Grant role is not mandatory parameter, do nothing if not specified
-        if role:
-            sql = "GRANT USAGE ON SCHEMA {} TO GROUP {}".format(target_schema,role)
+        if grantee:
+            sql = "GRANT USAGE ON SCHEMA {} TO {} {}".format(target_schema, 'GROUP' if to_group else '', grantee)
             self.query(sql)
 
 
-    def grant_select_on_schema(self, target_schema, role):
+    def grant_select_on_schema(self, target_schema, grantee, to_group=False):
         # Grant role is not mandatory parameter, do nothing if not specified
-        if role:
-            sql = "GRANT SELECT ON ALL TABLES IN SCHEMA {} TO GROUP {}".format(target_schema,role)
+        if grantee:
+            sql = "GRANT SELECT ON ALL TABLES IN SCHEMA {} TO {} {}".format(target_schema, 'GROUP' if to_group else '', grantee)
             self.query(sql)
 
 

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -151,7 +151,10 @@ class FastSyncTargetSnowflake:
         self.s3.delete_object(Bucket=bucket, Key=s3_key)
 
 
-    def grant_select_on_table(self, target_schema, table_name, role, is_temporary):
+    # grant_... functions are common functions called by utils.py: grant_privilege function
+    # "to_group" is not used here but exists for compatibility reasons with other database types
+    # "to_group" is for databases that can grant to users and groups separately like Amazon Redshift
+    def grant_select_on_table(self, target_schema, table_name, role, is_temporary, to_group=False):
         # Grant role is not mandatory parameter, do nothing if not specified
         if role:
             table_dict = utils.tablename_to_dict(table_name)
@@ -160,14 +163,14 @@ class FastSyncTargetSnowflake:
             self.query(sql)
 
 
-    def grant_usage_on_schema(self, target_schema, role):
+    def grant_usage_on_schema(self, target_schema, role, to_group=False):
         # Grant role is not mandatory parameter, do nothing if not specified
         if role:
             sql = "GRANT USAGE ON SCHEMA {} TO ROLE {}".format(target_schema,role)
             self.query(sql)
 
 
-    def grant_select_on_schema(self, target_schema, role):
+    def grant_select_on_schema(self, target_schema, role, to_group=False):
         # Grant role is not mandatory parameter, do nothing if not specified
         if role:
             sql = "GRANT SELECT ON ALL TABLES IN SCHEMA {} TO ROLE {}".format(target_schema,role)

--- a/pipelinewise/fastsync/mysql_to_redshift.py
+++ b/pipelinewise/fastsync/mysql_to_redshift.py
@@ -120,9 +120,9 @@ def sync_table(table):
             lock.release()
 
         # Table loaded, grant select on all tables in target schema
-        for grantee in utils.get_grantees(args.target, table):
-            redshift.grant_usage_on_schema(target_schema, grantee)
-            redshift.grant_select_on_schema(target_schema, grantee)
+        grantees = utils.get_grantees(args.target, table)
+        utils.grant_privilege(target_schema, grantees, redshift.grant_usage_on_schema)
+        utils.grant_privilege(target_schema, grantees, redshift.grant_select_on_schema)
 
     except Exception as exc:
         utils.log("CRITICAL: {}".format(exc))

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -119,9 +119,9 @@ def sync_table(table):
             lock.release()
 
         # Table loaded, grant select on all tables in target schema
-        for grantee in utils.get_grantees(args.target, table):
-            snowflake.grant_usage_on_schema(target_schema, grantee)
-            snowflake.grant_select_on_schema(target_schema, grantee)
+        grantees = utils.get_grantees(args.target, table)
+        utils.grant_privilege(target_schema, grantees, snowflake.grant_usage_on_schema)
+        utils.grant_privilege(target_schema, grantees, snowflake.grant_select_on_schema)
 
     except Exception as exc:
         utils.log("CRITICAL: {}".format(exc))
@@ -155,8 +155,8 @@ def main_impl():
         table_sync_excs = list(filter(None, p.map(sync_table, args.tables)))
 
     # Refresh information_schema columns cache
-    snowflake = FastSyncTargetSnowflake(args.target, args.transform)
-    snowflake.cache_information_schema_columns(args.tables)
+    #snowflake = FastSyncTargetSnowflake(args.target, args.transform)
+    #snowflake.cache_information_schema_columns(args.tables)
 
     # Log summary
     end_time = datetime.now()

--- a/pipelinewise/fastsync/postgres_to_redshift.py
+++ b/pipelinewise/fastsync/postgres_to_redshift.py
@@ -124,9 +124,9 @@ def sync_table(table):
             lock.release()
 
         # Table loaded, grant select on all tables in target schema
-        for grantee in utils.get_grantees(args.target, table):
-            redshift.grant_usage_on_schema(target_schema, grantee)
-            redshift.grant_select_on_schema(target_schema, grantee)
+        grantees = utils.get_grantees(args.target, table)
+        utils.grant_privilege(target_schema, grantees, redshift.grant_usage_on_schema)
+        utils.grant_privilege(target_schema, grantees, redshift.grant_select_on_schema)
 
     except Exception as exc:
         utils.log("CRITICAL: {}".format(exc))

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -123,9 +123,9 @@ def sync_table(table):
             lock.release()
 
         # Table loaded, grant select on all tables in target schema
-        for grantee in utils.get_grantees(args.target, table):
-            snowflake.grant_usage_on_schema(target_schema, grantee)
-            snowflake.grant_select_on_schema(target_schema, grantee)
+        grantees = utils.get_grantees(args.target, table)
+        utils.grant_privilege(target_schema, grantees, snowflake.grant_usage_on_schema)
+        utils.grant_privilege(target_schema, grantees, snowflake.grant_select_on_schema)
 
     except Exception as exc:
         utils.log("CRITICAL: {}".format(exc))

--- a/singer-connectors/target-postgres/requirements.txt
+++ b/singer-connectors/target-postgres/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-postgres==1.0.3
+pipelinewise-target-postgres==1.0.4

--- a/tests/end-to-end/test-project/tap_mysql.yml.template
+++ b/tests/end-to-end/test-project/tap_mysql.yml.template
@@ -35,6 +35,9 @@ batch_size_rows: 20000                 # Batch size for the stream to optimise l
 schemas:
   - source_schema: "mysql_source_db"
     target_schema: "mysql_grp24"
+    target_schema_select_permissions:
+      - group1
+
     tables:
       - table_name: "address"
         replication_method: "INCREMENTAL"

--- a/tests/end-to-end/test-project/tap_postgres.yml.template
+++ b/tests/end-to-end/test-project/tap_postgres.yml.template
@@ -35,6 +35,9 @@ batch_size_rows: 20000                 # Batch size for the stream to optimise l
 schemas:
   - source_schema: "public"
     target_schema: "postgres_world"
+    target_schema_select_permissions:
+      - group1
+
     tables:
       - table_name: "city"
         replication_method: "INCREMENTAL"

--- a/tests/units/fastsync/commons/test_fastsync_utils.py
+++ b/tests/units/fastsync/commons/test_fastsync_utils.py
@@ -254,3 +254,23 @@ def test_get_grantees():
         "schema_mapping": {"foo2": {"target_schema_select_permissions": ["grantee3", "grantee4"]}}
     }
     assert utils.get_grantees(target_config, "foo.foo") == ["grantee1", "grantee2"]
+
+    # default_target_schema_select_permissions as dict with string should return dict
+    target_config_with_default_as_dict = { "default_target_schema_select_permissions": {
+        "users": "grantee_user1",
+        "groups": "grantee_group1"
+    }}
+    assert utils.get_grantees(target_config_with_default_as_dict, "foo.foo") == {
+        "users": ["grantee_user1"],
+        "groups": ["grantee_group1"]
+    }
+
+    # default_target_schema_select_permissions as dict with list should return dict
+    target_config_with_default_as_dict = { "default_target_schema_select_permissions": {
+        "users": ["grantee_user1", "grantee_user2"],
+        "groups": ["grantee_group1", "grantee_group2"]
+    }}
+    assert utils.get_grantees(target_config_with_default_as_dict, "foo.foo") == {
+        "users": ["grantee_user1", "grantee_user2"],
+        "groups": ["grantee_group1", "grantee_group2"]
+    }


### PR DESCRIPTION
This PR is for FastSync Redshift compatibility to grant access to users and groups separately. Original issue reported at: https://github.com/transferwise/pipelinewise-target-redshift/issues/15

YAML can be defined in this format as well:
```
schemas:

  - source_schema: "my_db"             # Source schema (aka. database)
    target_schema: "repl_my_db"        # Target schema in the destination Data Warehouse
    target_schema_select_permissions:  # Optional only for Redshift
      users: ["user1", "user2]
      groups: ["group1", "group2"]
```

This is only for AWS Redshift. Other supported target databases (snowflake and postgres) can still use the list of roles as earlier.
