### PR TITLE
Added double quotes to prevent name clash between table and keywords in Redshift

### DIFF
--- a/pipelinewise/fastsync/commons/target_redshift.py
+++ b/pipelinewise/fastsync/commons/target_redshift.py
@@ -190,4 +190,4 @@ class FastSyncTargetRedshift:
 
         # Swap tables and drop the temp tamp
         self.query('DROP TABLE IF EXISTS {}.{}'.format(schema, target_table))
-        self.query('ALTER TABLE {}.{} RENAME TO {}'.format(schema, temp_table, target_table))
+        self.query('ALTER TABLE {}.{} RENAME TO "{}"'.format(schema, temp_table, target_table))


### PR DESCRIPTION
## Description

I experienced some issues running fast sync on MySQL to Redshift, having a table called user gave some problems due to name clash in Redshift. To fix the problem I added double quotes around the table name to avoid a name clash.

## Checklist

- [ ] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [ ] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
