### PR TITLE
[AP-XXXX] Increase default export batch size

### DIFF
--- a/pipelinewise/fastsync/commons/tap_mysql.py
+++ b/pipelinewise/fastsync/commons/tap_mysql.py
@@ -21,7 +21,7 @@ class FastSyncTapMySql:
     def __init__(self, connection_config, tap_type_to_target_type):
         self.connection_config = connection_config
         self.connection_config['charset'] = connection_config.get('charset', 'utf8')
-        self.connection_config['export_batch_rows'] = connection_config.get('export_batch_rows', 20000)
+        self.connection_config['export_batch_rows'] = connection_config.get('export_batch_rows', 50000)
         self.tap_type_to_target_type = tap_type_to_target_type
         self.conn = None
         self.conn_unbuffered = None


### PR DESCRIPTION
## Description

Increasing default `export_batch_rows` size from 20k to 50k in fastsync from mysql.
  
## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [ ] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
