### PR TITLE
Add post import checks to detect tables with no primary key

### DIFF
--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -612,7 +612,7 @@ class PipelineWise(object):
         else:
             schema_with_diff = new_schema
 
-        # Make selection from selectection.json if exists
+        # Make selection from selection.json if exists
         try:
             schema_with_diff = self.make_default_selection(schema_with_diff, tap_selection_file)
             schema_with_diff = utils.delete_keys_from_dict(
@@ -625,6 +625,11 @@ class PipelineWise(object):
 
         except Exception as exc:
             return f"Cannot load selection JSON at {tap_selection_file}. {str(exc)}"
+
+        # Post import checks
+        post_import_errors = self._run_post_import_tap_checks(schema_with_diff, target)
+        if len(post_import_errors) > 0:
+            return f"Post import tap checks failed at {tap_id}. {post_import_errors}"
 
         # Save the new catalog into the tap
         try:
@@ -1193,3 +1198,38 @@ TAP RUN SUMMARY
             if log_file_to_write_summary:
                 with open(log_file_to_write_summary, "a") as f:
                     f.write(summary)
+
+    def _run_post_import_tap_checks(self, tap, target) -> list:
+        """
+            Run post import checks on a tap properties object.
+
+        :param tap_properties: tap properties object
+        :return: List of errors. If no error returns an empty list
+        """
+        errors = []
+
+        # Foreach stream (table) in the original properties
+        for stream_idx, stream in enumerate(tap.get("streams", tap)):
+            # Collect required properties from the properties file
+            tap_stream_id = stream.get("tap_stream_id")
+            metadata = stream.get("metadata", [])
+
+            # Collect further properties from the tap and target properties
+            table_meta = {}
+            for meta_idx, meta in enumerate(metadata):
+                if type(meta) == dict and len(meta.get("breadcrumb", [])) == 0:
+                    table_meta = meta.get("metadata")
+                    break
+
+            selected = table_meta.get("selected", False)
+            replication_method = table_meta.get("replication-method")
+            table_key_properties = table_meta.get("table-key-properties", [])
+            primary_key_required = target.get("primary_key_required", False)
+
+            # Check if primary key is set for INCREMENTAL and LOG_BASED replications
+            if (selected and replication_method in [self.INCREMENTAL, self.LOG_BASED] and
+                    len(table_key_properties) == 0 and primary_key_required):
+                errors.append(f'No primary key set for - {replication_method} {tap_stream_id}.')
+                break
+
+        return errors

--- a/tests/units/cli/resources/test_post_import_checks/tap_properties_with_no_pk_full_table.json
+++ b/tests/units/cli/resources/test_post_import_checks/tap_properties_with_no_pk_full_table.json
@@ -1,0 +1,403 @@
+{
+    "streams": [
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test_mysql",
+                        "is-view": false,
+                        "replication-method": "FULL_TABLE",
+                        "row-count": 0,
+                        "selected": true,
+                        "table-key-properties": []
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "email"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "character varying"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "type": [
+                            "null",
+                            "integer"
+                        ]
+                    },
+                    "email": {
+                        "maxLength": 200,
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_one",
+            "table_name": "table_one",
+            "tap_stream_id": "db_test_mysql-table_one"
+        },
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test",
+                        "is-view": false,
+                        "replication-method": "INCREMENTAL",
+                        "replication-key": "id",
+                        "row-count": 628763,
+                        "schema-name": "db_test",
+                        "selected": true,
+                        "table-key-properties": [
+                            "id"
+                        ]
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "sub_type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "sub_type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_two",
+            "table_name": "table_two",
+            "tap_stream_id": "db_test_mysql-table_two"
+        },
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test",
+                        "is-view": false,
+                        "replication-method": "FULL_TABLE",
+                        "row-count": 628763,
+                        "schema-name": "db_test",
+                        "selected": false
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "sub_type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "sub_type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_three",
+            "table_name": "table_three",
+            "tap_stream_id": "db_test_mysql-table_three"
+        }
+    ]
+}

