### PR TITLE
Add extra_log parameter to CLI

### DIFF
--- a/pipelinewise/cli/__init__.py
+++ b/pipelinewise/cli/__init__.py
@@ -35,6 +35,7 @@ name_help = """Name of the project"""
 secret_help = """Path to vault password file"""
 version_help = """Displays the installed versions"""
 log_help = """File to log into"""
+extra_log_help = """Copy singer and fastsync logging into PipelineWise logger"""
 debug_help = """Forces the debug mode with logging on stdout and log level debug."""
 
 def main():
@@ -50,6 +51,7 @@ def main():
     parser.add_argument('--string', type=str)
     parser.add_argument('--version', action="version", help=version_help, version='PipelineWise {} - Command Line Interface'.format(__version__))
     parser.add_argument('--log', type=str, default='*', help=log_help)
+    parser.add_argument('--extra_log', default=False, required=False, help=extra_log_help, action="store_true")
     parser.add_argument('--debug', default=False, required=False, help=debug_help, action="store_true")
 
     args = parser.parse_args()

--- a/tests/units/cli/cli_args.py
+++ b/tests/units/cli/cli_args.py
@@ -3,7 +3,7 @@
 class CliArgs():
     """Class to simulate argparse command line arguments required by PipelineWise class
     """
-    def __init__(self, target='*', tap='*', tables=None, dir='*', name='*', secret=None, string=None, log='*', debug=False):
+    def __init__(self, target='*', tap='*', tables=None, dir='*', name='*', secret=None, string=None, log='*', extra_log=False, debug=False):
         self.target = target
         self.tap = tap
         self.tables = tables
@@ -12,6 +12,7 @@ class CliArgs():
         self.secret = secret
         self.string = string
         self.log = log
+        self.extra_log = extra_log
         self.debug = debug
 
 


### PR DESCRIPTION
Extra option to get tap-run and fastsync log output into std-out (#222 ).

I run PipelineWise Docker with Airflow (_DockerOperator_) and I need this option to see all the logs into Airflow.