### PR TITLE
Selectively install singer connectors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
             ./tests/db/tap_postgres_db.sh
       - run:
           name: Installing PipelineWise components and connectors
-          command: ./install.sh --acceptlicenses
+          command: ./install.sh --connectors=all --acceptlicenses
       - run:
           name: Run tests
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN alien -i /app/oracle-instantclient.rpm --scripts && rm -rf /app/oracle-insta
 COPY . /app
 
 RUN cd /app \
-    && ./install.sh --acceptlicenses --nousage --notestextras \
+    && ./install.sh --connectors=all --acceptlicenses --nousage --notestextras \
     && ln -s /root/.pipelinewise /app/.pipelinewise
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -105,9 +105,10 @@ $ docker exec -it pipelinewise_dev bash
 2. Run the install script that installs the PipelineWise CLI and every supported singer connectors into separated virtual environments:
    
     ```sh
-    $ ./install.sh
+    $ ./install.sh --connectors=all
     ```
-    Press `Y` to accept the license agreement of the required singer components. To automate the installation and accept every license agreement run `./install --acceptlicenses`)
+    Press `Y` to accept the license agreement of the required singer components. To automate the installation and accept every license agreement run `./install --acceptlicenses`
+    Use the optional `--connectors=...,...` argument to install only a specific list of singer connectors.
 
 3. To start CLI you need to activate the CLI virtual environment and has to set `PIPELINEWISE_HOME` environment variable:
    

--- a/docs/installation_guide/installation.rst
+++ b/docs/installation_guide/installation.rst
@@ -57,10 +57,10 @@ executable docker image:
     $ docker build -t pipelinewise:latest .
 
 
-Building the image may take 5-10 minutes depending on your network connection. At the moment
-there is no official, pre-built image available to download on DockerHub. Once the image is
-ready, create an alias to the docker wrapper script so you can use the ``pipelinewise``
-executable commands everywhere on your system:
+Building the image may take 5-10 minutes depending on your network connection. The output image will
+contain every supporter singer connectors. At the moment there is no official, pre-built image available
+to download on DockerHub. Once the image is ready, create an alias to the docker wrapper script so you can
+use the ``pipelinewise`` executable commands everywhere on your system:
 
 .. code-block:: bash
 
@@ -98,14 +98,14 @@ PipelineWise CLI and every supported singer connectors into separated virtual en
 
     $ git clone https://github.com/transferwise/pipelinewise.git
     $ cd ./pipelinewise
-    $ ./install.sh
+    $ ./install.sh --connectors=all
 
 Press ``Y`` to accept the license agreement of the required singer components. To automate
 the installation and accept every license agreement run ``./install --acceptlicenses``.
 
 .. code-block:: bash
 
-    $ ./install.sh
+    $ ./install.sh --connectors=all
 
     (...installation usually takes 5-10 minutes...)
 
@@ -119,6 +119,60 @@ the installation and accept every license agreement run ``./install --acceptlice
       $ pipelinewise status
 
     --------------------------------------------------------------------------
