### PR TITLE
[AP-454] More meaningful post import check message

### DIFF
--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -618,10 +618,11 @@ class PipelineWise(object):
         except Exception as exc:
             return f"Cannot load selection JSON at {tap_selection_file}. {str(exc)}"
 
-        # Post import checks
+        # 
+        checks
         post_import_errors = self._run_post_import_tap_checks(schema_with_diff, target)
         if len(post_import_errors) > 0:
-            return f"Post import tap checks failed at {tap_id}. {post_import_errors}"
+            return f"Post import tap checks failed in tap {tap_id}: {post_import_errors}"
 
         # Save the new catalog into the tap
         try:
@@ -1223,7 +1224,7 @@ TAP RUN SUMMARY
             # Check if primary key is set for INCREMENTAL and LOG_BASED replications
             if (selected and replication_method in [self.INCREMENTAL, self.LOG_BASED] and
                     len(table_key_properties) == 0 and primary_key_required):
-                errors.append(f'No primary key set for - {replication_method} {tap_stream_id}.')
+                errors.append(f'No primary key set for {tap_stream_id} stream ({replication_method})')
                 break
 
         return errors

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -618,8 +618,7 @@ class PipelineWise(object):
         except Exception as exc:
             return f"Cannot load selection JSON at {tap_selection_file}. {str(exc)}"
 
-        # 
-        checks
+        # Post import checks
         post_import_errors = self._run_post_import_tap_checks(schema_with_diff, target)
         if len(post_import_errors) > 0:
             return f"Post import tap checks failed in tap {tap_id}: {post_import_errors}"


### PR DESCRIPTION
## Description

Small PR to make post import error messages more understandable. The current format of a post impor check failure is:
```
Post import tap checks failed at <TAP_ID>. ['No primary key set for - <REPLICATIONA_METHOD> <TAP_STREAM_ID>.
```

With this PR it's going to look like:
```
Post import tap checks failed at <TAP_ID>: No primary key set for <TAP-STREAM_ID> stream (<REPLICATION_METHOD>)
```


## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions

