### PR TITLE
[AP-415] Create pipelinewise specific common temp directory

### DIFF
--- a/pipelinewise/cli/config.py
+++ b/pipelinewise/cli/config.py
@@ -84,6 +84,12 @@ class Config(object):
 
         return config
 
+    def get_temp_dir(self):
+        """
+        Returns the tap specific temp directory
+        """
+        return os.path.join(self.config_dir, 'tmp')
+
     def get_target_dir(self, target_id):
         '''
         Returns the absolute path of a target configuration directory
@@ -291,6 +297,7 @@ class Config(object):
 
         # Generate tap inheritable_config dict
         tap_inheritable_config = utils.delete_empty_keys({
+            "temp_dir": self.get_temp_dir(),
             "batch_size_rows": tap.get('batch_size_rows'),
             "hard_delete": tap.get('hard_delete', True),
             "flush_all_streams": tap.get('flush_all_streams', False),

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -263,7 +263,7 @@ class PipelineWise(object):
         else:
             self.config = {}
 
-    def get_temp_dir(self,):
+    def get_temp_dir(self):
         """
         Returns the tap specific temp directory
         """

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import shutil
-import tempfile
 import signal
 import sys
 import logging
@@ -94,7 +93,9 @@ class PipelineWise(object):
             dictA.update(dictB)
 
             # Save the new dict as JSON into a temp file
-            tempfile_path = tempfile.mkstemp()[1]
+            tempfile_path = utils.create_temp_file(dir=self.get_temp_dir(),
+                                                   prefix='target_config_',
+                                                   suffix='.json')[1]
             utils.save_json(dictA, tempfile_path)
 
             return tempfile_path
@@ -228,10 +229,14 @@ class PipelineWise(object):
             # Fallback required: Save filtered and fallback properties JSON
             if create_fallback:
                 # Save to files: filtered and fallback properties
-                temp_properties_path = tempfile.mkstemp()[1]
+                temp_properties_path = utils.create_temp_file(dir=self.get_temp_dir(),
+                                                              prefix='properties_',
+                                                              suffix='.json')[1]
                 utils.save_json(properties, temp_properties_path)
 
-                temp_fallback_properties_path = tempfile.mkstemp()[1]
+                temp_fallback_properties_path = utils.create_temp_file(dir=self.get_temp_dir(),
+                                                                       prefix='properties_',
+                                                                       suffix='.json')[1]
                 utils.save_json(fallback_properties, temp_fallback_properties_path)
 
                 return temp_properties_path, filtered_tap_stream_ids, temp_fallback_properties_path, fallback_filtered_tap_stream_ids
@@ -239,7 +244,9 @@ class PipelineWise(object):
             # Fallback not required: Save only the filtered properties JSON
             else:
                 # Save eed to save
-                temp_properties_path = tempfile.mkstemp()[1]
+                temp_properties_path = utils.create_temp_file(dir=self.get_temp_dir(),
+                                                              prefix='properties_',
+                                                              suffix='.json')[1]
                 utils.save_json(properties, temp_properties_path)
 
                 return temp_properties_path, filtered_tap_stream_ids
@@ -255,6 +262,12 @@ class PipelineWise(object):
             self.config = config
         else:
             self.config = {}
+
+    def get_temp_dir(self,):
+        """
+        Returns the tap specific temp directory
+        """
+        return os.path.join(self.config_dir, 'tmp')
 
     def get_tap_dir(self, target_id, tap_id):
         return os.path.join(self.config_dir, target_id, tap_id)
@@ -796,6 +809,7 @@ class PipelineWise(object):
             f"--properties {tap_properties}",
             f"--state {tap_state}",
             f"--target {target_config}",
+            f"--temp_dir {self.get_temp_dir()}",
             f"{tap_transform_arg}",
             f"{tables_command}"
         ))

--- a/pipelinewise/cli/schemas/target.json
+++ b/pipelinewise/cli/schemas/target.json
@@ -153,7 +153,12 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string"
+      "type": "string",
+      "not": {
+        "enum": [
+          "tmp"
+        ]
+      }
     },
     "name": {
       "type": "string"

--- a/pipelinewise/cli/utils.py
+++ b/pipelinewise/cli/utils.py
@@ -8,6 +8,7 @@ import shlex
 import copy
 import re
 import logging
+import tempfile
 import jsonschema
 
 from subprocess import Popen, PIPE, STDOUT
@@ -505,3 +506,12 @@ def run_command(command, log_file=None, line_callback=None):
             logger.error(stderr)
 
         return [rc, stdout, stderr]
+
+
+def create_temp_file(suffix=None, prefix=None, dir=None, text=None):
+    """
+    Create temp file with parent directories if not exists
+    """
+    if dir:
+        os.makedirs(dir, exist_ok=True)
+    return tempfile.mkstemp(suffix, prefix, dir, text)

--- a/pipelinewise/fastsync/commons/utils.py
+++ b/pipelinewise/fastsync/commons/utils.py
@@ -265,7 +265,7 @@ def parse_args(required_config_keys):
     --target            Target Config file
     --transform         Transformations Config file
     --tables            Tables to sync. (Separated by comma)
-    --export-dir        Directory to create temporary csv exports. Defaults to current work dir.
+    --temp_dir          Directory to create temporary csv exports. Defaults to current work dir.
 
     Returns the parsed args object from argparse. For each argument that
     point to JSON files (tap, state, properties, target, transform),
@@ -300,7 +300,7 @@ def parse_args(required_config_keys):
         help='Sync only specific tables')
 
     parser.add_argument(
-        '--export-dir',
+        '--temp_dir',
         help='Temporary directory required for CSV exports')
 
     args = parser.parse_args()
@@ -323,10 +323,10 @@ def parse_args(required_config_keys):
     else:
         args.tables = get_tables_from_properties(args.properties)
 
-    if args.export_dir:
-        args.export_dir = args.export_dir
+    if args.temp_dir:
+        args.temp_dir = args.temp_dir
     else:
-        args.export_dir = os.path.realpath('/tmp')
+        args.temp_dir = os.path.realpath('.')
 
     check_config(args.tap, required_config_keys['tap'])
     check_config(args.target, required_config_keys['target'])

--- a/pipelinewise/fastsync/mysql_to_redshift.py
+++ b/pipelinewise/fastsync/mysql_to_redshift.py
@@ -78,7 +78,7 @@ def sync_table(table):
 
     try:
         filename = "pipelinewise_fastsync_{}_{}.csv.gz".format(table, time.strftime("%Y%m%d-%H%M%S"))
-        filepath = os.path.join(args.export_dir, filename)
+        filepath = os.path.join(args.temp_dir, filename)
         target_schema = utils.get_target_schema(args.target, table)
 
         # Open connection and get binlog file position

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -76,7 +76,7 @@ def sync_table(table):
 
     try:
         filename = "pipelinewise_fastsync_{}_{}.csv.gz".format(table, time.strftime("%Y%m%d-%H%M%S"))
-        filepath = os.path.join(args.export_dir, filename)
+        filepath = os.path.join(args.temp_dir, filename)
         target_schema = utils.get_target_schema(args.target, table)
 
         # Open connection and get binlog file position

--- a/pipelinewise/fastsync/postgres_to_redshift.py
+++ b/pipelinewise/fastsync/postgres_to_redshift.py
@@ -82,7 +82,7 @@ def sync_table(table):
     try:
         dbname = args.tap.get("dbname")
         filename = "pipelinewise_fastsync_{}_{}_{}.csv.gz".format(dbname, table, time.strftime("%Y%m%d-%H%M%S"))
-        filepath = os.path.join(args.export_dir, filename)
+        filepath = os.path.join(args.temp_dir, filename)
         target_schema = utils.get_target_schema(args.target, table)
 
         # Open connection

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -80,7 +80,7 @@ def sync_table(table):
     try:
         dbname = args.tap.get("dbname")
         filename = "pipelinewise_fastsync_{}_{}_{}.csv.gz".format(dbname, table, time.strftime("%Y%m%d-%H%M%S"))
-        filepath = os.path.join(args.export_dir, filename)
+        filepath = os.path.join(args.temp_dir, filename)
         target_schema = utils.get_target_schema(args.target, table)
 
         # Open connection

--- a/pipelinewise/fastsync/s3_csv_to_snowflake.py
+++ b/pipelinewise/fastsync/s3_csv_to_snowflake.py
@@ -60,7 +60,7 @@ def sync_table(table_name: str, args: Namespace)->Union[bool, str]:
     try:
         filename = "pipelinewise_fastsync_{}_{}_{}.csv.gz".format(args.tap['bucket'], table_name,
                                                                   time.strftime("%Y%m%d-%H%M%S"))
-        filepath = os.path.join(args.export_dir, filename)
+        filepath = os.path.join(args.temp_dir, filename)
 
         target_schema = utils.get_target_schema(args.target, table_name)
 

--- a/singer-connectors/target-snowflake/requirements.txt
+++ b/singer-connectors/target-snowflake/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-snowflake==1.2.1
+pipelinewise-target-snowflake==1.3.0

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -324,3 +324,21 @@ class TestUtils(object):
 
         assert tap_names == expected_tap_names
         assert target_names == expected_target_names
+
+    def test_create_temp_file(self):
+        # By default temp files should be created in system temp directory
+        temp_file = cli.utils.create_temp_file()[1]
+        assert os.path.isfile(temp_file)
+        os.remove(temp_file)
+
+        # Providing extra dir argument should create the target directory even if it's not exist
+        temp_file = cli.utils.create_temp_file(dir="./temp_dir_to_create_automatically/deep_temp_dir")[1]
+        assert os.path.isfile(temp_file)
+        os.remove(temp_file)
+
+        # Providing dir, suffix and prefix arguments should create the target_directory with custom prefix and suffix
+        temp_file = cli.utils.create_temp_file(dir="./temp_dir_to_create_automatically/deep_temp_dir",
+                                               suffix=".json",
+                                               prefix="pipelinewise_test_temp_file_")[1]
+        assert os.path.isfile(temp_file)
+        os.remove(temp_file)

--- a/tests/units/cli/test_config.py
+++ b/tests/units/cli/test_config.py
@@ -128,6 +128,7 @@ class TestConfig(object):
         config = cli.config.Config(PIPELINEWISE_TEST_HOME)
 
         # Target and tap directory should be g
+        assert config.get_temp_dir() == "{}/tmp".format(PIPELINEWISE_TEST_HOME)
         assert config.get_target_dir("test-target-id") == "{}/test-target-id".format(PIPELINEWISE_TEST_HOME)
         assert config.get_tap_dir("test-target-id", "test-tap-id") == "{}/test-target-id/test-tap-id".format(PIPELINEWISE_TEST_HOME)
 

--- a/tests/units/fastsync/test_s3_csv_to_snowflake.py
+++ b/tests/units/fastsync/test_s3_csv_to_snowflake.py
@@ -29,7 +29,7 @@ class S3CsvToSnowflake(unittest.TestCase):
             'properties': {},
             'target': {},
             'transform': {},
-            'export_dir': '',
+            'temp_dir': '',
             'state': '',
 
         })
@@ -74,7 +74,7 @@ class S3CsvToSnowflake(unittest.TestCase):
             'properties': {},
             'target': {},
             'transform': {},
-            'export_dir': '',
+            'temp_dir': '',
         })
 
         with patch('pipelinewise.fastsync.s3_csv_to_snowflake.FastSyncTapS3Csv') as fastsync_s3_csv_mock:


### PR DESCRIPTION
## Description  

Currently every temp file created in the system `/tmp` directory but we'd like to have a pipelinewise specific temp directory in `~/.pipelinewise/tmp` to isolate pipelinewise temp files from system temp files. This PR makes it.

Temp files in scope:
* Fastsync `.csv.gz` files
* Generated runtime `config.json` files to run taps

## Extra
* The modified `pipelinewise/cli/schemas/target.json` JSON schema makes sure no target allowed to create with the name `tmp`. This check runs automatically by `validate` and `import` commands and from circeci as well.
* The generated target `config.json` automatically includes a new `temp_dir` property so every target can write their temp files into the same directory.

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
