### PR TITLE
[AP-549] Support reserved words as table names

### DIFF
--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -521,7 +521,7 @@ class PipelineWise:
                 tap_stream_id = stream.get('tap_stream_id')
                 tap_stream_sel = False
                 for sel in selection:
-                    if 'tap_stream_id' in sel and tap_stream_id == sel['tap_stream_id']:
+                    if 'tap_stream_id' in sel and tap_stream_id.lower() == sel['tap_stream_id'].lower():
                         tap_stream_sel = sel
 
                 # Find table specific metadata entries in the old and new streams

--- a/singer-connectors/target-snowflake/requirements.txt
+++ b/singer-connectors/target-snowflake/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-snowflake==1.5.0
+-e git+https://github.com/transferwise/pipelinewise-target-snowflake.git@AP-549#egg=pipelinewise-target-snowflake

--- a/singer-connectors/target-snowflake/requirements.txt
+++ b/singer-connectors/target-snowflake/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/transferwise/pipelinewise-target-snowflake.git@master#egg=pipelinewise-target-snowflake
+pipelinewise-target-snowflake==1.6.0

--- a/singer-connectors/target-snowflake/requirements.txt
+++ b/singer-connectors/target-snowflake/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/transferwise/pipelinewise-target-snowflake.git@AP-549#egg=pipelinewise-target-snowflake
+-e git+https://github.com/transferwise/pipelinewise-target-snowflake.git@master#egg=pipelinewise-target-snowflake

--- a/tests/db/tap_postgres_data.sql
+++ b/tests/db/tap_postgres_data.sql
@@ -5489,3 +5489,16 @@ insert into public.table_with_reserved_words("in", "from", "order") values
 ('08:10:13', '21:00:00+0000', '3'),
 ('18:10:00', '21:00:40+0010', '1'),
 ('00:00:00', '13:00:00', null);
+
+
+DROP TABLE IF EXISTS public."ORDER" CASCADE;
+
+CREATE TABLE "ORDER"
+(
+    id serial primary key,
+    cvarchar varchar,
+    created_at timestamp default current_timestamp
+);
+
+
+insert into "ORDER" (cvarchar) values ('A'), ('B'), ('C'), ('D'), ('E'), ('F'), ('G');

--- a/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
@@ -46,6 +46,13 @@ schemas:
       - table_name: "countrylanguage"
         replication_method: "FULL_TABLE"
 
+      - table_name: "order"
+        replication_method: "INCREMENTAL"
+        replication_key: "created_at"
+        transformations:
+          - column: 'cvarchar'
+            type: 'MASK-HIDDEN'
+
       - table_name: "table_with_reserved_words"
         replication_method: "INCREMENTAL"
         replication_key: "increment"


### PR DESCRIPTION
## Description

Supporting reserved words as table names when syncing from PG to SF, this includes PG reserved words used as table names in PG DB and SF reserved words used as table names.

### Example

Source table:
```
DROP TABLE IF EXISTS "ORDER" CASCADE;

CREATE TABLE "ORDER"
(
    id serial primary key,
    cvarchar varchar,
    created_at timestamp default current_timestamp
);

insert into "ORDER" (cvarchar) values ('A'), ('B'), ('C'), ('D'), ('E'), ('F'), ('G');

```

Replication config

```
      - table_name: "order"
        replication_method: "INCREMENTAL"
        replication_key: "created_at"
        transformations:
          - column: 'cvarchar'
            type: 'MASK-HIDDEN'
```

Table in SF
![image](https://user-images.githubusercontent.com/54845154/75989068-41163c80-5efb-11ea-9a8f-86348210f5b7.png)

## Checklist

- [X] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
