### PR TITLE
[AP-630] Add local_store_dir automatically to kafka tap configs

### DIFF
--- a/pipelinewise/cli/config.py
+++ b/pipelinewise/cli/config.py
@@ -149,7 +149,7 @@ class Config:
 
             # Save every tap JSON files
             for tap in target['taps']:
-                extra_config_keys = utils.get_tap_extra_config_keys(tap)
+                extra_config_keys = utils.get_tap_extra_config_keys(tap, self.get_temp_dir())
                 self.save_tap_jsons(target, tap, extra_config_keys)
 
     def save_main_config_json(self):

--- a/pipelinewise/cli/tap_properties.py
+++ b/pipelinewise/cli/tap_properties.py
@@ -54,7 +54,7 @@ def generate_tap_s3_csv_to_table_mappings(tap):
 # every supported tap we need to normalise the naming differences to
 # implement common functions that work smoothly with every tap.
 # i.e. stream selection, transformations, etc.
-def get_tap_properties(tap=None):
+def get_tap_properties(tap=None, temp_dir=None):
     """
     Returns the full dictionary of every tap properties
     """
@@ -97,6 +97,7 @@ def get_tap_properties(tap=None):
         },
         'tap-kafka': {
             'tap_config_extras': {
+                'local_store_dir': temp_dir,
                 'encoding': 'utf-8'
             },
             'tap_stream_id_pattern': '{{table_name}}',

--- a/pipelinewise/cli/utils.py
+++ b/pipelinewise/cli/utils.py
@@ -369,11 +369,11 @@ def extract_log_attributes(log_file):
     }
 
 
-def get_tap_property(tap, property_key):
+def get_tap_property(tap, property_key, temp_dir=None):
     """
     Get a tap specific property value
     """
-    tap_props_inst = tap_properties.get_tap_properties(tap)
+    tap_props_inst = tap_properties.get_tap_properties(tap, temp_dir)
     tap_props = tap_props_inst.get(tap.get('type'), tap_props_inst.get('DEFAULT', {}))
 
     return tap_props.get(property_key)
@@ -392,11 +392,11 @@ def get_tap_property_by_tap_type(tap_type, property_key):
     return tap_props.get(property_key)
 
 
-def get_tap_extra_config_keys(tap):
+def get_tap_extra_config_keys(tap, temp_dir=None):
     """
     Get tap extra config property
     """
-    return get_tap_property(tap, 'tap_config_extras')
+    return get_tap_property(tap, 'tap_config_extras', temp_dir)
 
 
 def get_tap_stream_id(tap, database_name, schema_name, table_name):

--- a/tests/units/cli/resources/tap-valid-kafka.yml
+++ b/tests/units/cli/resources/tap-valid-kafka.yml
@@ -1,0 +1,66 @@
+---
+
+# ------------------------------------------------------------------------------
+# General Properties
+# ------------------------------------------------------------------------------
+id: "kafka"                            # Unique identifier of the tap
+name: "Kafka Topic with sample data"   # Name of the tap
+type: "tap-kafka"                      # !! THIS SHOULD NOT CHANGE !!
+owner: "somebody@foo.com"              # Data owner to contact
+
+
+# ------------------------------------------------------------------------------
+# Source (Tap) - Kafka connection details
+# ------------------------------------------------------------------------------
+db_conn:
+  group_id: "myGroupId"
+  bootstrap_servers: "kafka1.foo.com:9092,kafka2.foo.com:9092,kafka3.foo.com:9092"
+  topic: "myKafkaTopic"
+
+
+  # --------------------------------------------------------------------------
+  # Optionally you can define primary key(s) from the kafka JSON messages.
+  # If primary keys defined then extra column(s) will be added to the output
+  # singer stream with the extracted values by JSONPath selectors.
+  # --------------------------------------------------------------------------
+  primary_keys:
+     transfer_id: "$.transferMetadata.transferId"
+
+  # --------------------------------------------------------------------------
+  # Kafka Consumer optional parameters
+  # --------------------------------------------------------------------------
+  #max_runtime_ms: 300000                   # The maximum time for the tap to collect new messages from Kafka topic.
+  #consumer_timeout_ms: 10000               # Number of milliseconds to block during message iteration before raising StopIteration
+  #session_timeout_ms: 30000                # The timeout used to detect failures when using Kafka’s group management facilities.
+  #heartbeat_interval_ms: 10000             # The expected time in milliseconds between heartbeats to the consumer coordinator when using Kafka’s group management facilities.
+  #max_poll_interval_ms: 300000             # The maximum delay between invocations of poll() when using consumer group management.
+  #local_store_dir: ./tap-kafka-local-store # Path to the local store with consumed kafka messages
+
+# ------------------------------------------------------------------------------
+# Destination (Target) - Target properties
+# Connection details should be in the relevant target YAML file
+# ------------------------------------------------------------------------------
+target: "snowflake"                       # ID of the target connector where the data will be loaded
+batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+default_target_schema: "kafka"            # Target schema where the data will be loaded
+default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
+  - grp_stats
+
+
+# ------------------------------------------------------------------------------
+# Source to target Schema mapping
+# ------------------------------------------------------------------------------
+schemas:
+  - source_schema: "kafka"             # This is mandatory, but can be anything in this tap type
+    target_schema: "kafka"             # Target schema in the destination Data Warehouse
+
+    # Kafka topic to replicate into destination Data Warehouse
+    # You can load data only from one kafka topic in one YAML file.
+    # If you want load from multiple kafka topics, create another tap YAML similar to this file
+    tables:
+      - table_name: "my_kafka_topic"   # target table name needs to match to the topic name in snake case format
+
+        # OPTIONAL: Load time transformations
+        #transformations:
+        #  - column: "last_name"            # Column to transform
+        #    type: "SET-NULL"               # Transformation type

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -286,6 +286,13 @@ class TestUtils:
         # Get property value by tap type
         assert cli.utils.get_tap_property_by_tap_type('tap-mysql', 'default_replication_method') == 'LOG_BASED'
 
+        # Kafka encoding and parameterised local_store_dir should be added as default extra config keys
+        tap = cli.utils.load_yaml('{}/resources/tap-valid-kafka.yml'.format(os.path.dirname(__file__)))
+        assert cli.utils.get_tap_extra_config_keys(tap, temp_dir='/my/temp/dir') == {
+            'local_store_dir': '/my/temp/dir',
+            'encoding': 'utf-8'
+        }
+
     def test_run_command(self):
         """Test run command functions
 


### PR DESCRIPTION
## Description

This PR adds `local_store_dir` config parameter automatically to every generated kafka tap configuration (json) and pointing to the pipelinewise temp directory. Defaults: `~/.pipelinewise/tmp`

**Background**
Starting from `pipelinewise-tap-kafka` 3.0.0, the consumed data from Kafka is loading into a local storage first and the path of this local storage is configurable in the tap json by the `local_store_dir` key. Further details about the local storage mechanism at [here](https://github.com/transferwise/pipelinewise-tap-kafka/pull/16).

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
