### PR TITLE
[AP-678] Make common fastsync target-postgres to work

### DIFF
--- a/pipelinewise/fastsync/commons/target_postgres.py
+++ b/pipelinewise/fastsync/commons/target_postgres.py
@@ -1,6 +1,9 @@
 import logging
 import psycopg2
 import psycopg2.extras
+import json
+import gzip
+from typing import List
 
 from . import utils
 
@@ -12,6 +15,10 @@ class FastSyncTargetPostgres:
     """
     Common functions for fastsync to Postgres
     """
+
+    EXTRACTED_AT_COLUMN = '_SDC_EXTRACTED_AT'
+    BATCHED_AT_COLUMN = '_SDC_BATCHED_AT'
+    DELETED_AT_COLUMN = '_SDC_DELETED_AT'
 
     def __init__(self, connection_config, transformation_config=None):
         self.connection_config = connection_config
@@ -47,50 +54,58 @@ class FastSyncTargetPostgres:
         table_dict = utils.tablename_to_dict(table_name)
         target_table = table_dict.get('table_name') if not is_temporary else table_dict.get('temp_table_name')
 
-        sql = 'DROP TABLE IF EXISTS {}.{}'.format(target_schema, target_table)
+        sql = 'DROP TABLE IF EXISTS {}."{}"'.format(target_schema, target_table.lower())
         self.query(sql)
 
-    def create_table(self, target_schema, table_name, columns, primary_key, is_temporary=False):
+    def create_table(self, target_schema: str, table_name: str, columns: List[str], primary_key: str,
+                     is_temporary: bool = False, sort_columns=False):
+
         table_dict = utils.tablename_to_dict(table_name)
         target_table = table_dict.get('table_name') if not is_temporary else table_dict.get('temp_table_name')
 
-        # if primary_key:
-        # pylint: disable=using-constant-test
-        if False:
-            sql = """CREATE TABLE IF NOT EXISTS {}.{} ({}
-            ,_SDC_EXTRACTED_AT TIMESTAMP WITHOUT TIME ZONE
-            ,_SDC_BATCHED_AT TIMESTAMP WITHOUT TIME ZONE
-            ,_SDC_DELETED_AT CHARACTER VARYING
-            , PRIMARY KEY ({}))
-            """.format(target_schema, target_table, ', '.join(columns), primary_key)
-        else:
-            sql = """CREATE TABLE IF NOT EXISTS {}.{} ({}
-            ,_SDC_EXTRACTED_AT TIMESTAMP WITHOUT TIME ZONE
-            ,_SDC_BATCHED_AT TIMESTAMP WITHOUT TIME ZONE
-            ,_SDC_DELETED_AT CHARACTER VARYING
-            )
-            """.format(target_schema, target_table, ', '.join(columns))
+        # skip the EXTRACTED, BATCHED and DELETED columns in case they exist because they gonna be added later
+        columns = [c for c in columns if not (c.startswith(self.EXTRACTED_AT_COLUMN) or
+                                              c.startswith(self.BATCHED_AT_COLUMN) or
+                                              c.startswith(self.DELETED_AT_COLUMN))]
+
+        columns += [f'{self.EXTRACTED_AT_COLUMN} TIMESTAMP WITHOUT TIME ZONE',
+                    f'{self.BATCHED_AT_COLUMN} TIMESTAMP WITHOUT TIME ZONE',
+                    f'{self.DELETED_AT_COLUMN} CHARACTER VARYING']
+
+        # We need the sort the columns for some taps( for now tap-s3-csv)
+        # because later on when copying a csv file into Snowflake
+        # the csv file columns need to be in the same order as the the target table that will be created below
+        if sort_columns:
+            columns.sort()
+
+        sql = f'CREATE TABLE IF NOT EXISTS {target_schema}."{target_table.lower()}" (' \
+              f'{",".join(columns).lower()}' \
+              f'{f", PRIMARY KEY ({primary_key.lower()}))" if primary_key else ")"}'
+
         self.query(sql)
 
-    def copy_to_table(self, s3_key, target_schema, table_name, is_temporary):
-        LOGGER.info('Loading %s into Redshift...', s3_key)
+    def copy_to_table(self, filepath, target_schema: str, table_name: str, size_bytes: int,
+                      is_temporary: bool = False):
+        LOGGER.info('Loading %s into Postgres...', filepath)
         table_dict = utils.tablename_to_dict(table_name)
         target_table = table_dict.get('table_name') if not is_temporary else table_dict.get('temp_table_name')
 
-        aws_access_key_id = self.connection_config['aws_access_key_id']
-        aws_secret_access_key = self.connection_config['aws_secret_access_key']
-        bucket = self.connection_config['s3_bucket']
+        with self.open_connection() as connection:
+            with connection.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+                inserts = 0
 
