### PR TITLE
[AP-680] Fastsync tables with composite primary key

### DIFF
--- a/pipelinewise/fastsync/commons/tap_mysql.py
+++ b/pipelinewise/fastsync/commons/tap_mysql.py
@@ -150,7 +150,7 @@ class FastSyncTapMySql:
                                                                            table_dict['table_name'])
         pk_specs = self.query(sql)
         if len(pk_specs) > 0:
-            [safe_column_name(k.get('Column_name')) for k in pk_specs]
+            return [safe_column_name(k.get('Column_name')) for k in pk_specs]
 
         return None
 

--- a/pipelinewise/fastsync/commons/tap_mysql.py
+++ b/pipelinewise/fastsync/commons/tap_mysql.py
@@ -141,16 +141,16 @@ class FastSyncTapMySql:
             'version': 1
         }
 
-    def get_primary_key(self, table_name):
+    def get_primary_keys(self, table_name):
         """
         Get the primary key of a table
         """
         table_dict = utils.tablename_to_dict(table_name)
         sql = "SHOW KEYS FROM `{}`.`{}` WHERE Key_name = 'PRIMARY'".format(table_dict['schema_name'],
                                                                            table_dict['table_name'])
-        primary_key = self.query(sql)
-        if len(primary_key) > 0:
-            return primary_key[0].get('Column_name')
+        pk_specs = self.query(sql)
+        if len(pk_specs) > 0:
+            return ','.join({safe_column_name(k.get('Column_name')) for k in pk_specs})
 
         return None
 
@@ -203,7 +203,7 @@ class FastSyncTapMySql:
 
         return {
             'columns': mapped_columns,
-            'primary_key': safe_column_name(self.get_primary_key(table_name))
+            'primary_key': self.get_primary_keys(table_name)
         }
 
     # pylint: disable=too-many-locals

--- a/pipelinewise/fastsync/commons/tap_mysql.py
+++ b/pipelinewise/fastsync/commons/tap_mysql.py
@@ -150,7 +150,7 @@ class FastSyncTapMySql:
                                                                            table_dict['table_name'])
         pk_specs = self.query(sql)
         if len(pk_specs) > 0:
-            return ','.join({safe_column_name(k.get('Column_name')) for k in pk_specs})
+            [safe_column_name(k.get('Column_name')) for k in pk_specs]
 
         return None
 

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -253,7 +253,7 @@ class FastSyncTapPostgres:
                     AND indisprimary""".format(schema_name, table_name)
         pk_specs = self.query(sql)
         if len(pk_specs) > 0:
-            [safe_column_name(k[0]) for k in pk_specs]
+            return [safe_column_name(k[0]) for k in pk_specs]
 
         return None
 

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -236,7 +236,7 @@ class FastSyncTapPostgres:
             'version': 1
         }
 
-    def get_primary_key(self, table):
+    def get_primary_keys(self, table):
         """
         Get the primary key of a table
         """
@@ -251,9 +251,9 @@ class FastSyncTapPostgres:
                         pg_attribute.attrelid = pg_class.oid AND
                         pg_attribute.attnum = any(pg_index.indkey)
                     AND indisprimary""".format(schema_name, table_name)
-        primary_key = self.query(sql)
-        if len(primary_key) > 0:
-            return primary_key[0][0]
+        pk_specs = self.query(sql)
+        if len(pk_specs) > 0:
+            return ','.join({safe_column_name(k[0]) for k in pk_specs})
 
         return None
 
