### PR TITLE
[AP-645] Support reserved words as table and column names in Redshift

### DIFF
--- a/pipelinewise/fastsync/commons/target_redshift.py
+++ b/pipelinewise/fastsync/commons/target_redshift.py
@@ -178,8 +178,9 @@ class FastSyncTargetRedshift:
         if grantee:
             table_dict = utils.tablename_to_dict(table_name)
             target_table = table_dict.get('table_name') if not is_temporary else table_dict.get('temp_table_name')
-            sql = 'GRANT SELECT ON {}."{}" TO {} {}'.format(target_schema, target_table.upper(), 'GROUP' if to_group else '',
-                                                          grantee)
+            sql = 'GRANT SELECT ON {}."{}" TO {} {}'.format(target_schema,
+                                                            target_table.upper(), 'GROUP' if to_group else '',
+                                                            grantee)
             self.query(sql)
 
     def grant_usage_on_schema(self, target_schema, grantee, to_group=False):

--- a/pipelinewise/fastsync/mysql_to_redshift.py
+++ b/pipelinewise/fastsync/mysql_to_redshift.py
@@ -92,6 +92,7 @@ def sync_table(table):
 
         # Exporting table data, get table definitions and close connection to avoid timeouts
         mysql.copy_table(table, filepath)
+        size_bytes = os.path.getsize(filepath)
         redshift_types = mysql.map_column_types_to_target(table)
         redshift_columns = redshift_types.get('columns', [])
         primary_key = redshift_types.get('primary_key')
@@ -106,7 +107,7 @@ def sync_table(table):
         redshift.create_table(target_schema, table, redshift_columns, primary_key, is_temporary=True)
 
         # Load into Redshift table
-        redshift.copy_to_table(s3_key, target_schema, table, is_temporary=True)
+        redshift.copy_to_table(s3_key, target_schema, table, size_bytes, is_temporary=True)
 
         # Obfuscate columns
         redshift.obfuscate_columns(target_schema, table)

--- a/pipelinewise/fastsync/postgres_to_redshift.py
+++ b/pipelinewise/fastsync/postgres_to_redshift.py
@@ -95,6 +95,7 @@ def sync_table(table):
 
         # Exporting table data, get table definitions and close connection to avoid timeouts
         postgres.copy_table(table, filepath)
+        size_bytes = os.path.getsize(filepath)
         redshift_types = postgres.map_column_types_to_target(table)
         redshift_columns = redshift_types.get('columns', [])
         primary_key = redshift_types.get('primary_key')
@@ -109,7 +110,7 @@ def sync_table(table):
         redshift.create_table(target_schema, table, redshift_columns, primary_key, is_temporary=True)
 
         # Load into Redshift table
-        redshift.copy_to_table(s3_key, target_schema, table, is_temporary=True)
+        redshift.copy_to_table(s3_key, target_schema, table, size_bytes, is_temporary=True)
 
         # Obfuscate columns
         redshift.obfuscate_columns(target_schema, table)

--- a/pipelinewise/fastsync/postgres_to_redshift.py
+++ b/pipelinewise/fastsync/postgres_to_redshift.py
@@ -74,7 +74,7 @@ def tap_type_to_target_type(pg_type):
     }.get(pg_type, 'CHARACTER VARYING({})'.format(DEFAULT_VARCHAR_LENGTH))
 
 
-# pylint: disable=inconsistent-return-statements
+# pylint: disable=inconsistent-return-statements,too-many-locals
 def sync_table(table):
     """Sync one table"""
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)

--- a/singer-connectors/target-redshift/requirements.txt
+++ b/singer-connectors/target-redshift/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-redshift==1.3.0
+pipelinewise-target-redshift==1.4.0

--- a/tests/end_to_end/helpers/assertions.py
+++ b/tests/end_to_end/helpers/assertions.py
@@ -118,6 +118,11 @@ def _map_tap_to_target_functions(tap_query_runner_fn: callable, target_query_run
         'run_query_target_snowflake': {
             'target_sql_get_cols_fn': db.sql_get_columns_snowflake,
             'target_sql_dynamic_row_count_fn': db.sql_dynamic_row_count_snowflake,
+        },
+        # target-redshift specific attributes and functions
+        'run_query_target_redshift': {
+            'target_sql_get_cols_fn': db.sql_get_columns_redshift,
+            'target_sql_dynamic_row_count_fn': db.sql_dynamic_row_count_redshift,
         }
     }
 

--- a/tests/end_to_end/helpers/env.py
+++ b/tests/end_to_end/helpers/env.py
@@ -369,6 +369,10 @@ class E2EEnv:
         self.run_query_target_redshift('DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres_logical2 CASCADE')
         self.run_query_target_redshift('DROP SCHEMA IF EXISTS ppw_e2e_tap_mysql CASCADE')
         self.run_query_target_redshift('DROP SCHEMA IF EXISTS ppw_e2e_tap_s3_csv CASCADE')
+        self.run_query_target_redshift('DROP SCHEMA IF EXISTS ppw_e2e_helper CASCADE')
+        self.run_query_target_redshift('CREATE SCHEMA ppw_e2e_helper')
+        self.run_query_target_redshift('CREATE TABLE ppw_e2e_helper.dual (dummy VARCHAR)')
+        self.run_query_target_redshift('INSERT INTO ppw_e2e_helper.dual VALUES (\'X\')')
 
         # Clean config directory
         shutil.rmtree(os.path.join(CONFIG_DIR, 'redshift'), ignore_errors=True)

--- a/tests/end_to_end/test-project/tap_postgres_to_rs.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_rs.yml.template
@@ -87,17 +87,17 @@ schemas:
         replication_key: "cid"
 
   ### SOURCE SCHEMA 3: logical 1
-  - source_schema: "logical1"
-    target_schema: "ppw_e2e_tap_postgres_logical1"
-
-    tables:
-      - table_name: "logical1_table1"
-        replication_method: "LOG_BASED"
-      - table_name: "logical1_table2"
-      - table_name: "logical1_edgydata"
+  #- source_schema: "logical1"
+  #  target_schema: "ppw_e2e_tap_postgres_logical1"
+  #
+  #  tables:
+  #    - table_name: "logical1_table1"
+  #      replication_method: "LOG_BASED"
+  #    - table_name: "logical1_table2"
+  #    - table_name: "logical1_edgydata"
 
   ### SOURCE SCHEMA 4: logical2
-  - source_schema: "logical2"
-    target_schema: "ppw_e2e_tap_postgres_logical2"
-    tables:
-      - table_name: "logical2_table1"
+  #- source_schema: "logical2"
+  #  target_schema: "ppw_e2e_tap_postgres_logical2"
+  #  tables:
+  #    - table_name: "logical2_table1"


### PR DESCRIPTION
## Description

This PR syncs the target_snowflake fastsync functionalities to target_redshift and adds support to use reserved words as table and column names in Redshift.

It also syncs the end to end test cases. Since we have common test data and end-to-end test functions, the test cases in target_snowflake can run on target_redshift and target_postgres as well. 

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
