### PR TITLE
[AP-659] Fix Fastsync to Snowflake with space in the table name

### DIFF
--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -143,7 +143,7 @@ class FastSyncTargetSnowflake:
         inserts = 0
         bucket = self.connection_config['s3_bucket']
 
-        sql = """COPY INTO {}."{}" FROM @{}/{}
+        sql = """COPY INTO {}."{}" FROM '@{}/{}'
                 FILE_FORMAT = (type='CSV' escape='\\x1e' escape_unenclosed_field='\\x1e' 
                 field_optionally_enclosed_by='\"' skip_header={} COMPRESSION='GZIP' BINARY_FORMAT='HEX') 
                 """.format(

--- a/tests/db/tap_mysql_data.sql
+++ b/tests/db/tap_mysql_data.sql
@@ -271,6 +271,28 @@ INSERT INTO `full`(end) VALUES (10),(9),(8),(7),(6),(30),(11);
 UNLOCK TABLES;
 
 
+--
+-- Table structure for table `TABLE WITH SPACE and UPPERCASE`
+--
+
+DROP TABLE IF EXISTS `table with space and UPPERCase`;
+CREATE TABLE `table with space and UPPERCase` (
+    begin int auto_increment primary key,
+    end INT
+)
+ENGINE=MyISAM AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `table with space and UPPERCase`
+--
+
+LOCK TABLES `table with space and UPPERCase` WRITE;
+/*!40000 ALTER TABLE `table with space and UPPERCase` DISABLE KEYS */;
+INSERT INTO `table with space and UPPERCase`(end) VALUES (10),(9),(8),(7),(6),(30),(11);
+/*!40000 ALTER TABLE `table with space and UPPERCase` ENABLE KEYS */;
+UNLOCK TABLES;
+
+
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;

--- a/tests/db/tap_postgres_data.sql
+++ b/tests/db/tap_postgres_data.sql
@@ -5502,3 +5502,16 @@ CREATE TABLE "ORDER"
 
 
 insert into "ORDER" (cvarchar) values ('A'), ('B'), ('C'), ('D'), ('E'), ('F'), ('G');
+
+
+DROP TABLE IF EXISTS public."table with space and UPPERCase" CASCADE;
+
+CREATE TABLE "table with space and UPPERCase"
+(
+    id serial primary key,
+    cvarchar varchar,
+    created_at timestamp default current_timestamp
+);
+
+
+insert into "table with space and UPPERCase" (cvarchar) values ('A'), ('B'), ('C'), ('D'), ('E'), ('F'), ('G');

--- a/tests/end_to_end/test-project/tap_mysql_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_sf.yml.template
@@ -24,7 +24,7 @@ db_conn:
 # Destination (Target) - Target properties
 # Connection details should be in the relevant target YAML file
 # ------------------------------------------------------------------------------
-target: "snowflake"                 # ID of the target connector where the data will be loaded
+target: "snowflake"                    # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
 
 
@@ -33,7 +33,7 @@ batch_size_rows: 20000                 # Batch size for the stream to optimise l
 # ------------------------------------------------------------------------------
 schemas:
   - source_schema: "mysql_source_db"
-    target_schema: "mysql_grp24"
+    target_schema: "ppw_e2e_mysql_to_snowflake"
 
     tables:
       - table_name: "table_with_binary" # This table has binary and varbinary columns
@@ -51,3 +51,6 @@ schemas:
       - table_name: "full" # This table has a reserved word as a name, full is reserved in both Mysql and Snowflake
         replication_method: "INCREMENTAL"
         replication_key: "begin"
+
+      - table_name: "table with space and UPPERCase" # This table has space and mixed upper and lowercase characters
+        replication_method: "LOG_BASED"

--- a/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
@@ -24,8 +24,8 @@ db_conn:
 # Destination (Target) - Target properties
 # Connection details should be in the relevant target YAML file
 # ------------------------------------------------------------------------------
-target: "snowflake"                 # ID of the target connector where the data will be loaded
-batch_size_rows: 1000                 # Batch size for the stream to optimise load performance
+target: "snowflake"                    # ID of the target connector where the data will be loaded
+batch_size_rows: 1000                  # Batch size for the stream to optimise load performance
 
 
 # ------------------------------------------------------------------------------
@@ -33,7 +33,7 @@ batch_size_rows: 1000                 # Batch size for the stream to optimise lo
 # ------------------------------------------------------------------------------
 schemas:
   - source_schema: "public"
-    target_schema: "postgres_world_sf"
+    target_schema: "ppw_e2e_postgres_to_snowflake"
 
     tables:
       - table_name: "city"
@@ -46,16 +46,23 @@ schemas:
       - table_name: "countrylanguage"
         replication_method: "FULL_TABLE"
 
-      - table_name: "order"
+      - table_name: "order" # This table has a reserved word as a name, full is reserved in both Mysql and Snowflake
         replication_method: "INCREMENTAL"
         replication_key: "created_at"
         transformations:
           - column: 'cvarchar'
             type: 'MASK-HIDDEN'
 
-      - table_name: "table_with_reserved_words"
+      - table_name: "table_with_reserved_words" # This table has SF reserved words as columns
         replication_method: "INCREMENTAL"
         replication_key: "increment"
         transformations:
           - column: 'order'
             type: 'HASH'
+
+      # Enable this table only when a new pipelinewise-tap-postgres released to PyPI
+      #
+      # tap-postgres has an issue when LOG_BASED replicating tables with spaces
+      #    Bugfix PR: https://github.com/transferwise/pipelinewise-tap-postgres/pull/49
+      #- table_name: "table with space and UPPERCase" # This table has space and mixed upper and lowercase characters
+      #  replication_method: "LOG_BASED"


### PR DESCRIPTION
## Description

This PR fixes an issue when fastsync to snowflake fails on tables with space in the table name. This happens when generating `MERGE` and `COPY` commands and when detecting primary keys in mysql tables.

There are some related PRs that is not fastsync related, but fixing the same issues with spaces in table names:
* https://github.com/transferwise/pipelinewise-tap-postgres/commit/58107197e0c62004532850dbc31e43963039c2af
* https://github.com/transferwise/pipelinewise-target-snowflake/commit/af5a3260169464a8323a9d35e0426c20347d1dff

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
