### PR TITLE
[AP-591] Not creating PIPELINEWISE.COLUMNS cache table

### DIFF
--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -258,23 +258,3 @@ class FastSyncTargetSnowflake:
                                                                   target_table.upper()))
 
         self.query('DROP TABLE IF EXISTS {}."{}"'.format(schema, temp_table.upper()))
-
-    # pylint: disable=invalid-name
-    def clear_information_schema_columns_cache(self, tables):
-        pipelinewise_schema = utils.tablename_to_dict(self.connection_config['stage'])['schema_name']
-        schemas_to_clear_in_cache = utils.get_target_schemas(self.connection_config, tables)
-
-        # Create an empty cache table if not exists
-        self.query("""
-            CREATE TABLE IF NOT EXISTS {}.columns (table_schema VARCHAR, table_name VARCHAR, column_name VARCHAR, data_type VARCHAR)
-        """.format(pipelinewise_schema))
-
-        #  Clear table columns from information_schema cache
-        for schema_name in schemas_to_clear_in_cache:
-            LOGGER.info('Clearing information_schema cache for schema: %s', schema_name)
-
-            # Delete existing data about the current schema
-            self.query("""
-                DELETE FROM {}.columns
-                WHERE LOWER(table_schema) = '{}'
-            """.format(pipelinewise_schema, schema_name.lower()))

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -153,10 +153,6 @@ def main_impl():
     with multiprocessing.Pool(cpu_cores) as proc:
         table_sync_excs = list(filter(None, proc.map(sync_table, args.tables)))
 
-    # Clear information_schema columns cache
-    snowflake = FastSyncTargetSnowflake(args.target, args.transform)
-    snowflake.clear_information_schema_columns_cache(args.tables)
-
     # Log summary
     end_time = datetime.now()
     LOGGER.info("""

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -158,10 +158,6 @@ def main_impl():
     with multiprocessing.Pool(cpu_cores) as proc:
         table_sync_excs = list(filter(None, proc.map(sync_table, args.tables)))
 
-    # Clear information_schema columns cache
-    snowflake = FastSyncTargetSnowflake(args.target, args.transform)
-    snowflake.clear_information_schema_columns_cache(args.tables)
-
     # Log summary
     end_time = datetime.now()
     LOGGER.info("""

--- a/pipelinewise/fastsync/s3_csv_to_snowflake.py
+++ b/pipelinewise/fastsync/s3_csv_to_snowflake.py
@@ -139,10 +139,6 @@ def main_impl():
         table_sync_excs = list(
             filter(lambda x: not isinstance(x, bool), proc.map(partial(sync_table, args=args), args.tables)))
 
-    # Clear information_schema columns cache
-    snowflake = FastSyncTargetSnowflake(args.target, args.transform)
-    snowflake.clear_information_schema_columns_cache(args.tables)
-
     # Log summary
     end_time = datetime.now()
     LOGGER.info("""

--- a/singer-connectors/target-snowflake/requirements.txt
+++ b/singer-connectors/target-snowflake/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-snowflake==1.6.0
+pipelinewise-target-snowflake==1.6.1

--- a/tests/units/fastsync/test_s3_csv_to_snowflake.py
+++ b/tests/units/fastsync/test_s3_csv_to_snowflake.py
@@ -114,7 +114,6 @@ class S3CsvToSnowflake(unittest.TestCase):
 
                         utils_mock.parse_args.return_value = ns
                         utils_mock.get_cpu_cores.return_value = 10
-                        fastsync_target_sf_mock.return_value.clear_information_schema_columns_cache.return_value = None
 
                         mock_enter = Mock()
                         mock_enter.return_value.map.return_value = [True, True, True, True]
@@ -133,7 +132,6 @@ class S3CsvToSnowflake(unittest.TestCase):
                         utils_mock.parse_args.assert_called_once()
                         utils_mock.get_cpu_cores.assert_called_once()
                         mock_enter.return_value.map.assert_called_once()
-                        fastsync_target_sf_mock.return_value.clear_information_schema_columns_cache.assert_called_once()
 
     # pylint: disable=unused-variable
     def test_main_impl_with_one_table_fails_to_sync_should_exit_with_error(self):
@@ -150,7 +148,6 @@ class S3CsvToSnowflake(unittest.TestCase):
 
                         utils_mock.parse_args.return_value = ns
                         utils_mock.get_cpu_cores.return_value = 10
-                        fastsync_target_sf_mock.return_value.clear_information_schema_columns_cache.return_value = None
 
                         mock_enter = Mock()
                         mock_enter.return_value.map.return_value = [True, True, 'Critical: random error', True]
@@ -170,8 +167,6 @@ class S3CsvToSnowflake(unittest.TestCase):
                             utils_mock.parse_args.assert_called_once()
                             utils_mock.get_cpu_cores.assert_called_once()
                             mock_enter.return_value.map.assert_called_once()
-                            fastsync_target_sf_mock.return_value.clear_information_schema_columns_cache\
-                                .assert_called_once()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

This PR is getting rid of `PIPELINEWISE.COLUMNS` table and its caching mechanism in fastsync components to snowflake. This is the corresponding PR of https://github.com/transferwise/pipelinewise-target-snowflake/pull/67 

Build and CircleCI tests supposed to fail until pipelinewise-target-snowflake_1.6.1 not released to PyPI

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
