### PR TITLE
support binary and varbinary columns in Mysql to SF fastsync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ references:
        # MariaDB service container image used as test source database (for tap-mysql)
       - image: mariadb:10.2.26
         name: db_mysql_source
+        command: --default-authentication-plugin=mysql_native_password --log-bin=mysql-bin --binlog-format=ROW
         environment:
           MYSQL_ROOT_PASSWORD: test
           MYSQL_USER: test

--- a/dev-project/pipelinewise-config/tap_mysql_mariadb.yml
+++ b/dev-project/pipelinewise-config/tap_mysql_mariadb.yml
@@ -68,5 +68,3 @@ schemas:
                                             # Important! Log based must be enabled in MySQL and
                                             #            requires config adjustments
                                             # Doc: https://transferwise.github.io/pipelinewise/connectors/taps/mysql.html
-
-

--- a/pipelinewise/fastsync/commons/tap_mysql.py
+++ b/pipelinewise/fastsync/commons/tap_mysql.py
@@ -1,3 +1,5 @@
+import codecs
+
 import pymysql
 import gzip
 import csv
@@ -144,8 +146,10 @@ class FastSyncTapMySql:
                             data_type,
                             column_type,
                             CASE
-                            WHEN data_type IN ('blob', 'tinyblob', 'mediumblob', 'longblob', 'binary', 'varbinary', 'geometry')
+                            WHEN data_type IN ('blob', 'tinyblob', 'mediumblob', 'longblob', 'geometry')
                                     THEN concat('hex(', column_name, ')')
+                            WHEN data_type IN ('binary', 'varbinary')
+                                    THEN COLUMN_NAME
                             WHEN data_type IN ('bit')
                                     THEN concat('cast(`', column_name, '` AS unsigned)')
                             WHEN data_type IN ('datetime', 'timestamp', 'date')
