### PR TITLE
Disable data flattening for kafka by default

### DIFF
--- a/pipelinewise/cli/tap_properties.py
+++ b/pipelinewise/cli/tap_properties.py
@@ -102,7 +102,7 @@ def get_tap_properties(tap=None):
         'tap_stream_name_pattern': '{{table_name}}',
         'tap_catalog_argument': '--properties',
         'default_replication_method': 'LOG_BASED',
-        'default_data_flattening_max_level': 10
+        'default_data_flattening_max_level': 0
     },
 
     'tap-zendesk': {


### PR DESCRIPTION
Data flattening needs to be disabled by default since we upgraded to pipelinewise-tap-kafka 2.0.0 . The latest tap-kafka doesn't do data flattening at all.