--- a/tests/units/cli/resources/test_post_import_checks/tap_properties_with_no_pk_incremental.json
+++ b/tests/units/cli/resources/test_post_import_checks/tap_properties_with_no_pk_incremental.json
@@ -1,0 +1,403 @@
+{
+    "streams": [
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test_mysql",
+                        "is-view": false,
+                        "replication-method": "LOG_BASED",
+                        "row-count": 0,
+                        "selected": true,
+                        "table-key-properties": []
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "email"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "character varying"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "type": [
+                            "null",
+                            "integer"
+                        ]
+                    },
+                    "email": {
+                        "maxLength": 200,
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_one",
+            "table_name": "table_one",
+            "tap_stream_id": "db_test_mysql-table_one"
+        },
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test",
+                        "is-view": false,
+                        "replication-method": "INCREMENTAL",
+                        "replication-key": "id",
+                        "row-count": 628763,
+                        "schema-name": "db_test",
+                        "selected": true,
+                        "table-key-properties": [
+                            "id"
+                        ]
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "sub_type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "sub_type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_two",
+            "table_name": "table_two",
+            "tap_stream_id": "db_test_mysql-table_two"
+        },
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test",
+                        "is-view": false,
+                        "replication-method": "FULL_TABLE",
+                        "row-count": 628763,
+                        "schema-name": "db_test",
+                        "selected": false
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "sub_type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "sub_type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_three",
+            "table_name": "table_three",
+            "tap_stream_id": "db_test_mysql-table_three"
+        }
+    ]
+}

--- a/tests/units/cli/resources/test_post_import_checks/tap_properties_with_no_pk_log_based.json
+++ b/tests/units/cli/resources/test_post_import_checks/tap_properties_with_no_pk_log_based.json
@@ -1,0 +1,403 @@
+{
+    "streams": [
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test_mysql",
+                        "is-view": false,
+                        "replication-method": "LOG_BASED",
+                        "row-count": 0,
+                        "selected": true,
+                        "table-key-properties": []
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "email"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "character varying"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "type": [
+                            "null",
+                            "integer"
+                        ]
+                    },
+                    "email": {
+                        "maxLength": 200,
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_one",
+            "table_name": "table_one",
+            "tap_stream_id": "db_test_mysql-table_one"
+        },
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test",
+                        "is-view": false,
+                        "replication-method": "INCREMENTAL",
+                        "replication-key": "id",
+                        "row-count": 628763,
+                        "schema-name": "db_test",
+                        "selected": true,
+                        "table-key-properties": [
+                            "id"
+                        ]
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "sub_type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "sub_type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_two",
+            "table_name": "table_two",
+            "tap_stream_id": "db_test_mysql-table_two"
+        },
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test",
+                        "is-view": false,
+                        "replication-method": "FULL_TABLE",
+                        "row-count": 628763,
+                        "schema-name": "db_test",
+                        "selected": false
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "sub_type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "sub_type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_three",
+            "table_name": "table_three",
+            "tap_stream_id": "db_test_mysql-table_three"
+        }
+    ]
+}

--- a/tests/units/cli/resources/test_post_import_checks/tap_properties_with_no_pk_not_selected.json
+++ b/tests/units/cli/resources/test_post_import_checks/tap_properties_with_no_pk_not_selected.json
@@ -1,0 +1,403 @@
+{
+    "streams": [
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test_mysql",
+                        "is-view": false,
+                        "replication-method": "INCREMENTAL",
+                        "row-count": 0,
+                        "selected": false,
+                        "table-key-properties": []
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "email"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "character varying"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "type": [
+                            "null",
+                            "integer"
+                        ]
+                    },
+                    "email": {
+                        "maxLength": 200,
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_one",
+            "table_name": "table_one",
+            "tap_stream_id": "db_test_mysql-table_one"
+        },
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test",
+                        "is-view": false,
+                        "replication-method": "INCREMENTAL",
+                        "replication-key": "id",
+                        "row-count": 628763,
+                        "schema-name": "db_test",
+                        "selected": true,
+                        "table-key-properties": [
+                            "id"
+                        ]
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "sub_type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "sub_type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_two",
+            "table_name": "table_two",
+            "tap_stream_id": "db_test_mysql-table_two"
+        },
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test",
+                        "is-view": false,
+                        "replication-method": "FULL_TABLE",
+                        "row-count": 628763,
+                        "schema-name": "db_test",
+                        "selected": false
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "sub_type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "sub_type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_three",
+            "table_name": "table_three",
+            "tap_stream_id": "db_test_mysql-table_three"
+        }
+    ]
+}