+
+Selecting singer connectors
+'''''''''''''''''''''''''''
+
+You can install PipelineWise only with required connectors by using the `--connectors=` argument. For example if you
+need to replicate data only from MySQL and PostgreSQL into a Snowflake database you can install PipelineWise by
+running:
+
+.. code-block:: bash
+
+    $ ./install --connectors=tap-mysql,tap-postgres,target-snowflake
+
+Here’s the list of the singer connectors and if they are installed by default or not:
+
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| **Connector**              | **Install Command**                     | **Included in default install?** | **Note**                              |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| all                        | ./install --connectors=all              |                                  | Installs every supported connector    |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| tap-adwords                | ./install --connectors=tap-adwords      |                                  |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| tap-jira                   | ./install --connectors=tap-jira         | YES                              |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| tap-kafka                  | ./install --connectors=tap-kafka        | YES                              |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| tap-mysql                  | ./install --connectors=tap-mysql        | YES                              |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| tap-oracle                 | ./install --connectors=tap-oracle       |                                  |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| tap-postgres               | ./install --connectors=tap-postgres     | YES                              |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| tap-s3-csv                 | ./install --connectors=tap-s3-csv       | YES                              |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| tap-salesforce             | ./install --connectors=tap-salesforce   | YES                              |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| tap-snowflake              | ./install --connectors=tap-snowflake    | YES                              |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| tap-zendesk                | ./install --connectors=tap-zendesk      | YES                              |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| target-postgres            | ./install --connectors=target-postgres  |                                  |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| target-s3-csv              | ./install --connectors=target-s3-csv    | YES                              |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| target-redshift            | ./install --connectors=target-redshift  | YES                              |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| target-snowflake           | ./install --connectors=target-snowflake | YES                              |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+| transform-field            | ./install --connectors=transform-field  | YES                              |                                       |
++----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
+
+
+.. warning::
+
+    When `--connectors=` argument is not specified then only the default connectors will be installed.
 
 Once the install script finished, you will need to activate the virtual environment
 with the Command Line Tools and set the ``PIPELINEWISE_HOME`` environment variable

--- a/docs/installation_guide/installation.rst
+++ b/docs/installation_guide/installation.rst
@@ -129,7 +129,7 @@ running:
 
 .. code-block:: bash
 
-    $ ./install --connectors=tap-mysql,tap-postgres,target-snowflake
+    $ ./install.sh --connectors=tap-mysql,tap-postgres,target-snowflake
 
 Here’s the list of the singer connectors and if they are installed by default or not:
 
@@ -138,7 +138,7 @@ Here’s the list of the singer connectors and if they are installed by default 
 +----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
 | all                        | ./install --connectors=all              |                                  | Installs every supported connector    |
 +----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
-| tap-adwords                | ./install --connectors=tap-adwords      |                                  |                                       |
+| tap-adwords                | ./install --connectors=tap-adwords      | NO                                |                                       |
 +----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
 | tap-jira                   | ./install --connectors=tap-jira         | YES                              |                                       |
 +----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
@@ -146,7 +146,7 @@ Here’s the list of the singer connectors and if they are installed by default 
 +----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
 | tap-mysql                  | ./install --connectors=tap-mysql        | YES                              |                                       |
 +----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
-| tap-oracle                 | ./install --connectors=tap-oracle       |                                  |                                       |
+| tap-oracle                 | ./install --connectors=tap-oracle       | NO                                |                                       |
 +----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
 | tap-postgres               | ./install --connectors=tap-postgres     | YES                              |                                       |
 +----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
@@ -158,7 +158,7 @@ Here’s the list of the singer connectors and if they are installed by default 
 +----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
 | tap-zendesk                | ./install --connectors=tap-zendesk      | YES                              |                                       |
 +----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
-| target-postgres            | ./install --connectors=target-postgres  |                                  |                                       |
+| target-postgres            | ./install --connectors=target-postgres  | NO                               |                                       |
 +----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+
 | target-s3-csv              | ./install --connectors=target-s3-csv    | YES                              |                                       |
 +----------------------------+-----------------------------------------+----------------------------------+---------------------------------------+

--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,14 @@ install_connector() {
     echo "--------------------------------------------------------------------------"
     echo "Installing $1 connector..."
     echo "--------------------------------------------------------------------------"
-    cd $SRC_DIR/singer-connectors/$1
+
+    CONNECTOR_DIR=$SRC_DIR/singer-connectors/$1
+    if [[ ! -d $CONNECTOR_DIR ]]; then
+        echo "ERROR: Directory not exists and does not look like a valid singer connector: $CONNECTOR_DIR"
+        exit 1
+    fi
+
+    cd $CONNECTOR_DIR
     make_virtualenv $1
 }
 
@@ -96,6 +103,13 @@ print_installed_connectors() {
         VERSION=`python3 -m pip list | grep $i | awk '{print $2}'`
         printf "%-20s %s\n" $i "$VERSION"
     done
+
+    if [[ $CONNECTORS != "all" ]]; then
+        echo
+        echo "WARNING: Not every singer connector installed. If you are missing something use the --connectors=...,... argument"
+        echo "         with an explicit list of required connectors or use the --connectors=all to install every available"
+        echo "         connector"
+    fi
 }
 
 # Parse command line arguments
@@ -113,6 +127,11 @@ for arg in "$@"; do
         --notestextras)
             NO_TEST_EXTRAS="YES"
             ;;
+        # Install extra connectors
+        --connectors=*)
+            CONNECTORS="${arg#*=}"
+            shift
+            ;;
         *)
             echo "Invalid argument: $arg"
             exit 1
@@ -125,25 +144,54 @@ cat $SRC_DIR/motd
 
 # Install PipelineWise core components
 cd $SRC_DIR
-make_virtualenv pipelinewise
+echo make_virtualenv pipelinewise
 
-# Install Singer connectors
-install_connector tap-adwords
-install_connector tap-jira
-install_connector tap-kafka
-install_connector tap-mysql
-install_connector tap-postgres
-install_connector tap-s3-csv
-install_connector tap-salesforce
-install_connector tap-snowflake
-install_connector tap-zendesk
-install_connector target-s3-csv
-install_connector target-snowflake
-install_connector transform-field
-install_connector tap-oracle
-install_connector target-postgres
-install_connector target-redshift
+# Set default and extra singer connectors
+DEFAULT_CONNECTORS=(
+    tap-jira
+    tap-kafka
+    tap-mysql
+    tap-postgres
+    tap-s3-csv
+    tap-salesforce
+    tap-snowflake
+    tap-zendesk
+    target-s3-csv
+    target-snowflake
+    target-redshift
+    transform-field
+)
+EXTRA_CONNECTORS=(
+    tap-adwords
+    tap-oracle
+    target-postgres
+)
 
+# Install only the default connectors if --connectors argument not passed
+if [[ -z $CONNECTORS ]]; then
+    for i in ${DEFAULT_CONNECTORS[@]}; do
+        install_connector $i
+    done
+
+
+# Install every avaliable connectors if --connectors=all passed
+elif [[ $CONNECTORS == "all" ]]; then
+    for i in ${DEFAULT_CONNECTORS[@]}; do
+        install_connector $i
+    done
+    for i in ${EXTRA_CONNECTORS[@]}; do
+        install_connector $i
+    done
+
+# Install the selected connectors if --connectors argument passed
+elif [[ ! -z $CONNECTORS ]]; then
+    OLDIFS=$IFS
+    IFS=,
+    for connector in $CONNECTORS; do
+        install_connector $connector
+    done
+    IFS=$OLDIFS
+fi
 
 # Capture end_time
 end_time=`date +%s`

--- a/install.sh
+++ b/install.sh
@@ -154,7 +154,7 @@ cat $SRC_DIR/motd
 
 # Install PipelineWise core components
 cd $SRC_DIR
-echo make_virtualenv pipelinewise
+make_virtualenv pipelinewise
 
 # Set default and extra singer connectors
 DEFAULT_CONNECTORS=(

--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,11 @@ check_license() {
     fi
 }
 
+clean_virtualenvs() {
+    echo "Cleaning previous installations in $VENV_DIR"
+    rm -rf $VENV_DIR
+}
+
 make_virtualenv() {
     echo "Making Virtual Environment for [$1] in $VENV_DIR"
     python3 -m venv $VENV_DIR/$1
@@ -131,6 +136,11 @@ for arg in "$@"; do
         --connectors=*)
             CONNECTORS="${arg#*=}"
             shift
+            ;;
+        # Clean previous installation
+        --clean)
+            clean_virtualenvs
+            exit 0
             ;;
         *)
             echo "Invalid argument: $arg"


### PR DESCRIPTION
This PR adding the option to install only specific singer connectors from the command line.

Available options:
* `./install.sh` : Installs only the default singer connectors. `DEFAULT` and `EXTRA` connectors specified here at: https://github.com/transferwise/pipelinewise/blob/0662cf0f31703816d37c8d03e44daedb4ef7ae6b/install.sh#L160
* `./install.sh --connectors=all` : Finds and installs every available singer connectors automatically
* `./install.sh --connectors=tap-mysql,tap-postgres,target-snowflake` : Installs only a specific list of singer connectors

* `./install.sh --clean` : Clean and delete every previously installed component from the system