### PR TITLE
[AP-453] handle reserved words used for column names in FS mysql to SF

### DIFF
--- a/pipelinewise/fastsync/commons/tap_mysql.py
+++ b/pipelinewise/fastsync/commons/tap_mysql.py
@@ -8,6 +8,7 @@ import pymysql
 from pymysql import InterfaceError, OperationalError
 
 from . import utils
+from ...utils import safe_column_name
 
 LOGGER = logging.getLogger(__name__)
 
@@ -166,9 +167,9 @@ class FastSyncTapMySql:
                             column_type,
                             CASE
                             WHEN data_type IN ('blob', 'tinyblob', 'mediumblob', 'longblob', 'geometry')
-                                    THEN concat('hex(', column_name, ')')
+                                    THEN concat('hex(`', column_name, '`)')
                             WHEN data_type IN ('binary', 'varbinary')
-                                    THEN concat('hex(trim(trailing CHAR(0x00) from ',COLUMN_NAME,'))')
+                                    THEN concat('hex(trim(trailing CHAR(0x00) from `',COLUMN_NAME,'`))')
                             WHEN data_type IN ('bit')
                                     THEN concat('cast(`', column_name, '` AS unsigned)')
                             WHEN data_type IN ('datetime', 'timestamp', 'date')
@@ -176,7 +177,7 @@ class FastSyncTapMySql:
                             WHEN column_type IN ('tinyint(1)')
                                     THEN concat('CASE WHEN `' , column_name , '` is null THEN null WHEN `' , column_name , '` = 0 THEN 0 ELSE 1 END')
                             WHEN column_name = 'raw_data_hash'
-                                    THEN concat('hex(', column_name, ')')
+                                    THEN concat('hex(`', column_name, '`)')
                             ELSE concat('cast(`', column_name, '` AS char CHARACTER SET utf8)')
                                 END AS safe_sql_value,
                             ordinal_position
@@ -190,17 +191,17 @@ class FastSyncTapMySql:
 
     def map_column_types_to_target(self, table_name):
         """
-        Map MySQL columnn types to equivalent types in target
+        Map MySQL column types to equivalent types in target
         """
         mysql_columns = self.get_table_columns(table_name)
         mapped_columns = [
-            '{} {}'.format(pc.get('column_name'),
+            '{} {}'.format(safe_column_name(pc.get('column_name')),
                            self.tap_type_to_target_type(pc.get('data_type'), pc.get('column_type')))
             for pc in mysql_columns]
 
         return {
             'columns': mapped_columns,
-            'primary_key': self.get_primary_key(table_name)
+            'primary_key': safe_column_name(self.get_primary_key(table_name))
         }
 
     # pylint: disable=too-many-locals

--- a/tests/db/tap_mysql_data.sql
+++ b/tests/db/tap_mysql_data.sql
@@ -24,9 +24,10 @@ DROP TABLE IF EXISTS `edgydata`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `edgydata` (
-  `c_id` int(11) NOT NULL AUTO_INCREMENT,
+  `order` int(11) PRIMARY KEY AUTO_INCREMENT,
   `c_varchar` varchar(128),
-  PRIMARY KEY (`c_id`)
+  `group` int,
+  `case` varchar(1)
 ) ENGINE=MyISAM AUTO_INCREMENT=1001 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -37,16 +38,16 @@ CREATE TABLE `edgydata` (
 LOCK TABLES `edgydata` WRITE;
 /*!40000 ALTER TABLE `edgydata` DISABLE KEYS */;
 INSERT INTO `edgydata` VALUES
-  (1, 'Lorem ipsum dolor sit amet'),
-  (2, 'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช'),
-  (3, 'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.'),
-  (4, 'Special Characters: ["\\,''!@£$%^&*()]\\\\'),
-  (5, '	'),
+  (1, 'Lorem ipsum dolor sit amet', 10, 'A'),
+  (2, 'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช', 20, 'A'),
+  (3, 'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.', null, 'B'),
+  (4, 'Special Characters: ["\\,''!@£$%^&*()]\\\\', null, 'B'),
+  (5, '	', 20, 'B'),
   (6,'Enter	The
-Ninja'),
+Ninja', 10, 'A'),
   (7,'Liewe
-Maatjies'),
-  (8,'Liewe	Maatjies')
+Maatjies', 20, 'A'),
+  (8,'Liewe	Maatjies', 10, null)
 ;
 
 /*!40000 ALTER TABLE `edgydata` ENABLE KEYS */;

--- a/tests/end_to_end/test-project/tap_mysql_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_sf.yml.template
@@ -36,5 +36,11 @@ schemas:
     target_schema: "mysql_grp24"
 
     tables:
-      - table_name: "table_with_binary"
+      - table_name: "table_with_binary" # This table has binary and varbinary columns
         replication_method: "LOG_BASED"
+
+      - table_name: "edgydata" # This table has SF reserved words as columns
+        replication_method: "LOG_BASED"
+        transformations:
+          - column: "case"
+            type: "HASH"

--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -129,7 +129,7 @@ class TestE2E:
             self.assert_command_success(return_code, stdout, stderr, log_file)
             self.assert_state_file_valid(target, tap, log_file)
 
-    def assert_columns_are_accurate_for_table(self, table_name: str, columns: List[str]):
+    def assert_columns_are_in_table(self, table_name: str, columns: List[str]):
         """
         fetches the given table's columns from pipelinewise.columns and tests if every given column
         is in the result
@@ -225,7 +225,7 @@ class TestE2E:
 
         # Run tap second time - only singer should be triggered
         self.assert_run_tap_success(tap, target, ['singer'])
-        self.assert_columns_are_accurate_for_table('edgydata', ['C_VARCHAR', 'CASE', 'GROUP', 'ORDER' ])
+        self.assert_columns_are_in_table('edgydata', ['C_VARCHAR', 'CASE', 'GROUP', 'ORDER'])
 
     @pytest.mark.dependency(depends=['import_config'])
     def test_replicate_pg_to_sf(self):


### PR DESCRIPTION
## Description

Sanitize columns during FstSync Mysql to SF.

#### Example:
Table in MYSQL:
```
CREATE TABLE `edgydata` (
  `order` int(11) PRIMARY KEY AUTO_INCREMENT,
  `c_varchar` varchar(128),
  `group` int,
  `case` varchar(1)
) ENGINE=MyISAM AUTO_INCREMENT=1001 DEFAULT CHARSET=utf8;

INSERT INTO `edgydata` VALUES
  (1, 'Lorem ipsum dolor sit amet', 10, 'A'),
  (2, 'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช', 20, 'A'),
  (3, 'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.', null, 'B'),
  (4, 'Special Characters: ["\\,''!@£$%^&*()]\\\\', null, 'B'),
  (5, '	', 20, 'B'),
  (6,'Enter	The
Ninja', 10, 'A'),
  (7,'Liewe
Maatjies', 20, 'A'),
  (8,'Liewe	Maatjies', 10, null
```

with a config like this:
```
      - table_name: "edgydata" # This table has SF reserved words as columns
        replication_method: "LOG_BASED"
        transformations:
          - column: "case"
            type: "HASH"
```
The table in SF looks like this:
![image](https://user-images.githubusercontent.com/54845154/75438071-ff681d80-595f-11ea-92ac-6783e7a27624.png)


`ORDER`, `GROUP` and `CASE` are all reserved words in SF.

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
