### PR TITLE
[AP-635] Generate tables config parameter for tap-snowflake

### DIFF
--- a/docs/connectors/taps/snowflake.rst
+++ b/docs/connectors/taps/snowflake.rst
@@ -43,10 +43,6 @@ Example YAML for tap-snowflake:
       user: "<USER>"                       # Snowflake user
       password: "<PASSWORD>"               # Plain string or vault encrypted
       warehouse: "<WAREHOUSE>"             # Snowflake warehouse
-      #filter_dbs: "<DBNAME"               # Optional: Scan only the required dbs
-      #filter_schemas: "SCHEMA_1,SCHEMA_2" # Optional: Scan only the required schemas
-                                          #           to improve the performance of
-                                          #           data extraction
 
 
     # ------------------------------------------------------------------------------
@@ -68,7 +64,6 @@ Example YAML for tap-snowflake:
         # List of tables to replicate from Snowflake to a destination
         #
         # Please check the Replication Strategies section in the documentation to understand the differences.
-        # For LOG_BASED replication method you might need to adjust the source mysql/ mariadb configuration.
         tables:
           - table_name: "TABLE_ONE"
             replication_method: "INCREMENTAL"   # One of INCREMENTAL or FULL_TABLE
@@ -80,7 +75,7 @@ Example YAML for tap-snowflake:
             #    type: "SET-NULL"               # Transformation type
 
           # You can add as many tables as you need...
-          - table_name: "table_two"
+          - table_name: "TABLE_TWO"
             replication_method: "FULL_TABLE"
 
       # You can add as many schemas as you need...

--- a/pipelinewise/cli/tap_properties.py
+++ b/pipelinewise/cli/tap_properties.py
@@ -68,12 +68,11 @@ def generate_tables_list(tap, as_string=False):
         for schema in schemas:
             tables = schema.get('tables', [])
             for table in tables:
-                schema_name = schema.get('source_schema')
-                table_name = table.get('table_name')
-                fqdn = f'{schema_name}.{table_name}'
+                schema_name = schema['source_schema']
+                table_name = table['table_name']
 
-                # Append fully qualified table name
-                tables_list.append(fqdn)
+                # Append table name with schema prefix
+                tables_list.append(f'{schema_name}.{table_name}')
 
     # Return as comma separated string
     if as_string:

--- a/pipelinewise/cli/tap_properties.py
+++ b/pipelinewise/cli/tap_properties.py
@@ -46,6 +46,43 @@ def generate_tap_s3_csv_to_table_mappings(tap):
     return s3_csv_tables
 
 
+def generate_tables_list(tap, as_string=False):
+    """
+    Generating table names from tap YAMLs in <SCHEMA_NAME>.<TABLE_NAME> format.
+    Some tap configurations are required to specify list of tables.
+
+    Example output as list:
+        "tables": [
+            "MY_SCHEMA.MY_TABLE_1",
+            "MY_SCHEMA.MY_TABLE_2"
+        ]
+
+    Example output as comma separated string that compatible with tap-snowflake tap
+        "tables": "MY_SCHEMA.MY_TABLE_1,MY_SCHEMA.MY_TABLE_2"
+    """
+    tables_list = []
+
+    # Using the input tap YAML we can generate the required config.json
+    schemas = tap.get('schemas', []) if tap else None
+    if schemas:
+        for schema in schemas:
+            tables = schema.get('tables', [])
+            for table in tables:
+                schema_name = schema.get('source_schema')
+                table_name = table.get('table_name')
+                fqdn = f'{schema_name}.{table_name}'
+
+                # Append fully qualified table name
+                tables_list.append(fqdn)
+
+    # Return as comma separated string
+    if as_string:
+        return ','.join(tables_list)
+
+    # Return as list
+    return tables_list
+
+
 # Taps are implemented by different persons and teams without
 # common naming convention and structures in the tap specific
 # properties.json.
