### PR TITLE
[AP-645] Create target schemas sequentially

### DIFF
--- a/pipelinewise/fastsync/commons/target_postgres.py
+++ b/pipelinewise/fastsync/commons/target_postgres.py
@@ -50,6 +50,11 @@ class FastSyncTargetPostgres:
         sql = 'CREATE SCHEMA IF NOT EXISTS {}'.format(schema)
         self.query(sql)
 
+    def create_schemas(self, tables):
+        schemas = utils.get_target_schemas(self.connection_config, tables)
+        for schema in schemas:
+            self.create_schema(schema)
+
     def drop_table(self, target_schema, table_name, is_temporary=False):
         table_dict = utils.tablename_to_dict(table_name)
         target_table = table_dict.get('table_name') if not is_temporary else table_dict.get('temp_table_name')

--- a/pipelinewise/fastsync/mysql_to_postgres.py
+++ b/pipelinewise/fastsync/mysql_to_postgres.py
@@ -93,7 +93,6 @@ def sync_table(table):
         mysql.close_connections()
 
         # Creating temp table in Postgres
-        postgres.create_schema(target_schema)
         postgres.drop_table(target_schema, table, is_temporary=True)
         postgres.create_table(target_schema, table, postgres_columns, primary_key, is_temporary=True)
 
@@ -142,6 +141,11 @@ def main_impl():
             CPU cores                      : %s
         -------------------------------------------------------
         """, args.tables, len(args.tables), cpu_cores)
+
+    # Create target schemas sequentially, Postgres doesn't like it running in parallel
+    postgres = FastSyncTargetPostgres(args.target, args.transform)
+    for target_schema in utils.get_target_schemas(args.target, args.tables):
+        postgres.create_schema(target_schema)
 
     # Start loading tables in parallel in spawning processes by
     # utilising all available CPU cores

--- a/pipelinewise/fastsync/mysql_to_postgres.py
+++ b/pipelinewise/fastsync/mysql_to_postgres.py
@@ -143,9 +143,8 @@ def main_impl():
         """, args.tables, len(args.tables), cpu_cores)
 
     # Create target schemas sequentially, Postgres doesn't like it running in parallel
-    postgres = FastSyncTargetPostgres(args.target, args.transform)
-    for target_schema in utils.get_target_schemas(args.target, args.tables):
-        postgres.create_schema(target_schema)
+    postgres_target = FastSyncTargetPostgres(args.target, args.transform)
+    postgres_target.create_schemas(args.tables)
 
     # Start loading tables in parallel in spawning processes by
     # utilising all available CPU cores

--- a/pipelinewise/fastsync/postgres_to_postgres.py
+++ b/pipelinewise/fastsync/postgres_to_postgres.py
@@ -97,7 +97,6 @@ def sync_table(table):
         postgres.close_connection()
 
         # Creating temp table in Postgres
-        postgres_target.create_schema(target_schema)
         postgres_target.drop_table(target_schema, table, is_temporary=True)
         postgres_target.create_table(target_schema, table, postgres_target_columns, primary_key, is_temporary=True)
 
@@ -146,6 +145,11 @@ def main_impl():
             CPU cores                      : %s
         -------------------------------------------------------
         """, args.tables, len(args.tables), cpu_cores)
+
+    # Create target schemas sequentially, Postgres doesn't like it running in parallel
+    postgres = FastSyncTargetPostgres(args.target, args.transform)
+    for target_schema in utils.get_target_schemas(args.target, args.tables):
+        postgres.create_schema(target_schema)
 
     # Start loading tables in parallel in spawning processes by
     # utilising all available CPU cores

--- a/pipelinewise/fastsync/postgres_to_postgres.py
+++ b/pipelinewise/fastsync/postgres_to_postgres.py
@@ -147,9 +147,8 @@ def main_impl():
         """, args.tables, len(args.tables), cpu_cores)
 
     # Create target schemas sequentially, Postgres doesn't like it running in parallel
-    postgres = FastSyncTargetPostgres(args.target, args.transform)
-    for target_schema in utils.get_target_schemas(args.target, args.tables):
-        postgres.create_schema(target_schema)
+    postgres_target = FastSyncTargetPostgres(args.target, args.transform)
+    postgres_target.create_schemas(args.tables)
 
     # Start loading tables in parallel in spawning processes by
     # utilising all available CPU cores


### PR DESCRIPTION
## Description

Fix postgres-to-postgres and mysql-to-postgres fastsync compoents to create target schemas sequentially before syncing tables in parallel. This is to avoid a concurrency issues becase Postgres requires a complex locking mechanism for `CREATE SCHEMA IF NOT EXISTS` to run in parallel.

Tests included in PR https://github.com/transferwise/pipelinewise/pull/403

## Checklist

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
