### PR TITLE
[AP-529] Support .yaml extension and prevent duplicate IDs

### DIFF
--- a/pipelinewise/cli/config.py
+++ b/pipelinewise/cli/config.py
@@ -53,6 +53,12 @@ class Config:
             # Add generated extra keys that not available in the YAML
             target_id = target_data['id']
 
+            # Check if a target with same ID already exists
+            # exit with error, otherwise, we would override the previous one and that would go unnoticed.
+            if target_id in targets:
+                config.logger.error('Duplicate target found "%s"', target_id)
+                sys.exit(1)
+
             target_data['files'] = config.get_connector_files(config.get_target_dir(target_id))
             target_data['taps'] = []
 
@@ -66,6 +72,13 @@ class Config:
             utils.validate(instance=tap_data, schema=tap_schema)
 
             tap_id = tap_data['id']
+
+            # Check if a tap with same ID already exists
+            # exit with error, otherwise, we would override the previous one and that would go unnoticed.
+            if tap_id in taps:
+                config.logger.error('Duplicate tap found "%s"', tap_id)
+                sys.exit(1)
+
             target_id = tap_data['target']
             if target_id not in targets:
                 config.logger.error("Can't find the target with the ID \"%s\" but it's referenced in %s", target_id,

--- a/pipelinewise/cli/utils.py
+++ b/pipelinewise/cli/utils.py
@@ -158,10 +158,11 @@ def get_tap_target_names(yaml_dir):
         yaml_dir (str): Path to the directory, which contains taps and targets files with .yml extension.
 
     Returns:
-        (tap_yamls, target_yamls): tap_yamls is a list of names inside yaml_dir with "tap_*.yml" pattern.
-                                   target_yamls is a list of names inside yaml_dir with "target_*.yml" pattern.
+        (tap_yamls, target_yamls): tap_yamls is a list of names inside yaml_dir with "tap_*.y(a)ml" pattern.
+                                   target_yamls is a list of names inside yaml_dir with "target_*.y(a)ml" pattern.
     """
-    yamls = [f for f in os.listdir(yaml_dir) if os.path.isfile(os.path.join(yaml_dir, f)) and f.endswith('.yml')]
+    yamls = [f for f in os.listdir(yaml_dir) if os.path.isfile(os.path.join(yaml_dir, f))
+             and (f.endswith('.yml') or f.endswith('.yaml'))]
     target_yamls = set(filter(lambda y: y.startswith('target_'), yamls))
     tap_yamls = set(filter(lambda y: y.startswith('tap_'), yamls))
 

--- a/tests/units/cli/resources/test_invalid_yaml_config_with_duplicate_targets/tap_test_unknown_target.yml
+++ b/tests/units/cli/resources/test_invalid_yaml_config_with_duplicate_targets/tap_test_unknown_target.yml
@@ -1,0 +1,65 @@
+---
+
+# ------------------------------------------------------------------------------
+# General Properties
+# ------------------------------------------------------------------------------
+id: "mysql_sample"                     # Unique identifier of the tap
+name: "Sample MySQL Database"          # Name of the tap
+type: "tap-mysql"                      # !! THIS SHOULD NOT CHANGE !!
+owner: "somebody@foo.com"              # Data owner to contact
+
+
+# ------------------------------------------------------------------------------
+# Source (Tap) - MySQL/ MariaDB connection details
+# ------------------------------------------------------------------------------
+db_conn:
+  host: "<HOST>"                       # MySQL/ MariaDB host
+  port: 3306                           # MySQL/ MariaDB port
+  user: "<USER>"                       # MySQL/ MariaDB user
+  password: "<PASSWORD>"               # Plain string or vault encrypted
+  dbname: "<DB_NAME>"                  # MySQL/ MariaDB database name
+  #filter_dbs: "schema1,schema2"       # Optional: Scan only the required schemas
+                                       #           to improve the performance of
+                                       #           data extraction
+
+
+# ------------------------------------------------------------------------------
+# Destination (Target) - Target properties
+# Connection details should be in the relevant target YAML file
+# ------------------------------------------------------------------------------
+target: "my_target"               # ID of the target connector where the data will be loaded
+batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+
+
+# ------------------------------------------------------------------------------
+# Source to target Schema mapping
+# ------------------------------------------------------------------------------
+schemas:
+
+  - source_schema: "my_db"             # Source schema (aka. database) in MySQL/ MariaDB with tables
+    target_schema: "repl_my_db"        # Target schema in the destination Data Warehouse
+    target_schema_select_permissions:  # Optional: Grant SELECT on schema and tables that created
+      - grp_stats
+
+    # List of tables to replicate from Postgres to destination Data Warehouse
+    #
+    # Please check the Replication Strategies section in the documentation to understand the differences.
+    # For LOG_BASED replication method you might need to adjust the source mysql/ mariadb configuration.
+    tables:
+      - table_name: "table_one"
+        replication_method: "INCREMENTAL"   # One of INCREMENTAL, LOG_BASED and FULL_TABLE
+        replication_key: "last_update"      # Important: Incremental load always needs replication key
+
+        # OPTIONAL: Load time transformations
+        #transformations:                    
+        #  - column: "last_name"            # Column to transform
+        #    type: "SET-NULL"               # Transformation type
+
+      # You can add as many tables as you need...
+      - table_name: "table_two"
+        replication_method: "LOG_BASED"     # Important! Log based must be enabled in MySQL
+
+  # You can add as many schemas as you need...
+  # Uncommend this if you want replicate tables from multiple schemas
+  #- source_schema: "another_schema_in_mysql" 
+  #  target_schema: "another

--- a/tests/units/cli/resources/test_invalid_yaml_config_with_duplicate_targets/target_test.yaml
+++ b/tests/units/cli/resources/test_invalid_yaml_config_with_duplicate_targets/target_test.yaml
@@ -1,0 +1,18 @@
+---
+# This is a minimalistic target configuration that used only for testing purposes
+id: "my_target"
+name: "Test Target Connector"
+type: "target-snowflake"
+db_conn:
+  account: "account"
+  dbname: "foo_db"
+  user: "user"
+  password: "secret"
+  warehouse: "MY_WAREHOUSE"
+  s3_bucket: "s3_bucket"
+  s3_key_prefix: "s3_prefix/"
+  aws_access_key_id: "access_key_id"
+  stage: "foo_stage"
+  file_format: "foo_file_format"
+  aws_secret_access_key: "secret_access_key"
+  client_side_encryption_master_key: "master_key"

--- a/tests/units/cli/resources/test_invalid_yaml_config_with_duplicate_targets/target_test.yml
+++ b/tests/units/cli/resources/test_invalid_yaml_config_with_duplicate_targets/target_test.yml
@@ -1,0 +1,18 @@
+---
+# This is a minimalistic target configuration that used only for testing purposes
+id: "my_target"
+name: "Test Target Connector"
+type: "target-snowflake"
+db_conn:
+  account: "account"
+  dbname: "foo_db"
+  user: "user"
+  password: "secret"
+  warehouse: "MY_WAREHOUSE"
+  s3_bucket: "s3_bucket"
+  s3_key_prefix: "s3_prefix/"
+  aws_access_key_id: "access_key_id"
+  stage: "foo_stage"
+  file_format: "foo_file_format"
+  aws_secret_access_key: "secret_access_key"
+  client_side_encryption_master_key: "master_key"

--- a/tests/units/cli/resources/test_validate_command/test_yaml_config_two_targets/tap_test.yml
+++ b/tests/units/cli/resources/test_validate_command/test_yaml_config_two_targets/tap_test.yml
@@ -1,0 +1,65 @@
+---
+
+# ------------------------------------------------------------------------------
+# General Properties
+# ------------------------------------------------------------------------------
+id: "mysql_sample"                     # Unique identifier of the tap
+name: "Sample MySQL Database"          # Name of the tap
+type: "tap-mysql"                      # !! THIS SHOULD NOT CHANGE !!
+owner: "somebody@foo.com"              # Data owner to contact
+
+
+# ------------------------------------------------------------------------------
+# Source (Tap) - MySQL/ MariaDB connection details
+# ------------------------------------------------------------------------------
+db_conn:
+  host: "<HOST>"                       # MySQL/ MariaDB host
+  port: 3306                           # MySQL/ MariaDB port
+  user: "<USER>"                       # MySQL/ MariaDB user
+  password: "<PASSWORD>"               # Plain string or vault encrypted
+  dbname: "<DB_NAME>"                  # MySQL/ MariaDB database name
+  #filter_dbs: "schema1,schema2"       # Optional: Scan only the required schemas
+                                       #           to improve the performance of
+                                       #           data extraction
+
+
+# ------------------------------------------------------------------------------
+# Destination (Target) - Target properties
+# Connection details should be in the relevant target YAML file
+# ------------------------------------------------------------------------------
+target: "test_snowflake_target"        # ID of the target connector where the data will be loaded
+batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+
+
+# ------------------------------------------------------------------------------
+# Source to target Schema mapping
+# ------------------------------------------------------------------------------
+schemas:
+
+  - source_schema: "my_db"             # Source schema (aka. database) in MySQL/ MariaDB with tables
+    target_schema: "repl_my_db"        # Target schema in the destination Data Warehouse
+    target_schema_select_permissions:  # Optional: Grant SELECT on schema and tables that created
+      - grp_stats
+
+    # List of tables to replicate from Postgres to destination Data Warehouse
+    #
+    # Please check the Replication Strategies section in the documentation to understand the differences.
+    # For LOG_BASED replication method you might need to adjust the source mysql/ mariadb configuration.
+    tables:
+      - table_name: "table_one"
+        replication_method: "INCREMENTAL"   # One of INCREMENTAL, LOG_BASED and FULL_TABLE
+        replication_key: "last_update"      # Important: Incremental load always needs replication key
+
+        # OPTIONAL: Load time transformations
+        #transformations:                    
+        #  - column: "last_name"            # Column to transform
+        #    type: "SET-NULL"               # Transformation type
+
+      # You can add as many tables as you need...
+      - table_name: "table_two"
+        replication_method: "LOG_BASED"     # Important! Log based must be enabled in MySQL
+
+  # You can add as many schemas as you need...
+  # Uncommend this if you want replicate tables from multiple schemas
+  #- source_schema: "another_schema_in_mysql" 
+  #  target_schema: "another

--- a/tests/units/cli/resources/test_validate_command/test_yaml_config_two_targets/target_test.yaml
+++ b/tests/units/cli/resources/test_validate_command/test_yaml_config_two_targets/target_test.yaml
@@ -1,0 +1,18 @@
+---
+# This is a minimalistic target configuration that used only for testing purposes
+id: "test_snowflake_target"
+name: "Test Target Connector #2"
+type: "target-snowflake"
+db_conn:
+  account: "account"
+  dbname: "foo_db"
+  user: "user"
+  password: "secret"
+  warehouse: "MY_WAREHOUSE"
+  s3_bucket: "s3_bucket"
+  s3_key_prefix: "s3_prefix/"
+  aws_access_key_id: "access_key_id"
+  stage: "foo_stage"
+  file_format: "foo_file_format"
+  aws_secret_access_key: "secret_access_key"
+  client_side_encryption_master_key: "master_key"

--- a/tests/units/cli/resources/test_validate_command/test_yaml_config_two_targets/target_test.yml
+++ b/tests/units/cli/resources/test_validate_command/test_yaml_config_two_targets/target_test.yml
@@ -1,0 +1,18 @@
+---
+# This is a minimalistic target configuration that used only for testing purposes
+id: "test_snowflake_target"
+name: "Test Target Connector #1"
+type: "target-snowflake"
+db_conn:
+  account: "account"
+  dbname: "foo_db"
+  user: "user"
+  password: "secret"
+  warehouse: "MY_WAREHOUSE"
+  s3_bucket: "s3_bucket"
+  s3_key_prefix: "s3_prefix/"
+  aws_access_key_id: "access_key_id"
+  stage: "foo_stage"
+  file_format: "foo_file_format"
+  aws_secret_access_key: "secret_access_key"
+  client_side_encryption_master_key: "master_key"

--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -416,30 +416,47 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
         # Delete test log file
         os.remove('{}.terminated'.format(pipelinewise.tap_run_log_file))
 
-    def test_validate_command(self):
-        """Test validate command"""
-        test_validate_command_dir = f'{os.path.dirname(__file__)}/resources/test_validate_command'
+    def test_validate_command_1(self):
+        """Test validate command should fail because of missing replication key for incremental"""
+        test_validate_command_dir = \
+            f'{os.path.dirname(__file__)}/resources/test_validate_command/missing_replication_key_incremental'
 
-        test_cases = [{
-            'dir': 'missing_replication_key_incremental',
-            'exception': True
-        }, {
-            'dir': 'missing_replication_key',
-            'exception': False
-        }, {
-            'dir': 'invalid_target',
-            'exception': True
-        }]
+        args = CliArgs(dir=test_validate_command_dir)
+        pipelinewise = PipelineWise(args, CONFIG_DIR, VIRTUALENVS_DIR)
 
-        for test_case in test_cases:
-            args = CliArgs(dir=f'{test_validate_command_dir}/{test_case["dir"]}')
-            pipelinewise = PipelineWise(args, CONFIG_DIR, VIRTUALENVS_DIR)
+        with pytest.raises(SystemExit):
+            pipelinewise.validate()
 
-            if test_case['exception']:
-                with pytest.raises(SystemExit):
-                    pipelinewise.validate()
-            else:
-                pipelinewise.validate()
+    def test_validate_command_2(self):
+        """Test validate command should succeed"""
+        test_validate_command_dir = \
+            f'{os.path.dirname(__file__)}/resources/test_validate_command/missing_replication_key'
+
+        args = CliArgs(dir=test_validate_command_dir)
+        pipelinewise = PipelineWise(args, CONFIG_DIR, VIRTUALENVS_DIR)
+
+        pipelinewise.validate()
+
+    def test_validate_command_3(self):
+        """Test validate command should fail because of invalid target in tap config"""
+        test_validate_command_dir = f'{os.path.dirname(__file__)}/resources/test_validate_command/invalid_target'
+
+        args = CliArgs(dir=test_validate_command_dir)
+        pipelinewise = PipelineWise(args, CONFIG_DIR, VIRTUALENVS_DIR)
+
+        with pytest.raises(SystemExit):
+            pipelinewise.validate()
+
+    def test_validate_command_4(self):
+        """Test validate command should fail because of duplicate targets"""
+        test_validate_command_dir = \
+            f'{os.path.dirname(__file__)}/resources/test_validate_command/test_yaml_config_two_targets'
+
+        args = CliArgs(dir=test_validate_command_dir)
+        pipelinewise = PipelineWise(args, CONFIG_DIR, VIRTUALENVS_DIR)
+
+        with pytest.raises(SystemExit):
+            pipelinewise.validate()
 
     # pylint: disable=protected-access
     def test_post_import_checks(self):

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -322,7 +322,7 @@ class TestUtils:
 
     def test_get_tap_target_names(self):
         """Test get tap and target yamls"""
-        expected_tap_names = {'tap_test.yml', 'tap_2test.yml'}
+        expected_tap_names = {'tap_test.yml', 'tap_2test.yml', 'tap_valid.yaml'}
         expected_target_names = {'target_test.yml'}
         tap_names, target_names = cli.utils.get_tap_target_names(f'{os.path.dirname(__file__)}'
                                                                  f'/resources/test_tap_target_names')

--- a/tests/units/cli/test_config.py
+++ b/tests/units/cli/test_config.py
@@ -130,6 +130,29 @@ class TestConfig:
         assert pytest_wrapped_e.type == SystemExit
         assert pytest_wrapped_e.value.code == 1
 
+
+    def test_from_invalid_yamls_fails(self):
+        """
+        Test creating Config object using invalid YAML configuration
+        directory should fail due to duplicate targets
+        """
+
+        # TODO: Make behaviours consistent.
+        #   In some cases it raise exception in some other cases it does exit
+
+        # Initialising Config object with a not existing directory should raise an exception
+        with pytest.raises(Exception):
+            cli.config.Config.from_yamls(PIPELINEWISE_TEST_HOME, 'not-existing-yaml-config-directory')
+
+        # Initialising config object with a tap that's referencing an unknown target should exit
+        yaml_config_dir = f'{os.path.dirname(__file__)}/resources/test_invalid_yaml_config_with_duplicate_targets'
+        vault_secret = f'{os.path.dirname(__file__)}/resources/vault-secret.txt'
+
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            cli.config.Config.from_yamls(PIPELINEWISE_TEST_HOME, yaml_config_dir, vault_secret)
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == 1
+
     def test_getters(self):
         """Test Config getter functions"""
         config = cli.config.Config(PIPELINEWISE_TEST_HOME)


### PR DESCRIPTION
## Description

- Support tap/target config files with `.yaml` extension when importing config.
- Raise exception when +2 taps have same ID, same for targets when importing and validating taps and targets.

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
