### PR TITLE
[AP-692] Upload tap_s3_csv test input files to s3 automatically

### DIFF
--- a/dev-project/.env
+++ b/dev-project/.env
@@ -26,6 +26,8 @@ TAP_MYSQL_DB=mysql_source_db
 # IMPORTANT:
 #   S3 environment not provided by the docker test env.
 #   Please add real credentials otherwise the related tests will be ignored.
+#   The bucket needs to have a folder called ppw_e2e_tap_s3_csv and
+#   ListBucket, PutObject, DeleteObject and GetObject permissions on this folder
 # ------------------------------------------------------------------------------
 TAP_S3_CSV_AWS_KEY=
 TAP_S3_CSV_AWS_SECRET_ACCESS_KEY=

--- a/tests/end_to_end/helpers/env.py
+++ b/tests/end_to_end/helpers/env.py
@@ -338,7 +338,7 @@ class E2EEnv:
     def setup_tap_s3_csv(self):
         """Upload test input files to S3 to be prapared for test run"""
         mock_data_1 = os.path.join(DIR, '..', 'test-project', 's3_mock_data', 'mock_data_1.csv')
-        mock_data_2 = os.path.join(DIR, '..', 'test-project', 's3_mock_data', 'mock_data_1.csv')
+        mock_data_2 = os.path.join(DIR, '..', 'test-project', 's3_mock_data', 'mock_data_2.csv')
 
         bucket = self._get_conn_env_var('TAP_S3_CSV', 'BUCKET')
         s3 = boto3.client('s3',

--- a/tests/end_to_end/test-project/tap_s3_csv_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_s3_csv_to_pg.yml.template
@@ -48,7 +48,7 @@ schemas:
       - table_name: "people"
         replication_method: "FULL_TABLE"
         s3_csv_mapping:
-          search_pattern: "^greenhouse/mock_data_1.csv$"
+          search_pattern: "^ppw_e2e_tap_s3_csv/mock_data_1.csv$"
           date_overrides:
             - birth_date
         transformations:
@@ -59,5 +59,5 @@ schemas:
 
       - table_name: "countries"
         s3_csv_mapping:
-          search_pattern: "^greenhouse/mock_data_2.csv$"
+          search_pattern: "^ppw_e2e_tap_s3_csv/mock_data_2.csv$"
           key_properties: ["id"]

--- a/tests/end_to_end/test-project/tap_s3_csv_to_rs.yml.template
+++ b/tests/end_to_end/test-project/tap_s3_csv_to_rs.yml.template
@@ -48,7 +48,7 @@ schemas:
       - table_name: "people"
         replication_method: "FULL_TABLE"
         s3_csv_mapping:
-          search_pattern: "^greenhouse/mock_data_1.csv$"
+          search_pattern: "^ppw_e2e_tap_s3_csv/mock_data_1.csv$"
           date_overrides:
             - birth_date
         transformations:
@@ -59,5 +59,5 @@ schemas:
 
       - table_name: "countries"
         s3_csv_mapping:
-          search_pattern: "^greenhouse/mock_data_2.csv$"
+          search_pattern: "^ppw_e2e_tap_s3_csv/mock_data_2.csv$"
           key_properties: ["id"]

--- a/tests/end_to_end/test-project/tap_s3_csv_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_s3_csv_to_sf.yml.template
@@ -48,7 +48,7 @@ schemas:
       - table_name: "people"
         replication_method: "FULL_TABLE"
         s3_csv_mapping:
-          search_pattern: "^greenhouse/mock_data_1.csv$"
+          search_pattern: "^ppw_e2e_tap_s3_csv/mock_data_1.csv$"
           date_overrides:
             - birth_date
         transformations:
@@ -59,5 +59,5 @@ schemas:
 
       - table_name: "countries"
         s3_csv_mapping:
-          search_pattern: "^greenhouse/mock_data_2.csv$"
+          search_pattern: "^ppw_e2e_tap_s3_csv/mock_data_2.csv$"
           key_properties: ["id"]

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -44,7 +44,8 @@ class TestTargetSnowflake:
         # Setup and clean source and target databases
         self.e2e.setup_tap_mysql()
         self.e2e.setup_tap_postgres()
-        self.e2e.setup_tap_s3_csv()
+        if self.e2e.env['TAP_S3_CSV']['is_configured']:
+            self.e2e.setup_tap_s3_csv()
         self.e2e.setup_target_snowflake()
 
         # Import project

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -44,6 +44,7 @@ class TestTargetSnowflake:
         # Setup and clean source and target databases
         self.e2e.setup_tap_mysql()
         self.e2e.setup_tap_postgres()
+        self.e2e.setup_tap_s3_csv()
         self.e2e.setup_target_snowflake()
 
         # Import project


### PR DESCRIPTION
## Description

End to end tests expect test files on s3 to test tap_s3_csv. These files currently uploaded to s3 manually. This PR uploads the files automatically every time when the tests starting.

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
