### PR TITLE
bump target-redshift

### DIFF
--- a/singer-connectors/target-redshift/requirements.txt
+++ b/singer-connectors/target-redshift/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-redshift==1.0.7
+pipelinewise-target-redshift==1.1.0


### PR DESCRIPTION
Bump target-redshift to 1.1.0 to have everything target-snowflake has:
* Emit new state message as soon as data flushed to Redshift
* Add `flush_all_streams` option
* Add `max_parallelism` option