-        sql = """COPY {}.{} FROM 's3://{}/{}'
-            ACCESS_KEY_ID '{}'
-            SECRET_ACCESS_KEY '{}'
-            DELIMITER ',' REMOVEQUOTES ESCAPE
-            BLANKSASNULL TIMEFORMAT 'auto'
-            GZIP
-        """.format(target_schema, target_table, bucket, s3_key, aws_access_key_id, aws_secret_access_key)
-        self.query(sql)
+                copy_sql = f"""COPY {target_schema}."{target_table.lower()}"
+                FROM STDIN WITH (FORMAT CSV, ESCAPE '"')
+                """
 
-        LOGGER.info('Deleting %s from S3...', s3_key)
+                with gzip.open(filepath, 'rb') as file:
+                    cur.copy_expert(copy_sql, file)
+
+                inserts = cur.rowcount
+                LOGGER.info('Loading into %s."%s": %s',
+                            target_schema,
+                            target_table.lower(),
+                            json.dumps({'inserts': inserts, 'updates': 0, 'size_bytes': size_bytes}))
 
     # grant_... functions are common functions called by utils.py: grant_privilege function
     # "to_group" is not used here but exists for compatibility reasons with other database types
@@ -101,7 +116,7 @@ class FastSyncTargetPostgres:
         if role:
             table_dict = utils.tablename_to_dict(table_name)
             target_table = table_dict.get('table_name') if not is_temporary else table_dict.get('temp_table_name')
-            sql = 'GRANT SELECT ON {}.{} TO GROUP {}'.format(target_schema, target_table, role)
+            sql = 'GRANT SELECT ON {}."{}" TO GROUP {}'.format(target_schema, target_table.lower(), role)
             self.query(sql)
 
     # pylint: disable=unused-argument
@@ -119,10 +134,10 @@ class FastSyncTargetPostgres:
             self.query(sql)
 
     # pylint: disable=duplicate-string-formatting-argument
-    def obfuscate_columns(self, target_schema, table_name):
+    def obfuscate_columns(self, target_schema: str, table_name: str, is_temporary: bool = False):
         LOGGER.info('Applying obfuscation rules')
         table_dict = utils.tablename_to_dict(table_name)
-        temp_table = table_dict.get('temp_table_name')
+        target_table = table_dict.get('table_name') if not is_temporary else table_dict.get('temp_table_name')
         transformations = self.transformation_config.get('transformations', [])
         trans_cols = []
 
@@ -138,21 +153,29 @@ class FastSyncTargetPostgres:
                 column = trans.get('field_id')
                 transform_type = trans.get('type')
                 if transform_type == 'SET-NULL':
-                    trans_cols.append('{} = NULL'.format(column))
+                    trans_cols.append('"{}" = NULL'.format(column))
                 elif transform_type == 'HASH':
-                    trans_cols.append('{} = FUNC_SHA1({})'.format(column, column))
+                    trans_cols.append('"{}" = ENCODE(DIGEST("{}", \'sha1\'), \'hex\')'.format(column, column))
                 elif 'HASH-SKIP-FIRST' in transform_type:
                     skip_first_n = transform_type[-1]
-                    trans_cols.append('{} = CONCAT(SUBSTRING({}, 1, {}), FUNC_SHA1(SUBSTRING({}, {} + 1)))'.format(
-                        column, column, skip_first_n, column, skip_first_n))
+                    trans_cols.append('"{}" = CONCAT(SUBSTRING("{}", 1, {}),'
+                                      'ENCODE(DIGEST(SUBSTRING("{}", {} + 1), \'sha1\'), \'hex\'))'
+                                      .format(column,
+                                              column,
+                                              skip_first_n,
+                                              column,
+                                              skip_first_n))
                 elif transform_type == 'MASK-DATE':
-                    trans_cols.append("{} = TO_CHAR({}::DATE,'YYYY-01-01')::DATE".format(column, column))
+                    trans_cols.append('"{}" = TO_CHAR("{}"::DATE, \'YYYY-01-01\')::DATE'.format(column, column))
                 elif transform_type == 'MASK-NUMBER':
-                    trans_cols.append('{} = 0'.format(column))
+                    trans_cols.append('"{}" = 0'.format(column))
 
         # Generate and run UPDATE if at least one obfuscation rule found
         if len(trans_cols) > 0:
-            sql = 'UPDATE {}.{} SET {}'.format(target_schema, temp_table, ','.join(trans_cols))
+            sql = f"""UPDATE {target_schema}."{target_table.lower()}"
+            SET {','.join(trans_cols)}
+            """
+
             self.query(sql)
 
     def swap_tables(self, schema, table_name):
@@ -161,5 +184,5 @@ class FastSyncTargetPostgres:
         temp_table = table_dict.get('temp_table_name')
 
         # Swap tables and drop the temp tamp
