### PR TITLE
[AP-XXXX] Support for iam roles and env vars for redshift fastsync

### DIFF
--- a/docs/connectors/targets/redshift.rst
+++ b/docs/connectors/targets/redshift.rst
@@ -44,10 +44,14 @@ Example YAML for target-redshift:
       dbname: "<DB_NAME>"                           # Redshift database name
 
       # We use an intermediate S3 to load data into Redshift
-      aws_access_key_id: "<ACCESS_KEY>"             # S3 - Plain string or vault encrypted
-      aws_secret_access_key: "<SECRET_ACCESS_KEY>"  # S3 - Plain string or vault encrypted
+      aws_access_key_id: "<ACCESS_KEY>"             # Optional: Plain string or vault encrypted. If not provided, it will be collected from AWS_ACCESS_KEY_ID env var
+      aws_secret_access_key: "<SECRET_ACCESS_KEY>"  # Optional: Plain string or vault encrypted. If not provided, it will be collected from AWS_SECRET_ACCESS_KEY env var
+      #aws_session_token: "<STS_TOKEN>"             # Optional: AWS STS token for temporary credentials. If not provided, it will be collected from AWS_SESSION_TOKEN env var
+      #aws_redshift_copy_role_arn: "<ROLE_ARN>"     # Optional: AWS Role ARN to be used for the Redshift COPY operation.
+                                                    #           Allow the user to use environment credentials and delegate the COPY command to a role
+                                                    #           Used instead of the given AWS keys for the COPY operation if provided
       s3_bucket: "<BUCKET_NAME>"                    # S3 external bucket name
-      s3_key_prefix: "redshift-imports/"            # Optional: S3 key prefix
+      s3_key_prefix: "redshift-imports/"            # Optional: S3 key prefix
 
       # Optional: Overrides the default COPY options to load data into Redshift
       #           The values below are the defaults and fit for purpose for most cases.

--- a/pipelinewise/cli/samples/target_redshift.yml.sample
+++ b/pipelinewise/cli/samples/target_redshift.yml.sample
@@ -19,10 +19,14 @@ db_conn:
   dbname: "<DB_NAME>"                           # Redshift database name
 
   # We use an intermediate S3 to load data into Redshift
-  aws_access_key_id: "<ACCESS_KEY>"             # S3 - Plain string or vault encrypted
-  aws_secret_access_key: "<SECRET_ACCESS_KEY>"  # S3 - Plain string or vault encrypted
+  aws_access_key_id: "<ACCESS_KEY>"             # Optional: Plain string or vault encrypted. If not provided, it will be collected from AWS_ACCESS_KEY_ID env var
+  aws_secret_access_key: "<SECRET_ACCESS_KEY>"  # Optional: Plain string or vault encrypted. If not provided, it will be collected from AWS_SECRET_ACCESS_KEY env var
+  #aws_session_token: "<STS_TOKEN>"             # Optional: AWS STS token for temporary credentials. If not provided, it will be collected from AWS_SESSION_TOKEN env var
+  #aws_redshift_copy_role_arn: "<ROLE_ARN>"     # Optional: AWS Role ARN to be used for the Redshift COPY operation.
+                                                #           Allow the user to use environment credentials and delegate the COPY command to a role
+                                                #           Used instead of the given AWS keys for the COPY operation if provided
   s3_bucket: "<BUCKET_NAME>"                    # S3 external bucket name
-  s3_key_prefix: "redshift-imports/"            # Optional: S3 key prefix
+  s3_key_prefix: "redshift-imports/"            # Optional: S3 key prefix
 
   # Optional: Overrides the default COPY options to load data into Redshift
   #           The values below are the defaults and fit for purpose for most cases.

--- a/pipelinewise/fastsync/mysql_to_redshift.py
+++ b/pipelinewise/fastsync/mysql_to_redshift.py
@@ -25,8 +25,6 @@ REQUIRED_CONFIG_KEYS = {
         'user',
         'password',
         'dbname',
-        'aws_access_key_id',
-        'aws_secret_access_key',
         's3_bucket'
     ]
 }

--- a/pipelinewise/fastsync/postgres_to_redshift.py
+++ b/pipelinewise/fastsync/postgres_to_redshift.py
@@ -26,8 +26,6 @@ REQUIRED_CONFIG_KEYS = {
         'user',
         'password',
         'dbname',
-        'aws_access_key_id',
-        'aws_secret_access_key',
         's3_bucket'
     ]
 }


### PR DESCRIPTION
## Description

Merge missing functionalites from target-redshift to redshift fastsync:
* `aws_session_token`: AWS STS token for temporary credentials
* `aws_redshift_copy_role_arn`: AWS Role ARN to be used for the Redshift COPY operation

Addresses issue reported at https://github.com/transferwise/pipelinewise-target-redshift/pull/31#issuecomment-561770332

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [ ] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
