### PR TITLE
add_metadata_columns is not defined in inheritable_config

### DIFF
--- a/pipelinewise/cli/config.py
+++ b/pipelinewise/cli/config.py
@@ -334,7 +334,8 @@ class Config:
             #   3: Otherwise we set flattening level to 0 (disabled)
             'data_flattening_max_level': tap.get('data_flattening_max_level',
                                                  utils.get_tap_property(tap, 'default_data_flattening_max_level') or 0),
-            'validate_records': tap.get('validate_records', False)
+            'validate_records': tap.get('validate_records', False),
+            'add_metadata_columns': tap.get('add_metadata_columns', False)
         })
 
         # Save the generated JSON files

--- a/tests/units/cli/test_config.py
+++ b/tests/units/cli/test_config.py
@@ -270,7 +270,8 @@ class TestConfig:
                 }
             },
             'temp_dir': './pipelinewise-test-config/tmp',
-            'validate_records': False
+            'validate_records': False,
+            'add_metadata_columns': False
         }
 
         # Delete the generated JSON config directory


### PR DESCRIPTION
add_metadata_columns doesn't seem to be defined by default when building the tap inheritable_config.json file. Making it harder to configure it later inside a tap .yml configuration.

This PR add the value inside the tap_inheritable_config dictionary.

## Description

<< Write here the description of your PR. Without description won't be approved! >>

## Checklist

- [ ] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [ ] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
