### PR TITLE
[AP-XXXX] Bump tap-jira

### DIFF
--- a/singer-connectors/tap-jira/requirements.txt
+++ b/singer-connectors/tap-jira/requirements.txt
@@ -1,1 +1,1 @@
-tap-jira==1.0.5
+tap-jira==2.0.0


### PR DESCRIPTION
## Description

Bump to tap-jira to 2.0.0

Due to an API change in Jira, `tap-jira` cannot extract the users streams. This has been fixed in https://github.com/singer-io/tap-jira/pull/46 and released in tap-jira-2.0.0.

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [ ] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
