### PR TITLE
mysql-to-snowflake fastsync: refresh information_schema columns cache

### DIFF
--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -155,8 +155,8 @@ def main_impl():
         table_sync_excs = list(filter(None, p.map(sync_table, args.tables)))
 
     # Refresh information_schema columns cache
-    #snowflake = FastSyncTargetSnowflake(args.target, args.transform)
-    #snowflake.cache_information_schema_columns(args.tables)
+    snowflake = FastSyncTargetSnowflake(args.target, args.transform)
+    snowflake.cache_information_schema_columns(args.tables)
 
     # Log summary
     end_time = datetime.now()


### PR DESCRIPTION
Fixed an issue when cached `information_schema.columns` table was not refreshed when mysql-to-snowflake FastSync completed.
