### PR TITLE
[AP-590] Fix install script to search full names packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,9 +18,9 @@ check_license() {
 
     echo
     echo "Checking license..."
-    PKG_NAME=`pip-licenses | grep $1 | awk '{print $1}'`
-    PKG_VERSION=`pip-licenses | grep $1 | awk '{print $2}'`
-    PKG_LICENSE=`pip-licenses --from mixed | grep $1 | awk '{for (i=1; i<=NF-2; i++) $i = $(i+2); NF-=2; print}'`
+    PKG_NAME=`pip-licenses | grep "$1[[:space:]]" | awk '{print $1}'`
+    PKG_VERSION=`pip-licenses | grep "$1[[:space:]]" | awk '{print $2}'`
+    PKG_LICENSE=`pip-licenses --from mixed | grep "$1[[:space:]]" | awk '{for (i=1; i<=NF-2; i++) $i = $(i+2); NF-=2; print}'`
 
     # Any License Agreement that is not Apache Software License (2.0) has to be accepted
     MAIN_LICENSE="Apache Software License"
@@ -105,7 +105,7 @@ print_installed_connectors() {
 
     for i in `ls $VENV_DIR`; do
         source $VENV_DIR/$i/bin/activate
-        VERSION=`python3 -m pip list | grep $i | awk '{print $2}'`
+        VERSION=`python3 -m pip list | grep "$i[[:space:]]" | awk '{print $2}'`
         printf "%-20s %s\n" $i "$VERSION"
     done
 


### PR DESCRIPTION
## Description

The install scripts showing components incorrectly, and there is a line in the list with no package name `1.1.0`:

```
--------------------------------------------------------------------------
Installed components:
--------------------------------------------------------------------------

Component            Version
-------------------- -------
pipelinewise         0.13.3
1.1.0
tap-adwords          1.11.2
tap-jira             2.0.0
tap-kafka            2.1.0
tap-mysql            1.2.0
tap-oracle           1.0.0
tap-postgres         1.4.1
tap-s3-csv           1.1.0
tap-salesforce       1.1.0
tap-snowflake        1.1.0
tap-zendesk          1.1.0
target-postgres      1.1.0
target-redshift      1.3.0
target-s3-csv        1.2.0
target-snowflake     1.5.0
transform-field      1.2.0
```

This is because `pip-licenses | grep 'pipelinewise'`, which is embedded in the install scripts returns multiple lines:
```
 pipelinewise                0.13.3      UNKNOWN                                                      
 pipelinewise-singer-python  1.1.0       UNKNOWN 
```

This PR is to search full-text package name and to fix this issue

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
