### PR TITLE
tap-postgresql bump version to 1.5.0

### DIFF
--- a/dev-project/docker-compose.yml
+++ b/dev-project/docker-compose.yml
@@ -48,7 +48,7 @@ services:
   # PostgreSQL service container used as test source database
   # Using Debezium image with wal2json plugin for logical decoding
   db_postgres_source:
-    image: debezium/postgres:11-alpine
+    image: debezium/postgres:12-alpine
     container_name: pipelinewise_dev_postgres_source
     # Making some logical decoding adjustments
     command: -c "wal_level=logical" -c "max_replication_slots=5" -c "max_wal_senders=5"

--- a/singer-connectors/tap-postgres/requirements.txt
+++ b/singer-connectors/tap-postgres/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-postgres==1.4.1
+pipelinewise-tap-postgres==1.5.0


### PR DESCRIPTION
## Description

Bump version to use tap-postgresql 1.5.0

## Checklist

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
