### PR TITLE
update target_snowflake.py

### DIFF
--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -103,14 +103,14 @@ class FastSyncTargetSnowflake:
         target_table = table_dict.get('table_name') if not is_temporary else table_dict.get('temp_table_name')
 
         if primary_key:
-            sql = """CREATE OR REPLACE TABLE {}.{} ({}
+            sql = """CREATE OR REPLACE TABLE {}.\"{}\" ({}
             ,_SDC_EXTRACTED_AT TIMESTAMP_NTZ
             ,_SDC_BATCHED_AT TIMESTAMP_NTZ
             ,_SDC_DELETED_AT VARCHAR
             , PRIMARY KEY ({}))
             """.format(target_schema, target_table, ', '.join(columns), primary_key)
         else:
-            sql = """CREATE OR REPLACE TABLE {}.{} ({}
+            sql = """CREATE OR REPLACE TABLE {}.\"{}\" ({}
             ,_SDC_EXTRACTED_AT TIMESTAMP_NTZ
             ,_SDC_BATCHED_AT TIMESTAMP_NTZ
             ,_SDC_DELETED_AT VARCHAR
@@ -219,7 +219,7 @@ class FastSyncTargetSnowflake:
         temp_table = table_dict.get('temp_table_name')
 
         # Swap tables and drop the temp tamp
-        self.query("ALTER TABLE {}.{} SWAP WITH {}.{}".format(schema, temp_table, schema, target_table))
+        self.query("ALTER TABLE {}.\"{}\" SWAP WITH {}.\"{}\"".format(schema, temp_table, schema, target_table))
         self.query("DROP TABLE IF EXISTS {}.{}".format(schema, temp_table))
         
 


### PR DESCRIPTION
allow creation of table columns with reserved key words.
Snowflake has reserverd key words (ORDERS, AS etc full list here: [https://docs.snowflake.net/manuals/sql-reference/reserved-keywords.html])

some key words like "ORDER" are frequently used as column or table names.

update the create table SQL to allow for creation of columns with keywords.
does not allow schemas and tables with keywords but a similar fix can be used if needed

this commit partially fixes #228 