### PR TITLE
[AP-483] Add more granular end to end tests

### DIFF
--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mysql==1.1.3
+pipelinewise-tap-mysql==1.1.5

--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mysql==1.1.2
+pipelinewise-tap-mysql==1.1.3

--- a/tests/db/tap_mysql_db.sh
+++ b/tests/db/tap_mysql_db.sh
@@ -25,6 +25,9 @@ fi
 export MYSQL_PWD=${DB_TAP_MYSQL_ROOT_PASSWORD}
 mysql --protocol TCP --host ${DB_TAP_MYSQL_HOST} --port ${DB_TAP_MYSQL_PORT} --user root -e "GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO ${DB_TAP_MYSQL_USER}"
 
+# Grant insert privileges for testing
+mysql --protocol TCP --host ${DB_TAP_MYSQL_HOST} --port ${DB_TAP_MYSQL_PORT} --user root -e "GRANT INSERT ON *.* TO ${DB_TAP_MYSQL_USER}"
+
 # Download the sample database and build it
 export MYSQL_PWD=${DB_TAP_MYSQL_PASSWORD}
 mysql --protocol TCP --host ${DB_TAP_MYSQL_HOST} --port ${DB_TAP_MYSQL_PORT} --user ${DB_TAP_MYSQL_USER} ${DB_TAP_MYSQL_DB} < ${TEST_DB_SQL}

