### PR TITLE
Drop currently_syncing key from state message validation

### DIFF
--- a/pipelinewise/cli/utils.py
+++ b/pipelinewise/cli/utils.py
@@ -103,7 +103,7 @@ def load_json(path):
 def is_state_message(line: str) -> bool:
     try:
         json_object = json.loads(line)
-        return 'currently_syncing' in json_object and 'bookmarks' in json_object
+        return 'bookmarks' in json_object
     except Exception as exc:
         return False
 


### PR DESCRIPTION
Upon discovering that tap-s3-csv (And possibly other taps) emits state messages with only `bookmarks`, which results in the state file not being updated due to these messages failing validation. To solve this, I dropped `currently_syncing` key from the validation and only relied on messages being json objects and existence of `bookmarks` key.