--- a/tests/units/cli/resources/test_post_import_checks/tap_properties_with_pk.json
+++ b/tests/units/cli/resources/test_post_import_checks/tap_properties_with_pk.json
@@ -1,0 +1,405 @@
+{
+    "streams": [
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test_mysql",
+                        "is-view": false,
+                        "replication-method": "LOG_BASED",
+                        "row-count": 0,
+                        "selected": true,
+                        "table-key-properties": [
+                            "id"
+                        ]
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "email"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "character varying"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "type": [
+                            "null",
+                            "integer"
+                        ]
+                    },
+                    "email": {
+                        "maxLength": 200,
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_one",
+            "table_name": "table_one",
+            "tap_stream_id": "db_test_mysql-table_one"
+        },
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test",
+                        "is-view": false,
+                        "replication-method": "INCREMENTAL",
+                        "replication-key": "id",
+                        "row-count": 628763,
+                        "schema-name": "db_test",
+                        "selected": true,
+                        "table-key-properties": [
+                            "id"
+                        ]
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "sub_type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "sub_type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_two",
+            "table_name": "table_two",
+            "tap_stream_id": "db_test_mysql-table_two"
+        },
+        {
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "db_test",
+                        "is-view": false,
+                        "replication-method": "FULL_TABLE",
+                        "row-count": 628763,
+                        "schema-name": "db_test",
+                        "selected": false
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "id"
+                    ],
+                    "metadata": {
+                        "inclusion": "automatic",
+                        "selected-by-default": true,
+                        "sql-datatype": "integer"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "sub_type"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "text"
+                    }
+                }
+            ],
+            "schema": {
+                "definitions": {
+                    "sdc_recursive_boolean_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_boolean_array"
+                        },
+                        "type": [
+                            "null",
+                            "boolean",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_integer_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_integer_array"
+                        },
+                        "type": [
+                            "null",
+                            "integer",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_number_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_number_array"
+                        },
+                        "type": [
+                            "null",
+                            "number",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_object_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_object_array"
+                        },
+                        "type": [
+                            "null",
+                            "object",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_string_array": {
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_string_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "sdc_recursive_timestamp_array": {
+                        "format": "date-time",
+                        "items": {
+                            "$ref": "#/definitions/sdc_recursive_timestamp_array"
+                        },
+                        "type": [
+                            "null",
+                            "string",
+                            "array"
+                        ]
+                    }
+                },
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "sub_type": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "stream": "table_three",
+            "table_name": "table_three",
+            "tap_stream_id": "db_test_mysql-table_three"
+        }
+    ]
+}

--- a/tests/units/cli/resources/test_post_import_checks/target_config_pk_not_required.json
+++ b/tests/units/cli/resources/test_post_import_checks/target_config_pk_not_required.json
@@ -1,0 +1,15 @@
+{
+    "account": "foo",
+    "aws_access_key_id": "secret",
+    "aws_secret_access_key": "secret/",
+    "client_side_encryption_master_key": "secret=",
+    "dbname": "my_db",
+    "file_format": "my_file_format",
+    "password": "secret",
+    "s3_bucket": "foo",
+    "s3_key_prefix": "foo/",
+    "stage": "my_stage",
+    "user": "user",
+    "warehouse": "MY_WAREHOUSE",
+    "primary_key_required": false
+}

--- a/tests/units/cli/resources/test_post_import_checks/target_config_pk_required.json
+++ b/tests/units/cli/resources/test_post_import_checks/target_config_pk_required.json
@@ -1,0 +1,15 @@
+{
+    "account": "foo",
+    "aws_access_key_id": "secret",
+    "aws_secret_access_key": "secret/",
+    "client_side_encryption_master_key": "secret=",
+    "dbname": "my_db",
+    "file_format": "my_file_format",
+    "password": "secret",
+    "s3_bucket": "foo",
+    "s3_key_prefix": "foo/",
+    "stage": "my_stage",
+    "user": "user",
+    "warehouse": "MY_WAREHOUSE",
+    "primary_key_required": true
+}


### PR DESCRIPTION
Checking if primary key exists in the source table at YAML import time. In this case we are noticed earlier if source table is not configured correct and don't need to wait the first run of the tap when it's failing.

Output in case of no Primary Key in a table:
```
            -------------------------------------------------------
            IMPORTING YAML CONFIGS FINISHED
            -------------------------------------------------------
                Total targets to import        : 3
                Total taps to import           : 132
                Taps imported successfully     : 132
                Taps failed to import          : [No primary key set for - LOG_BASED source_db-table_one]
                Runtime                        : 0:02:34.801859
            -------------------------------------------------------
```

If `primary_key_required: False` set in tap YAML then check passes even if no PK in the source table.

Addressing #221