### PR TITLE
[AP-421] Add stop_tap command

### DIFF
--- a/docs/user_guide/cli.rst
+++ b/docs/user_guide/cli.rst
@@ -51,6 +51,18 @@ Run a specific pipeline
 :--extra_log: Optional: Copy logging into PipelineWise logger to see tap run logs at runtime in STDOUT
 
 
+.. _cli_stop_tap:
+
+stop_tap
+""""""""
+
+Stop running a specific pipeline
+
+:--target: Target connector id
+
+:--tap: Tap connector id
+
+
 .. _cli_discover_tap:
 
 discover_tap

--- a/pipelinewise/cli/__init__.py
+++ b/pipelinewise/cli/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+import pidfile
 from pathlib import Path
 
 from pkg_resources import get_distribution
@@ -18,6 +19,7 @@ venv_dir = os.path.join(pipelinewise_home, '.virtualenvs')
 commands = [
   'init',
   'run_tap',
+  'stop_tap',
   'discover_tap',
   'status',
   'test_tap_connection',
@@ -63,7 +65,7 @@ def main():
             print("You must specify a project name using the argument --name")
             sys.exit(1)
 
-    if args.command == 'discover_tap' or args.command == 'test_tap_connection' or args.command == 'run_tap':
+    if args.command in ['discover_tap', 'test_tap_connection', 'run_tap', 'stop_tap']:
         if args.tap == '*':
             print("You must specify a source name using the argument --tap")
             sys.exit(1)

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -943,7 +943,7 @@ class PipelineWise(object):
                     self.logger.info("No table available that needs to be sync by singer")
 
         except pidfile.AlreadyRunningError:
-            self.logger.error('Another instance of the is already running.')
+            self.logger.error('Another instance of the tap is already running.')
             utils.silentremove(cons_target_config)
             utils.silentremove(tap_properties_fastsync)
             utils.silentremove(tap_properties_singer)
@@ -1055,7 +1055,7 @@ class PipelineWise(object):
                 )
 
         except pidfile.AlreadyRunningError:
-            self.logger.error('Another instance of the is already running.')
+            self.logger.error('Another instance of the tap is already running.')
             utils.silentremove(cons_target_config)
             sys.exit(1)
         # Delete temp file if there is any

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(name='pipelinewise',
         'singer-encodings==0.0.*',
         'python-dateutil<2.8.1',
         'messytables==0.15.*',
-        'pytz==2018.4'
+        'pytz==2018.4',
+        'python-pidfile==3.0.0'
     ],
     extras_require={
         "test": [

--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -75,7 +75,8 @@ class TestCli(object):
                 'properties': '/var/singer-connector/properties.json',
                 'state': '/var/singer-connector/state.json',
                 'transformation': '/var/singer-connector/transformation.json',
-                'selection': '/var/singer-connector/selection.json'
+                'selection': '/var/singer-connector/selection.json',
+                'pidfile': '/var/singer-connector/pipelinewise.pid'
             }
 
 
@@ -375,7 +376,7 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
         assert exp_err_pattern in stdout or exp_err_pattern in stderr
 
 
-    def _test_command_run_tap(self, capsys):
+    def test_command_run_tap(self, capsys):
         """Test run tap command"""
         args = CliArgs(target="target_one", tap="tap_one")
         pipelinewise = PipelineWise(args, CONFIG_DIR, VIRTUALENVS_DIR)
@@ -385,6 +386,18 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
         # TODO: sync discover_tap and run_tap behaviour. run_tap sys.exit but discover_tap does not.
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             pipelinewise.run_tap()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == 1
+
+
+    def test_command_stop_tap(self, capsys):
+        """Test stop tap command"""
+        args = CliArgs(target="target_one", tap="tap_one")
+        pipelinewise = PipelineWise(args, CONFIG_DIR, VIRTUALENVS_DIR)
+
+        # Tap is not running, pid file not exist, should exit with error
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            pipelinewise.stop_tap()
         assert pytest_wrapped_e.type == SystemExit
         assert pytest_wrapped_e.value.code == 1
 


### PR DESCRIPTION
## Description

This PR adds **stop_tap** command to PipelineWise. Usage: `pipelinewise stop_tap --target <TARGET_ID> --tap <TAP_ID>`

At the moment we need to stop long running taps manually by `kill -9 <PID>`.

This PR creates a pidfile for every running tap in `~/.pipelinewise/<target_id>/<tap_id>/pipelinewise.pid` so **stop_tap** can detect quickly the process id and can send SIGINT to the process that triggers a graceful exit.

## Extra

This will also allow us detecting if the tap is in running status much quicker as we do today. Currently we check the log history to find if the tap is running or not. In case of 150 taps the startup process takes at least 1 minute for each tap. Doing the same by checking if the pidfile exists is much quicker.

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
