### PR TITLE
Support for iam roles for snowflake fastsync

### DIFF
--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -25,8 +25,6 @@ REQUIRED_CONFIG_KEYS = {
         'user',
         'password',
         'warehouse',
-        'aws_access_key_id',
-        'aws_secret_access_key',
         's3_bucket',
         'stage',
         'file_format'

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -25,8 +25,6 @@ REQUIRED_CONFIG_KEYS = {
         'user',
         'password',
         'warehouse',
-        'aws_access_key_id',
-        'aws_secret_access_key',
         's3_bucket',
         'stage',
         'file_format'

--- a/pipelinewise/fastsync/s3_csv_to_snowflake.py
+++ b/pipelinewise/fastsync/s3_csv_to_snowflake.py
@@ -29,8 +29,6 @@ REQUIRED_CONFIG_KEYS = {
         'user',
         'password',
         'warehouse',
-        'aws_access_key_id',
-        'aws_secret_access_key',
         's3_bucket',
         'stage',
         'file_format'


### PR DESCRIPTION
## Description

Support for AWS iam roles for snowflake fastsync.

Creating the boto3 client object without acces/secret keys will enable boto3 to look for all possible credentials . Creating the storage integration object in snowflake with necessary permission for the bucket will enable load data to snowflake to work without aws credentials

## Checklist

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [ ] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usag e instructions