@@ -294,7 +294,7 @@ class FastSyncTapPostgres:
 
         return {
             'columns': mapped_columns,
-            'primary_key': safe_column_name(self.get_primary_key(table_name))
+            'primary_key': self.get_primary_keys(table_name)
         }
 
     def copy_table(self, table_name, path):

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -253,7 +253,7 @@ class FastSyncTapPostgres:
                     AND indisprimary""".format(schema_name, table_name)
         pk_specs = self.query(sql)
         if len(pk_specs) > 0:
-            return ','.join({safe_column_name(k[0]) for k in pk_specs})
+            [safe_column_name(k[0]) for k in pk_specs]
 
         return None
 

--- a/pipelinewise/fastsync/commons/tap_s3_csv.py
+++ b/pipelinewise/fastsync/commons/tap_s3_csv.py
@@ -220,7 +220,7 @@ class FastSyncTapS3Csv:
             replication_key: self.tables_last_modified[table].isoformat()
         } if table in self.tables_last_modified else {}
 
-    def _get_primary_keys(self, table_specs: Dict) -> Optional[str]:
+    def _get_primary_keys(self, table_specs: Dict) -> Optional[List]:
         """
         Returns the primary keys specified in the tap config by key_properties
         The keys are made safe by wrapping them in quotes in case one or more are reserved words.
@@ -228,7 +228,7 @@ class FastSyncTapS3Csv:
         :return: the keys concatenated and separated by comma if keys are given, otherwise None
         """
         if table_specs.get('key_properties', False):
-            return ','.join({safe_column_name(k) for k in table_specs['key_properties']})
+            return [safe_column_name(k) for k in table_specs['key_properties']]
 
         return None
 

--- a/pipelinewise/fastsync/commons/target_postgres.py
+++ b/pipelinewise/fastsync/commons/target_postgres.py
@@ -57,7 +57,7 @@ class FastSyncTargetPostgres:
         sql = 'DROP TABLE IF EXISTS {}."{}"'.format(target_schema, target_table.lower())
         self.query(sql)
 
-    def create_table(self, target_schema: str, table_name: str, columns: List[str], primary_key: str,
+    def create_table(self, target_schema: str, table_name: str, columns: List[str], primary_key: List[str],
                      is_temporary: bool = False, sort_columns=False):
 
         table_dict = utils.tablename_to_dict(table_name)
@@ -78,9 +78,11 @@ class FastSyncTargetPostgres:
         if sort_columns:
             columns.sort()
 
+        sql_columns = ",".join(columns).lower()
+        sql_primary_keys = ",".join(primary_key).lower() if primary_key else None
         sql = f'CREATE TABLE IF NOT EXISTS {target_schema}."{target_table.lower()}" (' \
-              f'{",".join(columns).lower()}' \
-              f'{f", PRIMARY KEY ({primary_key.lower()}))" if primary_key else ")"}'
+              f'{sql_columns}' \
+              f'{f", PRIMARY KEY ({sql_primary_keys}))" if primary_key else ")"}'
 
         self.query(sql)
 

--- a/pipelinewise/fastsync/commons/target_postgres.py
+++ b/pipelinewise/fastsync/commons/target_postgres.py
@@ -78,8 +78,8 @@ class FastSyncTargetPostgres:
         if sort_columns:
             columns.sort()
 
-        sql_columns = ",".join(columns).lower()
-        sql_primary_keys = ",".join(primary_key).lower() if primary_key else None
+        sql_columns = ','.join(columns).lower()
+        sql_primary_keys = ','.join(primary_key).lower() if primary_key else None
         sql = f'CREATE TABLE IF NOT EXISTS {target_schema}."{target_table.lower()}" (' \
               f'{sql_columns}' \
               f'{f", PRIMARY KEY ({sql_primary_keys}))" if primary_key else ")"}'

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -107,7 +107,7 @@ class FastSyncTargetSnowflake:
         sql = 'DROP TABLE IF EXISTS {}."{}"'.format(target_schema, target_table.upper())
         self.query(sql)
 
-    def create_table(self, target_schema: str, table_name: str, columns: List[str], primary_key: str,
+    def create_table(self, target_schema: str, table_name: str, columns: List[str], primary_key: List[str],
                      is_temporary: bool = False, sort_columns=False):
 
         table_dict = utils.tablename_to_dict(table_name)
@@ -128,9 +128,11 @@ class FastSyncTargetSnowflake:
         if sort_columns:
             columns.sort()
 
+        sql_columns = ",".join(columns)
+        sql_primary_keys = ",".join(primary_key) if primary_key else None
         sql = f'CREATE OR REPLACE TABLE {target_schema}."{target_table.upper()}" (' \
-              f'{",".join(columns)}' \
-              f'{f", PRIMARY KEY ({primary_key}))" if primary_key else ")"}'
+              f'{sql_columns}' \
+              f'{f", PRIMARY KEY ({sql_primary_keys}))" if primary_key else ")"}'
 
         self.query(sql)
 

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -128,8 +128,8 @@ class FastSyncTargetSnowflake:
         if sort_columns:
             columns.sort()
 
-        sql_columns = ",".join(columns)
-        sql_primary_keys = ",".join(primary_key) if primary_key else None
+        sql_columns = ','.join(columns)
+        sql_primary_keys = ','.join(primary_key) if primary_key else None
         sql = f'CREATE OR REPLACE TABLE {target_schema}."{target_table.upper()}" (' \
               f'{sql_columns}' \
               f'{f", PRIMARY KEY ({sql_primary_keys}))" if primary_key else ")"}'

--- a/singer-connectors/target-postgres/requirements.txt
+++ b/singer-connectors/target-postgres/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-postgres==1.1.0
+pipelinewise-target-postgres==2.0.0

--- a/tests/units/fastsync/commons/test_fastsync_target_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_target_postgres.py
@@ -52,7 +52,7 @@ class TestFastSyncTargetPostgres:
                                    table_name='test_table',
                                    columns=['"id" INTEGER',
                                             '"txt" CHARACTER VARYING'],
-                                   primary_key='"id"')
+                                   primary_key=['"id"'])
         assert self.postgres.executed_queries == [
             'CREATE TABLE IF NOT EXISTS test_schema."test_table" ('
             '"id" integer,"txt" character varying,'
@@ -68,7 +68,7 @@ class TestFastSyncTargetPostgres:
                                    columns=['"id" INTEGER',
                                             '"txt" CHARACTER VARYING',
                                             '"SELECT" CHARACTER VARYING'],
-                                   primary_key='"id"')
+                                   primary_key=['"id"'])
         assert self.postgres.executed_queries == [
             'CREATE TABLE IF NOT EXISTS test_schema."order" ('
             '"id" integer,"txt" character varying,"select" character varying,'
@@ -83,7 +83,7 @@ class TestFastSyncTargetPostgres:
                                    table_name='TABLE with SPACE',
                                    columns=['"id" INTEGER',
                                             '"column_with space" CHARACTER VARYING'],
-                                   primary_key='"id"')
+                                   primary_key=['"id"'])
         assert self.postgres.executed_queries == [
             'CREATE TABLE IF NOT EXISTS test_schema."table with space" ('
             '"id" integer,"column_with space" character varying,'
@@ -91,6 +91,22 @@ class TestFastSyncTargetPostgres:
             '_sdc_batched_at timestamp without time zone,'
             '_sdc_deleted_at character varying'
             ', PRIMARY KEY ("id"))']
+
+        # Create table with composite primary key
+        self.postgres.executed_queries = []
+        self.postgres.create_table(target_schema='test_schema',
+                                   table_name='TABLE with SPACE',
+                                   columns=['"id" INTEGER',
+                                            '"num" INTEGER',
+                                            '"column_with space" CHARACTER VARYING'],
+                                   primary_key=['"id"', '"num"'])
+        assert self.postgres.executed_queries == [
+            'CREATE TABLE IF NOT EXISTS test_schema."table with space" ('
+            '"id" integer,"num" integer,"column_with space" character varying,'
+            '_sdc_extracted_at timestamp without time zone,'
+            '_sdc_batched_at timestamp without time zone,'
+            '_sdc_deleted_at character varying'
+            ', PRIMARY KEY ("id","num"))']
 
         # Create table with no primary key
         self.postgres.executed_queries = []

--- a/tests/units/fastsync/commons/test_fastsync_target_snowflake.py
+++ b/tests/units/fastsync/commons/test_fastsync_target_snowflake.py
@@ -69,7 +69,7 @@ class TestFastSyncTargetSnowflake:
                                     table_name='test_table',
                                     columns=['"ID" INTEGER',
                                              '"TXT" VARCHAR'],
-                                    primary_key='"ID"')
+                                    primary_key=['"ID"'])
         assert self.snowflake.executed_queries == [
             'CREATE OR REPLACE TABLE test_schema."TEST_TABLE" ('
             '"ID" INTEGER,"TXT" VARCHAR,'
@@ -85,7 +85,7 @@ class TestFastSyncTargetSnowflake:
                                     columns=['"ID" INTEGER',
                                              '"TXT" VARCHAR',
                                              '"SELECT" VARCHAR'],
-                                    primary_key='"ID"')
+                                    primary_key=['"ID"'])
         assert self.snowflake.executed_queries == [
             'CREATE OR REPLACE TABLE test_schema."ORDER" ('
             '"ID" INTEGER,"TXT" VARCHAR,"SELECT" VARCHAR,'
@@ -100,7 +100,7 @@ class TestFastSyncTargetSnowflake:
                                     table_name='TABLE with SPACE',
                                     columns=['"ID" INTEGER',
                                              '"COLUMN WITH SPACE" CHARACTER VARYING'],
-                                    primary_key='"ID"')
+                                    primary_key=['"ID"'])
         assert self.snowflake.executed_queries == [
             'CREATE OR REPLACE TABLE test_schema."TABLE WITH SPACE" ('
             '"ID" INTEGER,"COLUMN WITH SPACE" CHARACTER VARYING,'
@@ -108,6 +108,22 @@ class TestFastSyncTargetSnowflake:
             '_SDC_BATCHED_AT TIMESTAMP_NTZ,'
             '_SDC_DELETED_AT VARCHAR'
             ', PRIMARY KEY ("ID"))']
+
+        # Create table with composite primary key
+        self.snowflake.executed_queries = []
+        self.snowflake.create_table(target_schema='test_schema',
+                                    table_name='TABLE with SPACE',
+                                    columns=['"ID" INTEGER',
+                                             '"NUM" INTEGER',
+                                             '"COLUMN WITH SPACE" CHARACTER VARYING'],
+                                    primary_key=['"ID", "NUM"'])
+        assert self.snowflake.executed_queries == [
+            'CREATE OR REPLACE TABLE test_schema."TABLE WITH SPACE" ('
+            '"ID" INTEGER,"NUM" INTEGER,"COLUMN WITH SPACE" CHARACTER VARYING,'
+            '_SDC_EXTRACTED_AT TIMESTAMP_NTZ,'
+            '_SDC_BATCHED_AT TIMESTAMP_NTZ,'
+            '_SDC_DELETED_AT VARCHAR'
+            ', PRIMARY KEY ("ID", "NUM"))']
 
         # Create table with no primary key
         self.snowflake.executed_queries = []

--- a/tests/units/fastsync/test_fastsync_tap_s3_csv.py
+++ b/tests/units/fastsync/test_fastsync_tap_s3_csv.py
@@ -172,11 +172,11 @@ class TestFastSyncTapS3Csv(TestCase):
         self.assertIsNone(self.fs_tap_s3_csv._get_primary_keys({'key_properties': []}))
 
     def test_get_primary_keys_with_table_that_has_1_key_returns_one_safe_key(self):
-        self.assertEqual('"KEY_1"', self.fs_tap_s3_csv._get_primary_keys({'key_properties': ['key_1']}))
+        self.assertEqual(['"KEY_1"'], self.fs_tap_s3_csv._get_primary_keys({'key_properties': ['key_1']}))
 
     def test_get_primary_keys_with_table_that_has_2_keys_returns_concatenated_keys(self):
         self.assertIn(self.fs_tap_s3_csv._get_primary_keys({'key_properties': ['key_2', 'key_3']}),
-                      ['"KEY_2","KEY_3"', '"KEY_3","KEY_2"'])
+                      [['"KEY_2"', '"KEY_3"'], ['"KEY_3"', '"KEY_2"']])
 
     def test_get_table_columns(self):
         output = list(


### PR DESCRIPTION
## Description

`CREATE TABLE` statements not generated correctly by fastsync if table has composite key. The only reason why fastsync is still working with tables with composite PKs is that Snowflake and Redshift don't enforce primary keys.

Fixing it to generate DDLs with composite PKs correctly.

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
