### PR TITLE
fixed issue when missing required PK not detected by post_import_tap_checks

### DIFF
--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1226,7 +1226,7 @@ TAP RUN SUMMARY
             selected = table_meta.get("selected", False)
             replication_method = table_meta.get("replication-method")
             table_key_properties = table_meta.get("table-key-properties", [])
-            primary_key_required = target.get("primary_key_required", False)
+            primary_key_required = target.get("primary_key_required", True)
 
             # Check if primary key is set for INCREMENTAL and LOG_BASED replications
             if (selected and replication_method in [self.INCREMENTAL, self.LOG_BASED] and

--- a/tests/units/cli/resources/test_post_import_checks/target_config_pk_not_defined.json
+++ b/tests/units/cli/resources/test_post_import_checks/target_config_pk_not_defined.json
@@ -1,0 +1,14 @@
+{
+    "account": "foo",
+    "aws_access_key_id": "secret",
+    "aws_secret_access_key": "secret/",
+    "client_side_encryption_master_key": "secret=",
+    "dbname": "my_db",
+    "file_format": "my_file_format",
+    "password": "secret",
+    "s3_bucket": "foo",
+    "s3_key_prefix": "foo/",
+    "stage": "my_stage",
+    "user": "user",
+    "warehouse": "MY_WAREHOUSE"
+}

--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -459,6 +459,7 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
 
         target_pk_required = cli.utils.load_json("{}/target_config_pk_required.json".format(test_files_dir))
         target_pk_not_required = cli.utils.load_json("{}/target_config_pk_not_required.json".format(test_files_dir))
+        target_pk_not_defined = cli.utils.load_json("{}/target_config_pk_not_defined.json".format(test_files_dir))
         tap_with_pk = cli.utils.load_json("{}//tap_properties_with_pk.json".format(test_files_dir))
         tap_with_no_pk_full_table = cli.utils.load_json("{}//tap_properties_with_no_pk_full_table.json".format(test_files_dir))
         tap_with_no_pk_incremental = cli.utils.load_json("{}//tap_properties_with_no_pk_incremental.json".format(test_files_dir))
@@ -472,7 +473,10 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
         assert pipelinewise._run_post_import_tap_checks(tap_with_no_pk_incremental, target_pk_not_required) == []
         assert pipelinewise._run_post_import_tap_checks(tap_with_no_pk_log_based, target_pk_not_required) == []
         assert pipelinewise._run_post_import_tap_checks(tap_with_no_pk_not_selected, target_pk_required) == []
+        assert pipelinewise._run_post_import_tap_checks(tap_with_no_pk_full_table, target_pk_not_defined) == []
 
         # Test scenarios when post import checks should fail due to primary keys not exists
         assert len(pipelinewise._run_post_import_tap_checks(tap_with_no_pk_incremental, target_pk_required)) == 1
         assert len(pipelinewise._run_post_import_tap_checks(tap_with_no_pk_log_based, target_pk_required)) == 1
+        assert len(pipelinewise._run_post_import_tap_checks(tap_with_no_pk_incremental, target_pk_not_defined)) == 1
+        assert len(pipelinewise._run_post_import_tap_checks(tap_with_no_pk_log_based, target_pk_not_defined)) == 1


### PR DESCRIPTION
**Description**
If `primary_key_required` key not defined explicitly in the target YAML then `post_import_tap_checks` not reporting that source table has no PK.

**Reason**
`primary_key_required` is an optional parameter in the target YAMLs and defaults to `True` but `_run_post_import_tap_checks` expecting the default as `False`. This PR makes it to be in sync and adding some new tests to cover the scenario when `primary_key_required` is not explicitly defined in the target YAML.