@@ -165,10 +169,11 @@ class FastSyncTapMySql:
             """.format(table_dict.get('schema_name'), table_dict.get('table_name'))
         return self.query(sql)
 
-
     def map_column_types_to_target(self, table_name):
         mysql_columns = self.get_table_columns(table_name)
-        mapped_columns = ["{} {}".format(pc.get('column_name'), self.tap_type_to_target_type(pc.get('data_type'), pc.get('column_type'))) for pc in mysql_columns]
+        mapped_columns = ["{} {}".format(pc.get('column_name'),
+                                         self.tap_type_to_target_type(pc.get('data_type'), pc.get('column_type'))) for
+                          pc in mysql_columns]
 
         return {
             "columns": mapped_columns,
@@ -207,15 +212,37 @@ class FastSyncTapMySql:
                     if not rows:
                         break
 
-
                     # Log export status
                     exported_rows += len(rows)
-                    if (len(rows) == export_batch_rows):
-                        #Then we believe this to be just an interim batch and not the final one so report on progress
-                        utils.log("Exporting batch from {} to {} rows from {}...".format((exported_rows-export_batch_rows),exported_rows, table_name))
+                    if len(rows) == export_batch_rows:
+                        # Then we believe this to be just an interim batch and not the final one so report on progress
+                        utils.log(
+                            "Exporting batch from {} to {} rows from {}...".format((exported_rows - export_batch_rows),
+                                                                                   exported_rows, table_name))
 
                     # Write rows to file
                     for row in rows:
+                        row = list(row)
+                        for ind, val in enumerate(row):
+                            if isinstance(val, bytes):
+                                # Removes all trailing '\x00' from the bytes Trailing zeroes in bytes is caused by
+                                # how BINARY type columns pads the inserted values, this doesn't happen when using
+                                # VARBINARY.
+                                #
+                                # ref: https://dev.mysql.com/doc/refman/8.0/en/binary-varbinary.html
+                                #
+                                # Leaving the trailing zeroes makes FT & Incremental behave differently than Binlog
+                                # and we end up with inconsistent state records.
+                                #
+                                # Example: for a binary value b'pk0'
+                                #   - Binlog would read it as b'pk0' then in HEX it would be b'706b30'
+                                #   - FT & Inc would read it as b'pk0\x00\x00\x00\x00....\x00' then in HEX
+                                #       it would be b'706b300000...0'
+                                stripped_utf8_elem = val.decode().rstrip('\x00').encode()
+
+                                # encode the stripped elem to binary hex and then to utf8 string
+                                row[ind] = codecs.encode(stripped_utf8_elem, 'hex').decode("utf-8")
+
                         writer.writerow(row)
 
                 utils.log("Exported total of {} rows from {}...".format(exported_rows, table_name))

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Dict
 
 import snowflake.connector
 import time
@@ -141,7 +141,7 @@ class FastSyncTargetSnowflake:
         if master_key != '':
             sql = """COPY INTO {}.{} FROM @{}/{}
                 FILE_FORMAT = (type='CSV' escape='\\x1e' escape_unenclosed_field='\\x1e' 
-                field_optionally_enclosed_by='\"' skip_header={} COMPRESSION='GZIP') 
+                field_optionally_enclosed_by='\"' skip_header={} COMPRESSION='GZIP' BINARY_FORMAT='HEX') 
             """.format(
                 target_schema,
                 target_table,
@@ -153,7 +153,7 @@ class FastSyncTargetSnowflake:
             sql = """COPY INTO {}.{} FROM 's3://{}/{}'
                 CREDENTIALS = (aws_key_id='{}' aws_secret_key='{}')
                 FILE_FORMAT = (type='CSV' escape='\\x1e' escape_unenclosed_field='\\x1e' 
-                field_optionally_enclosed_by='\"' skip_header={} COMPRESSION='GZIP')
+                field_optionally_enclosed_by='\"' skip_header={} COMPRESSION='GZIP' BINARY_FORMAT='HEX')
             """.format(
                 target_schema,
                 target_table,

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -6,7 +6,7 @@ import time
 
 import multiprocessing
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from .commons import utils
 from .commons.tap_mysql import FastSyncTapMySql
 from .commons.target_snowflake import FastSyncTargetSnowflake
@@ -41,8 +41,8 @@ def tap_type_to_target_type(mysql_type, mysql_column_type):
     return {
         'char':'VARCHAR',
         'varchar':'VARCHAR',
-        'binary':'VARCHAR',
-        'varbinary':'VARCHAR',
+        'binary':'BINARY',
+        'varbinary':'BINARY',
         'blob':'VARCHAR',
         'tinyblob':'VARCHAR',
         'mediumblob':'VARCHAR',

--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/transferwise/pipelinewise-tap-mysql.git@support-binary-cols#egg=pipelinewise-tap-mysql
+pipelinewise-tap-mysql==1.1.1

--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mysql==1.0.7
+-e git+https://github.com/transferwise/pipelinewise-tap-mysql.git@support-binary-cols#egg=pipelinewise-tap-mysql

--- a/singer-connectors/target-snowflake/requirements.txt
+++ b/singer-connectors/target-snowflake/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/transferwise/pipelinewise-target-snowflake.git@AP-111#egg=pipelinewise-target-snowflake
+pipelinewise-target-snowflake==1.2.0

--- a/singer-connectors/target-snowflake/requirements.txt
+++ b/singer-connectors/target-snowflake/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-snowflake==1.1.8
+-e git+https://github.com/transferwise/pipelinewise-target-snowflake.git@AP-111#egg=pipelinewise-target-snowflake

--- a/tests/db/tap_mysql_data.sql
+++ b/tests/db/tap_mysql_data.sql
@@ -189,8 +189,39 @@ INSERT INTO `weight_unit` VALUES (1,'1 kg pkg.',1,'2017-03-26 00:36:37','2017-03
 /*!40000 ALTER TABLE `weight_unit` ENABLE KEYS */;
 UNLOCK TABLES;
 
-/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+-- Dump completed on 2017-03-26  2:01:31
 
+--
+-- Table structure for table `table_with_binary`
+--
+
+DROP TABLE IF EXISTS `table_with_binary`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `table_with_binary` (
+  `id` binary(50) PRIMARY KEY,
+  `data` varbinary(100),
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `table_with_binary`
+--
+
+LOCK TABLES `table_with_binary` WRITE;
+/*!40000 ALTER TABLE `table_with_binary` DISABLE KEYS */;
+INSERT INTO `table_with_binary`(id, data) VALUES
+                                            (BINARY ('1000'),BINARY('data1000')),
+                                            (BINARY('1001'), BINARY('data1001')),
+                                            (BINARY(1002), null),
+                                            (HEX (1003), HEX('data1003'))
+                                            ;
+/*!40000 ALTER TABLE `table_with_binary` ENABLE KEYS */;
+UNLOCK TABLES;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
@@ -198,5 +229,3 @@ UNLOCK TABLES;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
-
--- Dump completed on 2017-03-26  2:01:31

--- a/tests/end-to-end/test-project/tap_mysql_to_sf.yml.template
+++ b/tests/end-to-end/test-project/tap_mysql_to_sf.yml.template
@@ -1,0 +1,40 @@
+---
+
+# ------------------------------------------------------------------------------
+# General Properties
+# ------------------------------------------------------------------------------
+id: "mariadb_to_sf"
+name: "MariaDB source test database"
+type: "tap-mysql"
+owner: "test-runner"
+
+
+# ------------------------------------------------------------------------------
+# Source (Tap) - MySQL connection details
+# ------------------------------------------------------------------------------
+db_conn:
+  host: "${DB_TAP_MYSQL_HOST}"                  # PostgreSQL host
+  port: ${DB_TAP_MYSQL_PORT}                    # PostgreSQL port
+  user: "${DB_TAP_MYSQL_USER}"                  # PostgreSQL user
+  password: "${DB_TAP_MYSQL_PASSWORD}"          # Plain string or vault encrypted
+  dbname: "${DB_TAP_MYSQL_DB}"                  # PostgreSQL database name
+
+
+# ------------------------------------------------------------------------------
+# Destination (Target) - Target properties
+# Connection details should be in the relevant target YAML file
+# ------------------------------------------------------------------------------
+target: "snowflake"                 # ID of the target connector where the data will be loaded
+batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+
+
+# ------------------------------------------------------------------------------
+# Source to target Schema mapping
+# ------------------------------------------------------------------------------
+schemas:
+  - source_schema: "mysql_source_db"
+    target_schema: "mysql_grp24"
+
+    tables:
+      - table_name: "table_with_binary"
+        replication_method: "LOG_BASED"

--- a/tests/end-to-end/test_e2e.py
+++ b/tests/end-to-end/test_e2e.py
@@ -186,6 +186,28 @@ class TestE2E(object):
         self.assert_command_success(rc, stdout, stderr, log_file)
 
     @pytest.mark.dependency(depends=["import_config"])
+    def test_replicate_mariadb_to_snowflake(self):
+        """Replicate data from MariaDB to Snowflake DWH, check if return code is zero and success log file created"""
+
+        tap_name = 'mariadb_to_sf'
+        target_name = 'snowflake'
+
+        # Run tap first time - fastsync should be triggered
+        [rc, stdout, stderr] = self.run_command("pipelinewise run_tap --tap {} --target {}".format(tap_name,
+                                                                                                   target_name))
+
+        log_file = self.find_run_tap_log_file(stdout, 'fastsync')
+        self.assert_command_success(rc, stdout, stderr, log_file)
+
+        # Run tap second time - singer should be triggered and state message should be emitted
+        [rc, stdout, stderr] = self.run_command("pipelinewise run_tap --tap {} --target {}".format(tap_name,
+                                                                                                   target_name))
+        log_file = self.find_run_tap_log_file(stdout, 'singer')
+        self.assert_command_success(rc, stdout, stderr, log_file)
+
+        self.assert_state_file_valid(target_name, tap_name, log_file)
+
+    @pytest.mark.dependency(depends=["import_config"])
     def test_replicate_postgres_to_postgres(self):
         """Replicate data from Postgres to Postgres DWH, check if return code is zero and success log file created"""
         [rc, stdout, stderr] = self.run_command("pipelinewise run_tap --tap postgres_source --target postgres_dwh")


### PR DESCRIPTION
Supporting binary and varbinary columns in Mysql sources when using fast sync.

Atm, I'm fetching the right pipelinewise-tap-mysql and pipelinewise-target-snowflake using git urls because the latest changes are not yet released on PyPi. I will update this PR once those changes are released, so this PR shouldn't be merged until then.

Last change to finish AP-111.

TODO before merge:
1- Update requirements files of pipelinewise-tap-mysql & pipelinewise-target-snowflake connectors.
2- bump pipelinewise minor