### PR TITLE
Fixed discovery mode

### DIFF
--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -562,30 +562,22 @@ class PipelineWise(object):
             self.logger.info(f"Testing tap connection ({target_id} - {tap_id}) PASSED")
 
     def discover_tap(self, tap=None, target=None):
-        # Define tap props
         if tap is None:
-            tap_id = self.tap.get('id')
-            tap_type = self.tap.get('type')
-            tap_config_file = self.tap.get('files', {}).get('config')
-            tap_properties_file = self.tap.get('files', {}).get('properties')
-            tap_selection_file = self.tap.get('files', {}).get('selection')
-            tap_bin = self.tap_bin
+            tap = self.tap
+        if target is None:
+            target = self.target
 
-        else:
-            tap_id = tap.get('id')
-            tap_type = tap.get('type')
-            tap_config_file = tap.get('files', {}).get('config')
-            tap_properties_file = tap.get('files', {}).get('properties')
-            tap_selection_file = tap.get('files', {}).get('selection')
-            tap_bin = self.get_connector_bin(tap_type)
+        # Define tap props
+        tap_id = tap.get('id')
+        tap_type = tap.get('type')
+        tap_config_file = tap.get('files', {}).get('config')
+        tap_properties_file = tap.get('files', {}).get('properties')
+        tap_selection_file = tap.get('files', {}).get('selection')
+        tap_bin = self.get_connector_bin(tap_type)
 
         # Define target props
-        if target is None:
-            target_id = self.target.get('id')
-            target_type = self.target.get('type')
-        else:
-            target_id = target.get('id')
-            target_type = target.get('type')
+        target_id = target.get('id')
+        target_type = target.get('type')
 
         self.logger.info(f"Discovering {tap_id} ({tap_type}) tap in {target_id} ({target_type}) target...")
 


### PR DESCRIPTION
Fixing #289 

**Description**
`discover_tap` command crashes with every tap and target. To reproduce run:
 `pipelinewise discover_tap --tap test_mysql_mysql_mariadb --target my_test_snowflake`

**Exception**
`
Traceback (most recent call last): File "/app/.virtualenvs/pipelinewise/bin/pipelinewise", line 11, in <module> load_entry_point('pipelinewise', 'console_scripts', 'pipelinewise')() File "/app/pipelinewise/cli/__init__.py", line 109, in main getattr(pipelinewise, args.command)() File "/app/pipelinewise/cli/pipelinewise.py", line 630, in discover_tap post_import_errors = self._run_post_import_tap_checks(schema_with_diff, target) File "/app/pipelinewise/cli/pipelinewise.py", line 1229, in _run_post_import_tap_checks primary_key_required = target.get("primary_key_required", False) AttributeError: 'NoneType' object has no attribute 'get'
`

**Reason**
The `_run_post_import_tap_checks` requires a full `target` dict but `discover_tap` command not passing it.

The `import` command still works and do proper discovery because it's passing the `target` dict