@@ -148,13 +185,8 @@ def get_tap_properties(tap=None, temp_dir=None):
         },
         'tap-snowflake': {
             'tap_config_extras': {
-                # PipelineWise doesn't support replicating from multiple
-                # databases by one tap but tap-postgres does.
-                #
-                # To avoid problems of loading two tables with the same name
-                # but from differnet dbs we force tap-postgres to filter only
-                # the db that's in scope
-                'filter_dbs': tap.get('db_conn', {}).get('dbname') if tap else None
+                # Adding only the required list of tables to avoid long running discovery mode
+                'tables': generate_tables_list(tap, as_string=True)
             },
             'tap_stream_id_pattern': '{{database_name}}-{{schema_name}}-{{table_name}}',
             'tap_stream_name_pattern': '{{schema_name}}-{{table_name}}',

--- a/tests/units/cli/resources/tap-valid-snowflake.yml
+++ b/tests/units/cli/resources/tap-valid-snowflake.yml
@@ -44,7 +44,7 @@ schemas:
         replication_key: "last_update"      # Important: Incremental load always needs replication key
 
         # OPTIONAL: Load time transformations
-        #transformations:                    
+        #transformations:
         #  - column: "last_name"            # Column to transform
         #    type: "SET-NULL"               # Transformation type
 

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -264,33 +264,40 @@ class TestUtils:
 
     def test_tap_properties(self):
         """Test tap property getter functions"""
-        tap = cli.utils.load_yaml('{}/resources/tap-valid-mysql.yml'.format(os.path.dirname(__file__)))
+        tap_mysql = cli.utils.load_yaml('{}/resources/tap-valid-mysql.yml'.format(os.path.dirname(__file__)))
 
         # Every tap should have catalog argument --properties or --catalog
-        tap_catalog_argument = cli.utils.get_tap_property(tap, 'tap_catalog_argument')
+        tap_catalog_argument = cli.utils.get_tap_property(tap_mysql, 'tap_catalog_argument')
         assert tap_catalog_argument in ['--catalog', '--properties']
 
         # Every tap should have extra_config_keys defined in dict
-        assert isinstance(cli.utils.get_tap_extra_config_keys(tap), dict) is True
+        assert isinstance(cli.utils.get_tap_extra_config_keys(tap_mysql), dict) is True
 
         # MySQL stream_id should be formatted as {{schema_name}}-{{table_name}}
-        assert cli.utils.get_tap_stream_id(tap, 'dummy_db', 'dummy_schema', 'dummy_table') == 'dummy_schema-dummy_table'
+        assert cli.utils.get_tap_stream_id(tap_mysql, 'dummy_db', 'dummy_schema', 'dummy_table') == \
+               'dummy_schema-dummy_table'
 
         # MySQL stream_name should be formatted as {{schema_name}}-{{table_name}}
-        assert cli.utils.get_tap_stream_name(tap, 'dummy_db', 'dummy_schema',
+        assert cli.utils.get_tap_stream_name(tap_mysql, 'dummy_db', 'dummy_schema',
                                              'dummy_table') == 'dummy_schema-dummy_table'
 
         # MySQL stream_name should be formatted as {{schema_name}}-{{table_name}}
-        assert cli.utils.get_tap_default_replication_method(tap) == 'LOG_BASED'
+        assert cli.utils.get_tap_default_replication_method(tap_mysql) == 'LOG_BASED'
 
         # Get property value by tap type
         assert cli.utils.get_tap_property_by_tap_type('tap-mysql', 'default_replication_method') == 'LOG_BASED'
 
         # Kafka encoding and parameterised local_store_dir should be added as default extra config keys
-        tap = cli.utils.load_yaml('{}/resources/tap-valid-kafka.yml'.format(os.path.dirname(__file__)))
-        assert cli.utils.get_tap_extra_config_keys(tap, temp_dir='/my/temp/dir') == {
+        tap_kafka = cli.utils.load_yaml('{}/resources/tap-valid-kafka.yml'.format(os.path.dirname(__file__)))
+        assert cli.utils.get_tap_extra_config_keys(tap_kafka, temp_dir='/my/temp/dir') == {
             'local_store_dir': '/my/temp/dir',
             'encoding': 'utf-8'
+        }
+
+        # Snwoflake tables list should be added to tap_config_extras
+        tap_snowflake = cli.utils.load_yaml('{}/resources/tap-valid-snowflake.yml'.format(os.path.dirname(__file__)))
+        assert cli.utils.get_tap_extra_config_keys(tap_snowflake) == {
+            'tables': 'SCHEMA_1.TABLE_ONE,SCHEMA_1.TABLE_TWO'
         }
 
     def test_run_command(self):


### PR DESCRIPTION
## Description

This PR generating the mandatory `tables` parameter to tap-snowflake type of taps by parsing the YAML file. This is required since tap-snowflake introducing the mandatory `tables` configuration parameter in https://github.com/transferwise/pipelinewise-tap-snowflake/pull/19

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