--- a/tests/end-to-end/e2e_utils.py
+++ b/tests/end-to-end/e2e_utils.py
@@ -1,0 +1,93 @@
+import os
+import re
+import shlex
+import psycopg2
+import subprocess
+import snowflake.connector
+
+from dotenv import load_dotenv
+
+
+def load_env():
+    """Load environment variables in priority order:
+        1: Existing environment variables
+        2: Docker compose .env environment variables"""
+    load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), "../../dev-project/.env"))
+    env = {
+        'DB_TAP_POSTGRES_HOST': os.environ.get('DB_TAP_POSTGRES_HOST'),
+        'DB_TAP_POSTGRES_PORT': os.environ.get('DB_TAP_POSTGRES_PORT'),
+        'DB_TAP_POSTGRES_USER': os.environ.get('DB_TAP_POSTGRES_USER'),
+        'DB_TAP_POSTGRES_PASSWORD': os.environ.get('DB_TAP_POSTGRES_PASSWORD'),
+        'DB_TAP_POSTGRES_DB': os.environ.get('DB_TAP_POSTGRES_DB'),
+        'DB_TAP_MYSQL_HOST': os.environ.get('DB_TAP_MYSQL_HOST'),
+        'DB_TAP_MYSQL_PORT': os.environ.get('DB_TAP_MYSQL_PORT'),
+        'DB_TAP_MYSQL_USER': os.environ.get('DB_TAP_MYSQL_USER'),
+        'DB_TAP_MYSQL_PASSWORD': os.environ.get('DB_TAP_MYSQL_PASSWORD'),
+        'DB_TAP_MYSQL_DB': os.environ.get('DB_TAP_MYSQL_DB'),
+        'DB_TARGET_POSTGRES_HOST': os.environ.get('DB_TARGET_POSTGRES_HOST'),
+        'DB_TARGET_POSTGRES_PORT': os.environ.get('DB_TARGET_POSTGRES_PORT'),
+        'DB_TARGET_POSTGRES_USER': os.environ.get('DB_TARGET_POSTGRES_USER'),
+        'DB_TARGET_POSTGRES_PASSWORD': os.environ.get('DB_TARGET_POSTGRES_PASSWORD'),
+        'DB_TARGET_POSTGRES_DB': os.environ.get('DB_TARGET_POSTGRES_DB'),
+        'TARGET_SNOWFLAKE_ACCOUNT': os.environ.get('TARGET_SNOWFLAKE_ACCOUNT'),
+        'TARGET_SNOWFLAKE_DBNAME': os.environ.get('TARGET_SNOWFLAKE_DBNAME'),
+        'TARGET_SNOWFLAKE_USER': os.environ.get('TARGET_SNOWFLAKE_USER'),
+        'TARGET_SNOWFLAKE_PASSWORD': os.environ.get('TARGET_SNOWFLAKE_PASSWORD'),
+        'TARGET_SNOWFLAKE_WAREHOUSE': os.environ.get('TARGET_SNOWFLAKE_WAREHOUSE'),
+        'TARGET_SNOWFLAKE_AWS_ACCESS_KEY': os.environ.get('TARGET_SNOWFLAKE_AWS_ACCESS_KEY'),
+        'TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY': os.environ.get('TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY'),
+        'TARGET_SNOWFLAKE_S3_BUCKET': os.environ.get('TARGET_SNOWFLAKE_S3_BUCKET'),
+        'TARGET_SNOWFLAKE_S3_KEY_PREFIX': os.environ.get('TARGET_SNOWFLAKE_S3_KEY_PREFIX'),
+        'TARGET_SNOWFLAKE_STAGE': os.environ.get('TARGET_SNOWFLAKE_STAGE'),
+        'TARGET_SNOWFLAKE_FILE_FORMAT': os.environ.get('TARGET_SNOWFLAKE_FILE_FORMAT'),
+        'TAP_S3_CSV_SOURCE_AWS_KEY': os.environ.get('TAP_S3_CSV_SOURCE_AWS_KEY'),
+        'TAP_S3_CSV_SOURCE_AWS_SECRET_ACCESS_KEY': os.environ.get('TAP_S3_CSV_SOURCE_AWS_SECRET_ACCESS_KEY'),
+        'TAP_S3_CSV_SOURCE_BUCKET': os.environ.get('TAP_S3_CSV_SOURCE_BUCKET'),
+    }
+
+    return env
+
+def find_run_tap_log_file(stdout, sync_engine=None):
+    """Pipelinewise creates log file per running tap instances in a dynamically created directory:
+        ~/.pipelinewise/<TARGET_ID>/<TAP_ID>/log
+
+        Every log file matches the pattern:
+        <TARGET_ID>-<TAP_ID>-<DATE>_<TIME>.<SYNC_ENGINE>.log.<STATUS>
+
+        The generated full path is logged to STDOUT when tap starting"""
+    if sync_engine:
+        pattern = re.compile(r"Writing output into (.+\.{}\.log)".format(sync_engine))
+    else:
+        pattern = re.compile(r"Writing output into (.+\.log)")
+
+    return pattern.search(stdout).group(1)
+
+def run_query_postgres(env, query):
+    with psycopg2.connect(host=env['DB_TARGET_POSTGRES_HOST'],
+                          port=env['DB_TARGET_POSTGRES_PORT'],
+                          user=env['DB_TARGET_POSTGRES_USER'],
+                          password=env['DB_TARGET_POSTGRES_PASSWORD'],
+                          database=env['DB_TARGET_POSTGRES_DB']) as conn:
+        conn.set_session(autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute(query)
+
+def run_query_snowflake(env, query):
+    with snowflake.connector.connect(account=env['TARGET_SNOWFLAKE_ACCOUNT'],
+                                     database=env['TARGET_SNOWFLAKE_DBNAME'],
+                                     warehouse=env['TARGET_SNOWFLAKE_WAREHOUSE'],
+                                     user=env['TARGET_SNOWFLAKE_USER'],
+                                     password=env['TARGET_SNOWFLAKE_PASSWORD'],
+                                     autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(query)
+
+def run_command(command):
+    """Run shell command and return returncode, stdout and stderr"""
+    proc = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    x = proc.communicate()
+    rc = proc.returncode
+    stdout = x[0].decode('utf-8')
+    stderr = x[1].decode('utf-8')
+
+    return [rc, stdout, stderr]

--- a/tests/end-to-end/test-project/tap_mysql.yml.template
+++ b/tests/end-to-end/test-project/tap_mysql.yml.template
@@ -49,4 +49,4 @@ schemas:
         replication_method: "FULL_TABLE"
 
       - table_name: "weight_unit"
-        replication_method: "FULL_TABLE"
+        replication_method: "LOG_BASED"

--- a/tests/end-to-end/test_e2e.py
+++ b/tests/end-to-end/test_e2e.py
@@ -1,14 +1,10 @@
 import os
-import re
 import glob
-import shlex
 import shutil
 import pytest
-import psycopg2
-import subprocess
-import snowflake.connector
+import re
+import e2e_utils
 
-from dotenv import load_dotenv
 from pathlib import Path
 
 DIR = os.path.dirname(__file__)
@@ -22,51 +18,13 @@ class TestE2E(object):
     """
 
     def setup_method(self):
-        self.env = self.load_env()
+        self.env = e2e_utils.load_env()
         self.project_dir = os.path.join(DIR, "test-project")
         self.init_test_project_dir()
 
     def teardown_method(self):
         pass
 
-    def load_env(self):
-        """Load environment variables in priority order:
-            1: Existing environment variables 
-            2: Docker compose .env environment variables"""
-        load_dotenv(dotenv_path=os.path.join(DIR, "../../dev-project/.env"))
-        env = {
-            'DB_TAP_POSTGRES_HOST': os.environ.get('DB_TAP_POSTGRES_HOST'),
-            'DB_TAP_POSTGRES_PORT': os.environ.get('DB_TAP_POSTGRES_PORT'),
-            'DB_TAP_POSTGRES_USER': os.environ.get('DB_TAP_POSTGRES_USER'),
-            'DB_TAP_POSTGRES_PASSWORD': os.environ.get('DB_TAP_POSTGRES_PASSWORD'),
-            'DB_TAP_POSTGRES_DB': os.environ.get('DB_TAP_POSTGRES_DB'),
-            'DB_TAP_MYSQL_HOST': os.environ.get('DB_TAP_MYSQL_HOST'),
-            'DB_TAP_MYSQL_PORT': os.environ.get('DB_TAP_MYSQL_PORT'),
-            'DB_TAP_MYSQL_USER': os.environ.get('DB_TAP_MYSQL_USER'),
-            'DB_TAP_MYSQL_PASSWORD': os.environ.get('DB_TAP_MYSQL_PASSWORD'),
-            'DB_TAP_MYSQL_DB': os.environ.get('DB_TAP_MYSQL_DB'),
-            'DB_TARGET_POSTGRES_HOST': os.environ.get('DB_TARGET_POSTGRES_HOST'),
-            'DB_TARGET_POSTGRES_PORT': os.environ.get('DB_TARGET_POSTGRES_PORT'),
-            'DB_TARGET_POSTGRES_USER': os.environ.get('DB_TARGET_POSTGRES_USER'),
-            'DB_TARGET_POSTGRES_PASSWORD': os.environ.get('DB_TARGET_POSTGRES_PASSWORD'),
-            'DB_TARGET_POSTGRES_DB': os.environ.get('DB_TARGET_POSTGRES_DB'),
-            'TARGET_SNOWFLAKE_ACCOUNT': os.environ.get('TARGET_SNOWFLAKE_ACCOUNT'),
-            'TARGET_SNOWFLAKE_DBNAME': os.environ.get('TARGET_SNOWFLAKE_DBNAME'),
-            'TARGET_SNOWFLAKE_USER': os.environ.get('TARGET_SNOWFLAKE_USER'),
-            'TARGET_SNOWFLAKE_PASSWORD': os.environ.get('TARGET_SNOWFLAKE_PASSWORD'),
-            'TARGET_SNOWFLAKE_WAREHOUSE': os.environ.get('TARGET_SNOWFLAKE_WAREHOUSE'),
-            'TARGET_SNOWFLAKE_AWS_ACCESS_KEY': os.environ.get('TARGET_SNOWFLAKE_AWS_ACCESS_KEY'),
-            'TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY': os.environ.get('TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY'),
-            'TARGET_SNOWFLAKE_S3_BUCKET': os.environ.get('TARGET_SNOWFLAKE_S3_BUCKET'),
-            'TARGET_SNOWFLAKE_S3_KEY_PREFIX': os.environ.get('TARGET_SNOWFLAKE_S3_KEY_PREFIX'),
-            'TARGET_SNOWFLAKE_STAGE': os.environ.get('TARGET_SNOWFLAKE_STAGE'),
-            'TARGET_SNOWFLAKE_FILE_FORMAT': os.environ.get('TARGET_SNOWFLAKE_FILE_FORMAT'),
-            'TAP_S3_CSV_SOURCE_AWS_KEY': os.environ.get('TAP_S3_CSV_SOURCE_AWS_KEY'),
-            'TAP_S3_CSV_SOURCE_AWS_SECRET_ACCESS_KEY': os.environ.get('TAP_S3_CSV_SOURCE_AWS_SECRET_ACCESS_KEY'),
-            'TAP_S3_CSV_SOURCE_BUCKET': os.environ.get('TAP_S3_CSV_SOURCE_BUCKET'),
-        }
-
-        return env
 
     def init_test_project_dir(self):
         """Load every YML template from test-project directory, replace the environment
@@ -86,65 +44,25 @@ class TestE2E(object):
 
     def clean_target_postgres(self):
         """Clean postgres_dwh"""
-        with psycopg2.connect(host=self.env['DB_TARGET_POSTGRES_HOST'],
-                              port=self.env['DB_TARGET_POSTGRES_PORT'],
-                              user=self.env['DB_TARGET_POSTGRES_USER'],
-                              password=self.env['DB_TARGET_POSTGRES_PASSWORD'],
-                              database=self.env['DB_TARGET_POSTGRES_DB']) as conn:
-            conn.set_session(autocommit=True)
-            with conn.cursor() as cur:
-                # Drop target schemas if exists
-                cur.execute("DROP SCHEMA IF EXISTS mysql_grp24 CASCADE;")
-                cur.execute("DROP SCHEMA IF EXISTS postgres_world CASCADE;")
+        # Drop target schemas if exists
+        e2e_utils.run_query_postgres(self.env, "DROP SCHEMA IF EXISTS mysql_grp24 CASCADE")
+        e2e_utils.run_query_postgres(self.env, "DROP SCHEMA IF EXISTS postgres_world CASCADE")
 
-                # Create groups required for tests
-                cur.execute("DROP GROUP IF EXISTS group1;")
-                cur.execute("CREATE GROUP group1;")
+        # Create groups required for tests
+        e2e_utils.run_query_postgres(self.env, "DROP GROUP IF EXISTS group1")
+        e2e_utils.run_query_postgres(self.env, "CREATE GROUP group1")
 
         # Clean config directory
         shutil.rmtree(os.path.join(CONFIG_DIR, 'postgres_dwh'), ignore_errors=True)
 
     def clean_target_snowflake(self):
         """Clean snowflake"""
-        with snowflake.connector.connect(account=self.env['TARGET_SNOWFLAKE_ACCOUNT'],
-                                         database=self.env['TARGET_SNOWFLAKE_DBNAME'],
-                                         warehouse=self.env['TARGET_SNOWFLAKE_WAREHOUSE'],
-                                         user=self.env['TARGET_SNOWFLAKE_USER'],
-                                         password=self.env['TARGET_SNOWFLAKE_PASSWORD'],
-                                         autocommit=True) as conn:
-            with conn.cursor() as cur:
-                # Drop target schemas if exists
-                cur.execute("DROP SCHEMA IF EXISTS mysql_grp24")
-                cur.execute("DROP SCHEMA IF EXISTS postgres_world_sf")
-                cur.execute("DROP SCHEMA IF EXISTS s3_feeds")
+        e2e_utils.run_query_snowflake(self.env, "DROP SCHEMA IF EXISTS mysql_grp24")
+        e2e_utils.run_query_snowflake(self.env, "DROP SCHEMA IF EXISTS postgres_world_sf")
+        e2e_utils.run_query_snowflake(self.env, "DROP SCHEMA IF EXISTS s3_feeds")
 
         # Clean config directory
         shutil.rmtree(os.path.join(CONFIG_DIR, 'snowflake'), ignore_errors=True)
-
-    def run_command(self, command):
-        """Run shell command and return returncode, stdout and stderr"""
-        proc = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        x = proc.communicate()
-        rc = proc.returncode
-        stdout = x[0].decode('utf-8')
-        stderr = x[1].decode('utf-8')
-
-        return [rc, stdout, stderr]
-
-    def find_run_tap_log_file(self, stdout, sync_engine=None):
-        """Pipelinewise creates log file per running tap instances in a dynamically created directory:
-            ~/.pipelinewise/<TARGET_ID>/<TAP_ID>/log
-            
-            Every log file matches the pattern:
-            <TARGET_ID>-<TAP_ID>-<DATE>_<TIME>.<SYNC_ENGINE>.log.<STATUS>
-
-            The generated full path is logged to STDOUT when tap starting"""
-        if sync_engine:
-            pattern = re.compile(r"Writing output into (.+\.{}\.log)".format(sync_engine))
-        else:
-            pattern = re.compile(r"Writing output into (.+\.log)")
-
-        return pattern.search(stdout).group(1)
 
     def assert_command_success(self, rc, stdout, stderr, log_path=None):
         """Assert helper function to check if command finished successfully.
@@ -191,9 +109,9 @@ class TestE2E(object):
     def assert_run_tap_success(self, tap, target, sync_engines):
         """Run a specific tap and make sure that it's using the correct sync engine,
         finished successfully and state file created with the right content"""
-        [rc, stdout, stderr] = self.run_command("pipelinewise run_tap --tap {} --target {}".format(tap, target))
+        [rc, stdout, stderr] = e2e_utils.run_command("pipelinewise run_tap --tap {} --target {}".format(tap, target))
         for sync_engine in sync_engines:
-            log_file = self.find_run_tap_log_file(stdout, sync_engine)
+            log_file = e2e_utils.find_run_tap_log_file(stdout, sync_engine)
             self.assert_command_success(rc, stdout, stderr, log_file)
             self.assert_state_file_valid(target, tap, log_file)
 
@@ -203,7 +121,7 @@ class TestE2E(object):
         connectors """
         self.clean_target_postgres()
         self.clean_target_snowflake()
-        [rc, stdout, stderr] = self.run_command("pipelinewise import_config --dir {}".format(self.project_dir))
+        [rc, stdout, stderr] = e2e_utils.run_command("pipelinewise import_config --dir {}".format(self.project_dir))
         self.assert_command_success(rc, stdout, stderr)
 
     @pytest.mark.dependency(depends=["import_config"])


### PR DESCRIPTION
## Description

This PR makes mariadb to postgres end to end tests more granular. The primary goal of this PR is making sure that performance improvements in pipelinewise-tap-mysql [here](https://github.com/transferwise/pipelinewise-tap-mysql/pull/12) is not introducing new bug.

This PR also refactors the existing end to end tests structure and eliminates some duplicates by introducing `e2e_utils.py` and move common functions to this file.

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
