### PR TITLE
[AP-655] Create unique replication slots for PG fastsync

### DIFF
--- a/pipelinewise/cli/tap_properties.py
+++ b/pipelinewise/cli/tap_properties.py
@@ -109,13 +109,8 @@ def get_tap_properties(tap=None, temp_dir=None):
         },
         'tap-postgres': {
             'tap_config_extras': {
-                # Postgres can run multiple databases in the same PG instance.
-                #
-                # To avoid table name collision problems when loading
-                # two tables with the same name but from two different postgres
-                # databases from the same PG instance we force tap-postgres to filter
-                # only the db that's in scope
-                'filter_dbs': tap.get('db_conn', {}).get('dbname') if tap else None
+                # Set tap_id to locate the corresponding replication slot
+                'tap_id': tap['id'] if tap else None,
             },
             'tap_stream_id_pattern': '{{schema_name}}-{{table_name}}',
             'tap_stream_name_pattern': '{{schema_name}}-{{table_name}}',

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -96,6 +96,7 @@ class FastSyncTapPostgres:
 
                 return []
 
+    # pylint: disable=no-member
     def create_replication_slot(self):
         """
         Create replication slot on the primary host
@@ -119,7 +120,7 @@ class FastSyncTapPostgres:
                                                                 tap_id=self.connection_config['tap_id'])
 
             # Backward compatibility: try to locate existing v15 slot first. PPW <= 0.15.0
-            v15_slots = self.primary_host_query(f"SELECT * FROM pg_replication_slots"
+            v15_slots = self.primary_host_query(f'SELECT * FROM pg_replication_slots'
                                                 " WHERE slot_name = '{slot_name_v15}'")
             if len(v15_slots) >= 0:
                 slot_name = slot_name_v15
@@ -129,7 +130,6 @@ class FastSyncTapPostgres:
             # Create the replication host
             self.primary_host_query(f"SELECT * FROM pg_create_logical_replication_slot('{slot_name}'")
         except Exception as exc:
-            # If
             # ERROR: replication slot already exists SQL state: 42710
             if exc.pgcode == '42710':
                 pass

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -17,7 +17,9 @@ REQUIRED_CONFIG_KEYS = {
         'host',
         'port',
         'user',
-        'password'
+        'password',
+        'dbname',
+        'tap_id'    # tap_id is required to generate unique replication slot names
     ],
     'target': [
         'account',

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -1,0 +1,31 @@
+import pytest
+from unittest import TestCase
+from pipelinewise.fastsync.commons.tap_postgres import FastSyncTapPostgres
+
+
+class TestFastSyncTapPostgres(TestCase):
+    """
+    Unit tests for fastsync tap postgres
+    """
+    def setUp(self) -> None:
+        self.maxDiff = None
+
+    def test_generate_replication_slot_name(self):
+        """Validate if the replication slot name generated correctly"""
+        postgres = FastSyncTapPostgres(connection_config={}, tap_type_to_target_type={})
+
+        # Provide only database name
+        assert postgres.generate_replication_slot_name('some_db') == 'pipelinewise_some_db'
+
+        # Provide database name and tap_id
+        assert postgres.generate_replication_slot_name('some_db',
+                                                       'some_tap') == 'pipelinewise_some_db_some_tap'
+
+        # Provide database name, tap_id and prefix
+        assert postgres.generate_replication_slot_name('some_db',
+                                                       'some_tap',
+                                                       prefix='custom_prefix') == 'custom_prefix_some_db_some_tap'
+
+        # Replication slot name should be lowercase
+        assert postgres.generate_replication_slot_name('SoMe_DB',
+                                                       'SoMe_TaP') == 'pipelinewise_some_db_some_tap'


### PR DESCRIPTION
## Description

This PR makes possible to `LOG_BASE` replicate multiple database in the same postgres instance by multiple parallel running taps:
* Replication slot name includes the tap_id using the pattern: `pipelinewise_<dbname>_<tap_id>`
* Passing `tap_id` to tap-postgres so it can locate and use it to consume new wal entries
* Backward compatibility with `PPW <= 0.15.x` to use the old replication slot pattern if exists. 

Related PR for tap-postgres: https://github.com/transferwise/pipelinewise-tap-postgres/pull/50

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