-        self.query('DROP TABLE IF EXISTS {}.{}'.format(schema, target_table))
-        self.query('ALTER TABLE {}.{} RENAME TO {}'.format(schema, temp_table, target_table))
+        self.query('DROP TABLE IF EXISTS {}."{}"'.format(schema, target_table.lower()))
+        self.query('ALTER TABLE {}."{}" RENAME TO "{}"'.format(schema, temp_table.lower(), target_table.lower()))

--- a/tests/units/fastsync/commons/test_fastsync_target_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_target_postgres.py
@@ -1,0 +1,179 @@
+from pipelinewise.fastsync.commons.target_postgres import FastSyncTargetPostgres
+
+
+class FastSyncTargetPostgresMock(FastSyncTargetPostgres):
+    """
+    Mocked FastSyncTargetPostgres class
+    """
+    def __init__(self, connection_config, transformation_config=None):
+        super().__init__(connection_config, transformation_config)
+
+        self.executed_queries = []
+
+    def query(self, query, params=None):
+        self.executed_queries.append(query)
+
+
+# pylint: disable=attribute-defined-outside-init
+class TestFastSyncTargetPostgres:
+    """
+    Unit tests for fastsync target postgres
+    """
+    def setup_method(self):
+        """Initialise test FastSyncTargetPostgres object"""
+        self.postgres = FastSyncTargetPostgresMock(connection_config={}, transformation_config={})
+
+    def test_create_schema(self):
+        """Validate if create schema queries generated correctly"""
+        self.postgres.create_schema('new_schema')
+        assert self.postgres.executed_queries == ['CREATE SCHEMA IF NOT EXISTS new_schema']
+
+    def test_drop_table(self):
+        """Validate if drop table queries generated correctly"""
+        self.postgres.drop_table('test_schema', 'test_table')
+        self.postgres.drop_table('test_schema', 'test_table', is_temporary=True)
+        self.postgres.drop_table('test_schema', 'UPPERCASE_TABLE')
+        self.postgres.drop_table('test_schema', 'UPPERCASE_TABLE', is_temporary=True)
+        self.postgres.drop_table('test_schema', 'test table with space')
+        self.postgres.drop_table('test_schema', 'test table with space', is_temporary=True)
+        assert self.postgres.executed_queries == [
+            'DROP TABLE IF EXISTS test_schema."test_table"',
+            'DROP TABLE IF EXISTS test_schema."test_table_temp"',
+            'DROP TABLE IF EXISTS test_schema."uppercase_table"',
+            'DROP TABLE IF EXISTS test_schema."uppercase_table_temp"',
+            'DROP TABLE IF EXISTS test_schema."test table with space"',
+            'DROP TABLE IF EXISTS test_schema."test table with space_temp"']
+
+    def test_create_table(self):
+        """Validate if create table queries generated correctly"""
+        # Create table with standard table and column names
+        self.postgres.executed_queries = []
+        self.postgres.create_table(target_schema='test_schema',
+                                   table_name='test_table',
+                                   columns=['"id" INTEGER',
+                                            '"txt" CHARACTER VARYING'],
+                                   primary_key='"id"')
+        assert self.postgres.executed_queries == [
+            'CREATE TABLE IF NOT EXISTS test_schema."test_table" ('
+            '"id" integer,"txt" character varying,'
+            '_sdc_extracted_at timestamp without time zone,'
+            '_sdc_batched_at timestamp without time zone,'
+            '_sdc_deleted_at character varying'
+            ', PRIMARY KEY ("id"))']
+
+        # Create table with reserved words in table and column names
+        self.postgres.executed_queries = []
+        self.postgres.create_table(target_schema='test_schema',
+                                   table_name='ORDER',
+                                   columns=['"id" INTEGER',
+                                            '"txt" CHARACTER VARYING',
+                                            '"SELECT" CHARACTER VARYING'],
+                                   primary_key='"id"')
+        assert self.postgres.executed_queries == [
+            'CREATE TABLE IF NOT EXISTS test_schema."order" ('
+            '"id" integer,"txt" character varying,"select" character varying,'
+            '_sdc_extracted_at timestamp without time zone,'
+            '_sdc_batched_at timestamp without time zone,'
+            '_sdc_deleted_at character varying'
+            ', PRIMARY KEY ("id"))']
+
+        # Create table with mixed lower and uppercase and space characters
+        self.postgres.executed_queries = []
+        self.postgres.create_table(target_schema='test_schema',
+                                   table_name='TABLE with SPACE',
+                                   columns=['"id" INTEGER',
+                                            '"column_with space" CHARACTER VARYING'],
+                                   primary_key='"id"')
+        assert self.postgres.executed_queries == [
+            'CREATE TABLE IF NOT EXISTS test_schema."table with space" ('
+            '"id" integer,"column_with space" character varying,'
+            '_sdc_extracted_at timestamp without time zone,'
+            '_sdc_batched_at timestamp without time zone,'
+            '_sdc_deleted_at character varying'
+            ', PRIMARY KEY ("id"))']
+
+        # Create table with no primary key
+        self.postgres.executed_queries = []
+        self.postgres.create_table(target_schema='test_schema',
+                                   table_name='test_table_no_pk',
+                                   columns=['"id" INTEGER',
+                                            '"txt" CHARACTER VARYING'],
+                                   primary_key=None)
+        assert self.postgres.executed_queries == [
+            'CREATE TABLE IF NOT EXISTS test_schema."test_table_no_pk" ('
+            '"id" integer,"txt" character varying,'
+            '_sdc_extracted_at timestamp without time zone,'
+            '_sdc_batched_at timestamp without time zone,'
+            '_sdc_deleted_at character varying)']
+
+    def test_grant_select_on_table(self):
+        """Validate if GRANT command generated correctly"""
+        # GRANT table with standard table and column names
+        self.postgres.executed_queries = []
+        self.postgres.grant_select_on_table(target_schema='test_schema',
+                                            table_name='test_table',
+                                            role='test_role',
+                                            is_temporary=False)
+        assert self.postgres.executed_queries == [
+            'GRANT SELECT ON test_schema."test_table" TO GROUP test_role']
+
+        # GRANT table with reserved word in table and column names in temp table
+        self.postgres.executed_queries = []
+        self.postgres.grant_select_on_table(target_schema='test_schema',
+                                            table_name='full',
+                                            role='test_role',
+                                            is_temporary=False)
+        assert self.postgres.executed_queries == [
+            'GRANT SELECT ON test_schema."full" TO GROUP test_role']
+
+        # GRANT table with with space and uppercase in table name and s3 key
+        self.postgres.executed_queries = []
+        self.postgres.grant_select_on_table(target_schema='test_schema',
+                                            table_name='table with SPACE and UPPERCASE',
+                                            role='test_role',
+                                            is_temporary=False)
+        assert self.postgres.executed_queries == [
+            'GRANT SELECT ON test_schema."table with space and uppercase" TO GROUP test_role']
+
+    def test_grant_usage_on_schema(self):
+        """Validate if GRANT command generated correctly"""
+        self.postgres.executed_queries = []
+        self.postgres.grant_usage_on_schema(target_schema='test_schema',
+                                            role='test_role')
+        assert self.postgres.executed_queries == [
+            'GRANT USAGE ON SCHEMA test_schema TO GROUP test_role']
+
+    def test_grant_select_on_schema(self):
+        """Validate if GRANT command generated correctly"""
+        self.postgres.executed_queries = []
+        self.postgres.grant_select_on_schema(target_schema='test_schema',
+                                             role='test_role')
+        assert self.postgres.executed_queries == [
+            'GRANT SELECT ON ALL TABLES IN SCHEMA test_schema TO GROUP test_role']
+
+    def test_swap_tables(self):
+        """Validate if swap table commands generated correctly"""
+        # Swap tables with standard table and column names
+        self.postgres.executed_queries = []
+        self.postgres.swap_tables(schema='test_schema',
+                                  table_name='test_table')
+        assert self.postgres.executed_queries == [
+            'DROP TABLE IF EXISTS test_schema."test_table"',
+            'ALTER TABLE test_schema."test_table_temp" RENAME TO "test_table"']
+
+        # Swap tables with reserved word in table and column names in temp table
+        self.postgres.executed_queries = []
+        self.postgres.swap_tables(schema='test_schema',
+                                  table_name='full')
+        assert self.postgres.executed_queries == [
+            'DROP TABLE IF EXISTS test_schema."full"',
+            'ALTER TABLE test_schema."full_temp" RENAME TO "full"']
+
+        # Swap tables with with space and uppercase in table name
+        self.postgres.executed_queries = []
+        self.postgres.swap_tables(schema='test_schema',
+                                  table_name='table with SPACE and UPPERCASE')
+        assert self.postgres.executed_queries == [
+            'DROP TABLE IF EXISTS test_schema."table with space and uppercase"',
+            'ALTER TABLE test_schema."table with space and uppercase_temp" '
+            'RENAME TO "table with space and uppercase"']


### PR DESCRIPTION
## Description

Target-Postgres common fastsync component is currently not working and not used anywhere. This PR makes it to work.

This change is an improvement to use target-postgres and fastsync-postgres components to speed up developing complex end to end test cases locally so we don't need to rely on external commercial databases like Snowflake or Redshift.

The new E2E test cases are WiP and will be transferrable between different target components. When newly added E2E tests will be working with local target-postgres we can transfer them easily to snowflake or other target connectors.

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
