### PR TITLE
Fix dependency hell

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,15 +29,17 @@ setup(name='pipelinewise',
         'idna==2.7',
         'PyMySQL==0.7.11',
         'psycopg2==2.8.2',
-        'boto3==1.9.33',
-        'snowflake-connector-python==2.0.1'
+        'boto3==1.10.8',
+        'snowflake-connector-python==2.0.3'
     ],
     extras_require={
         "test": [
             "pytest==5.0.1",
             "pytest-dependency==0.4.0",
             "coverage==4.5.3",
-            "python-dotenv==0.10.3"
+            "python-dotenv==0.10.3",
+            "nose==1.3.7",
+            "mock==3.0.5"
         ]
     },
     entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
       long_description = f.read()
 
 setup(name='pipelinewise',
-    version='0.10.3',
+    version='0.10.4',
     description='PipelineWise',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/singer-connectors/tap-postgres/requirements.txt
+++ b/singer-connectors/tap-postgres/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-postgres==1.1.9
+pipelinewise-tap-postgres==1.2.0

--- a/singer-connectors/target-snowflake/requirements.txt
+++ b/singer-connectors/target-snowflake/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-snowflake==1.1.1
+pipelinewise-target-snowflake==1.1.5

--- a/tests/end-to-end/test_e2e.py
+++ b/tests/end-to-end/test_e2e.py
@@ -7,6 +7,7 @@ import psycopg2
 import subprocess
 
 from dotenv import load_dotenv
+from pathlib import Path
 
 DIR = os.path.dirname(__file__)
 
@@ -129,17 +130,37 @@ class TestE2E(object):
         if exists"""
         if rc != 0 or stderr != "":
             failed_log = ""
+            failed_log_path = f"{log_path}.failed"
             # Load failed log file if exists
-            if os.path.isfile("{}.success".format(log_path)):
-                with open(log_path, 'r') as file:
+            if os.path.isfile(failed_log_path):
+                with open(failed_log_path, 'r') as file:
                     failed_log = file.read()
 
-            if failed_log:
-                assert not "STDOUT: {}\nSTDERR: {}\nFAILED LOG: {}".format(str(stdout), str(stderr), failed_log)
-            else:
-                assert not "STDOUT: {}\nSTDERR: {}".format(str(stdout), str(stderr))
+            print(f"STDOUT: {stdout}\nSTDERR: {stderr}\nFAILED LOG: {failed_log}")
+            assert False
 
-        assert True
+        # check success log file if log path defined
+        success_log_path = f"{log_path}.success"
+        if log_path and not os.path.isfile(success_log_path):
+            assert False
+        else:
+            assert True
+
+    def assert_state_file_valid(self, target_name, tap_name, log_path=None):
+        """Assert helper function to check if state file exists for a certain tap
+        for a certain target"""
+        state_file = Path(f"{Path.home()}/.pipelinewise/{target_name}/{tap_name}/state.json").resolve()
+        assert os.path.isfile(state_file)
+
+        # Check if state file content equals to last emitted state in log
+        if log_path:
+            success_log_path = f"{log_path}.success"
+            with open(success_log_path, 'r') as log_f:
+                last_state = \
+                    re.search(r'\nINFO STATE emitted from target: (.+\n)', '\n'.join(log_f.readlines())).groups()[-1]
+
+            with open(state_file, 'r') as state_f:
+                assert last_state == ''.join(state_f.readlines())
 
     @pytest.mark.dependency(name="import_config")
     def test_import_project(self):
@@ -153,15 +174,15 @@ class TestE2E(object):
     def test_replicate_mariadb_to_postgres(self):
         """Replicate data from MariaDB to Postgres DWH, check if return code is zero and success log file created"""
         [rc, stdout, stderr] = self.run_command("pipelinewise run_tap --tap mariadb_source --target postgres_dwh")
-        self.assert_command_success(rc, stdout, stderr)
-        assert os.path.isfile("{}.success".format(self.find_run_tap_log_file(stdout)))
+        log_file = self.find_run_tap_log_file(stdout)
+        self.assert_command_success(rc, stdout, stderr, log_file)
 
     @pytest.mark.dependency(depends=["import_config"])
     def test_replicate_postgres_to_postgres(self):
         """Replicate data from Postgres to Postgres DWH, check if return code is zero and success log file created"""
         [rc, stdout, stderr] = self.run_command("pipelinewise run_tap --tap postgres_source --target postgres_dwh")
-        self.assert_command_success(rc, stdout, stderr)
-        assert os.path.isfile("{}.success".format(self.find_run_tap_log_file(stdout)))
+        log_file = self.find_run_tap_log_file(stdout)
+        self.assert_command_success(rc, stdout, stderr, log_file)
 
     @pytest.mark.dependency(depends=["import_config"])
     def test_replicate_postgres_to_snowflake(self):
@@ -170,21 +191,15 @@ class TestE2E(object):
         tap_name = 'postgres_source_sf'
         target_name = 'snowflake'
 
+        # Run tap first time - fastsync should be triggered
         [rc, stdout, stderr] = self.run_command("pipelinewise run_tap --tap {} --target {}".format(tap_name,
                                                                                                    target_name))
-        self.assert_command_success(rc, stdout, stderr)
-        log_file = "{}.success".format(self.find_run_tap_log_file(stdout, 'singer'))
+        log_file = self.find_run_tap_log_file(stdout, 'fastsync')
+        self.assert_command_success(rc, stdout, stderr, log_file)
 
-        from pathlib import Path
-
-        state_file = Path("{}/.pipelinewise/{}/{}/state.json".format(str(Path.home()), target_name, tap_name)).resolve()
-
-        assert os.path.isfile(log_file)
-        assert os.path.isfile(state_file)
-
-        with open(log_file, 'r') as log_f:
-            last_state = \
-                re.search(r'\nINFO STATE emitted from target: (.+\n)', '\n'.join(log_f.readlines())).groups()[-1]
-
-            with open(state_file, 'r') as state_f:
-                assert last_state == ''.join(state_f.readlines())
+        # Run tap second time - singer should be triggered and state message should be emitted
+        [rc, stdout, stderr] = self.run_command("pipelinewise run_tap --tap {} --target {}".format(tap_name,
+                                                                                                   target_name))
+        log_file = self.find_run_tap_log_file(stdout, 'singer')
+        self.assert_command_success(rc, stdout, stderr, log_file)
+        self.assert_state_file_valid(target_name, tap_name, log_file)


### PR DESCRIPTION
**PROBLEM**
`snowflake-python-connector` was causing some dependency issues and circleci was failing:
```
tests/end-to-end/test_e2e.py:175: … AssertionError: assert not 'STDOUT: 2019-11-01 08:47:33 INFO: Running postgres_source_sf tap in snowflake…`
```

**REASON**
Massive dependency hell across `boto3`,`botocore`, `snowflake-python-connector` (latest 2.0.3), `azure-storage-python`, `python-dateutil` and `urllib`:
Running the target-snowflake tests programatically (locally and circleci) is fine but running `target-snowflake` executable from the command line (like pipelinewise does) was generating the error at install time:
```  
ERROR: botocore 1.13.9 has requirement python-dateutil<2.8.1,>=2.1; python_version >= "2.7", but you'll have python-dateutil 2.8.1 which is incompatible.
ERROR: boto3 1.9.33 has requirement botocore<1.13.0,>=1.12.33, but you'll have botocore 1.13.9 which is incompatible.
ERROR
```
And completely fails at runtime from CLI:
```
$ target-snowflake
…
pkg_resources.DistributionNotFound: The 'botocore<1.13.0,>=1.12.33' distribution was not found and is required by boto3
…
```
Or from CLI:
```
$ pipelinewise
…
pkg_resources.ContextualVersionConflict: (urllib3 1.25.6 (/opt/pipelinewise/dev-project/.virtualenvs/pipelinewise/lib/python3.7/site-packages), Requirement.parse('urllib3<1.25.0'), {'snowflake-connector-python'})
…
```

**WHY DID IT FAIL ON MASTER AND DIDN’T IN PR BRANCH?**
Some unversioned dependencies to latest or double referenced libraries, i.e. `azure-storage-common` depends on unversioned `python-dateutil`, new python-dateutil released in the last 24 hours and it started a dependency chain reaction

**FIX**
Digging into the dependency tree of `pipelinewise` and `pipelinewise-target-snowflake` and pinning `boto3` and `botoclient` to certain versions that compatible with the latest `snowflake-python-connector` (2.0.3)

COMMITS and PyPI packages:
* pipelinewise-target-snowflake (1.1.5)
* pipelinewise (0.10.4)

**RESULTS**
Every tests passing in every repository

