### PR TITLE
[AP-608] Log inserts, updates and csv size_bytes in fastsync to snowf…

### DIFF
--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -133,12 +133,12 @@ class FastSyncTargetSnowflake:
 
         self.query(sql)
 
+    # pylint: disable=too-many-locals
     def copy_to_table(self, s3_key, target_schema, table_name, size_bytes, is_temporary, skip_csv_header=False):
         LOGGER.info('Loading %s into Snowflake...', s3_key)
         table_dict = utils.tablename_to_dict(table_name)
         target_table = table_dict.get('table_name') if not is_temporary else table_dict.get('temp_table_name')
         inserts = 0
-        updates = 0
 
         aws_access_key_id = self.connection_config['aws_access_key_id']
         aws_secret_access_key = self.connection_config['aws_secret_access_key']
@@ -171,14 +171,15 @@ class FastSyncTargetSnowflake:
                 int(skip_csv_header),
             )
 
+        # Get number of inserted records - COPY does insert only
         results = self.query(sql)
         if len(results) > 0:
             inserts = results[0].get('rows_loaded', 0)
 
-        LOGGER.info('Loading into {}."{}": {}'.format(
+        LOGGER.info('Loading into %s."%s": %s',
                     target_schema,
                     target_table.upper(),
-                    json.dumps({'inserts': inserts, 'updates': updates, 'size_bytes': size_bytes})))
+                    json.dumps({'inserts': inserts, 'updates': 0, 'size_bytes': size_bytes}))
 
         LOGGER.info('Deleting %s from S3...', s3_key)
         self.s3.delete_object(Bucket=bucket, Key=s3_key)

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import json
 import time
 from typing import List
 
@@ -132,10 +133,12 @@ class FastSyncTargetSnowflake:
 
         self.query(sql)
 
-    def copy_to_table(self, s3_key, target_schema, table_name, is_temporary, skip_csv_header=False):
+    def copy_to_table(self, s3_key, target_schema, table_name, size_bytes, is_temporary, skip_csv_header=False):
         LOGGER.info('Loading %s into Snowflake...', s3_key)
         table_dict = utils.tablename_to_dict(table_name)
         target_table = table_dict.get('table_name') if not is_temporary else table_dict.get('temp_table_name')
+        inserts = 0
+        updates = 0
 
         aws_access_key_id = self.connection_config['aws_access_key_id']
         aws_secret_access_key = self.connection_config['aws_secret_access_key']
@@ -168,7 +171,14 @@ class FastSyncTargetSnowflake:
                 int(skip_csv_header),
             )
 
-        self.query(sql)
+        results = self.query(sql)
+        if len(results) > 0:
+            inserts = results[0].get('rows_loaded', 0)
+
+        LOGGER.info('Loading into {}."{}": {}'.format(
+                    target_schema,
+                    target_table.upper(),
+                    json.dumps({'inserts': inserts, 'updates': updates, 'size_bytes': size_bytes})))
 
         LOGGER.info('Deleting %s from S3...', s3_key)
         self.s3.delete_object(Bucket=bucket, Key=s3_key)

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -89,6 +89,7 @@ def sync_table(table):
 
         # Exporting table data, get table definitions and close connection to avoid timeouts
         mysql.copy_table(table, filepath)
+        size_bytes = os.path.getsize(filepath)
         snowflake_types = mysql.map_column_types_to_target(table)
         snowflake_columns = snowflake_types.get('columns', [])
         primary_key = snowflake_types.get('primary_key')
@@ -103,7 +104,7 @@ def sync_table(table):
         snowflake.create_table(target_schema, table, snowflake_columns, primary_key, is_temporary=True)
 
         # Load into Snowflake table
-        snowflake.copy_to_table(s3_key, target_schema, table, is_temporary=True)
+        snowflake.copy_to_table(s3_key, target_schema, table, size_bytes, is_temporary=True)
 
         # Obfuscate columns
         snowflake.obfuscate_columns(target_schema, table)

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -73,7 +73,7 @@ def tap_type_to_target_type(pg_type):
     }.get(pg_type, 'VARCHAR')
 
 
-# pylint: disable=inconsistent-return-statements
+# pylint: disable=inconsistent-return-statements,too-many-locals
 def sync_table(table):
     """Sync one table"""
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -94,6 +94,7 @@ def sync_table(table):
 
         # Exporting table data, get table definitions and close connection to avoid timeouts
         postgres.copy_table(table, filepath)
+        size_bytes = os.path.getsize(filepath)
         snowflake_types = postgres.map_column_types_to_target(table)
         snowflake_columns = snowflake_types.get('columns', [])
         primary_key = snowflake_types.get('primary_key')
@@ -108,7 +109,7 @@ def sync_table(table):
         snowflake.create_table(target_schema, table, snowflake_columns, primary_key, is_temporary=True)
 
         # Load into Snowflake table
-        snowflake.copy_to_table(s3_key, target_schema, table, is_temporary=True)
+        snowflake.copy_to_table(s3_key, target_schema, table, size_bytes, is_temporary=True)
 
         # Obfuscate columns
         snowflake.obfuscate_columns(target_schema, table)

--- a/pipelinewise/fastsync/s3_csv_to_snowflake.py
+++ b/pipelinewise/fastsync/s3_csv_to_snowflake.py
@@ -65,6 +65,7 @@ def sync_table(table_name: str, args: Namespace) -> Union[bool, str]:
         target_schema = utils.get_target_schema(args.target, table_name)
 
         s3_csv.copy_table(table_name, filepath)
+        size_bytes = os.path.getsize(filepath)
 
         snowflake_types = s3_csv.map_column_types_to_target(filepath, table_name)
         snowflake_columns = snowflake_types.get('columns', [])
@@ -84,7 +85,7 @@ def sync_table(table_name: str, args: Namespace) -> Union[bool, str]:
                                sort_columns=True)
 
         # Load into Snowflake table
-        snowflake.copy_to_table(s3_key, target_schema, table_name, is_temporary=True, skip_csv_header=True)
+        snowflake.copy_to_table(s3_key, target_schema, table_name, size_bytes, is_temporary=True, skip_csv_header=True)
 
         # Obfuscate columns
         snowflake.obfuscate_columns(target_schema, table_name)


### PR DESCRIPTION
## Description

For better logging experience adding the csv file size to the logs and logging load stats in a more consumable JSON format:

```
time=2020-03-20 13:22:22 name=target_snowflake level=INFO message=Loading into test_pk."TEST_TABLE_THREE": {"inserts": 3, "updates": 0, "size_bytes": 57}
time=2020-03-20 13:22:22 name=target_snowflake level=INFO message=Loading into test_pk."TEST_TABLE_TWO": {"inserts": 2, "updates": 0, "size_bytes": 60}
time=2020-03-20 13:22:24 name=target_snowflake level=INFO message=Loading into test_pk."TEST_TABLE_ONE": {"inserts": 1, "updates": 0, "size_bytes": 8}
```

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
