### PR TITLE
[AP-694] Add unit tests for fastsync components

### DIFF
--- a/pipelinewise/fastsync/mysql_to_redshift.py
+++ b/pipelinewise/fastsync/mysql_to_redshift.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 import logging
-import multiprocessing
 import os
 import sys
 import time
-from datetime import datetime
+from functools import partial
+from argparse import Namespace
+import multiprocessing
+from typing import Union
 
+from datetime import datetime
 from .commons import utils
 from .commons.tap_mysql import FastSyncTapMySql
 from .commons.target_redshift import FastSyncTargetRedshift
@@ -72,10 +75,8 @@ def tap_type_to_target_type(mysql_type, mysql_column_type):
     )
 
 
-# pylint: disable=inconsistent-return-statements
-def sync_table(table):
+def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     """Sync one table"""
-    args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     mysql = FastSyncTapMySql(args.tap, tap_type_to_target_type)
     redshift = FastSyncTargetRedshift(args.target, args.transform)
 
@@ -128,6 +129,8 @@ def sync_table(table):
         utils.grant_privilege(target_schema, grantees, redshift.grant_usage_on_schema)
         utils.grant_privilege(target_schema, grantees, redshift.grant_select_on_schema)
 
+        return True
+
     except Exception as exc:
         LOGGER.exception(exc)
         return '{}: {}'.format(table, exc)
@@ -159,7 +162,8 @@ def main_impl():
     # Start loading tables in parallel in spawning processes by
     # utilising all available CPU cores
     with multiprocessing.Pool(cpu_cores) as proc:
-        table_sync_excs = list(filter(None, proc.map(sync_table, args.tables)))
+        table_sync_excs = list(
+            filter(lambda x: not isinstance(x, bool), proc.map(partial(sync_table, args=args), args.tables)))
 
     # Log summary
     end_time = datetime.now()

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -3,7 +3,10 @@ import logging
 import os
 import sys
 import time
+from functools import partial
+from argparse import Namespace
 import multiprocessing
+from typing import Union
 
 from datetime import datetime
 from .commons import utils
@@ -67,10 +70,8 @@ def tap_type_to_target_type(mysql_type, mysql_column_type):
     }.get(mysql_type, 'VARCHAR')
 
 
-# pylint: disable=inconsistent-return-statements
-def sync_table(table):
+def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     """Sync one table"""
-    args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     mysql = FastSyncTapMySql(args.tap, tap_type_to_target_type)
     snowflake = FastSyncTargetSnowflake(args.target, args.transform)
 
@@ -124,6 +125,8 @@ def sync_table(table):
         utils.grant_privilege(target_schema, grantees, snowflake.grant_usage_on_schema)
         utils.grant_privilege(target_schema, grantees, snowflake.grant_select_on_schema)
 
+        return True
+
     except Exception as exc:
         LOGGER.exception(exc)
         return '{}: {}'.format(table, exc)
@@ -150,7 +153,8 @@ def main_impl():
     # Start loading tables in parallel in spawning processes by
     # utilising all available CPU cores
     with multiprocessing.Pool(cpu_cores) as proc:
-        table_sync_excs = list(filter(None, proc.map(sync_table, args.tables)))
+        table_sync_excs = list(
+            filter(lambda x: not isinstance(x, bool), proc.map(partial(sync_table, args=args), args.tables)))
 
     # Log summary
     end_time = datetime.now()

--- a/pipelinewise/fastsync/postgres_to_postgres.py
+++ b/pipelinewise/fastsync/postgres_to_postgres.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 import logging
-import multiprocessing
 import os
 import sys
 import time
-from datetime import datetime
+from functools import partial
+from argparse import Namespace
+import multiprocessing
+from typing import Union
 
+from datetime import datetime
 from .commons import utils
 from .commons.tap_postgres import FastSyncTapPostgres
 from .commons.target_postgres import FastSyncTargetPostgres
@@ -69,10 +72,8 @@ def tap_type_to_target_type(pg_type):
     }.get(pg_type, 'CHARACTER VARYING')
 
 
-# pylint: disable=inconsistent-return-statements
-def sync_table(table):
+def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     """Sync one table"""
-    args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     postgres = FastSyncTapPostgres(args.tap, tap_type_to_target_type)
     postgres_target = FastSyncTargetPostgres(args.target, args.transform)
 
@@ -123,6 +124,8 @@ def sync_table(table):
         utils.grant_privilege(target_schema, grantees, postgres_target.grant_usage_on_schema)
         utils.grant_privilege(target_schema, grantees, postgres_target.grant_select_on_schema)
 
+        return True
+
     except Exception as exc:
         LOGGER.exception(exc)
         return '{}: {}'.format(table, exc)
@@ -153,7 +156,8 @@ def main_impl():
     # Start loading tables in parallel in spawning processes by
     # utilising all available CPU cores
     with multiprocessing.Pool(cpu_cores) as proc:
-        table_sync_excs = list(filter(None, proc.map(sync_table, args.tables)))
+        table_sync_excs = list(
+            filter(lambda x: not isinstance(x, bool), proc.map(partial(sync_table, args=args), args.tables)))
 
     # Log summary
     end_time = datetime.now()

--- a/pipelinewise/fastsync/postgres_to_redshift.py
+++ b/pipelinewise/fastsync/postgres_to_redshift.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 import logging
-import multiprocessing
 import os
 import sys
 import time
+from functools import partial
+from argparse import Namespace
+import multiprocessing
+from typing import Union
 
 from datetime import datetime
-
 from .commons import utils
 from .commons.tap_postgres import FastSyncTapPostgres
 from .commons.target_redshift import FastSyncTargetRedshift
@@ -74,10 +76,9 @@ def tap_type_to_target_type(pg_type):
     }.get(pg_type, 'CHARACTER VARYING({})'.format(DEFAULT_VARCHAR_LENGTH))
 
 
-# pylint: disable=inconsistent-return-statements,too-many-locals
-def sync_table(table):
+# pylint: disable=too-many-locals
+def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     """Sync one table"""
-    args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     postgres = FastSyncTapPostgres(args.tap, tap_type_to_target_type)
     redshift = FastSyncTargetRedshift(args.target, args.transform)
 
@@ -131,6 +132,8 @@ def sync_table(table):
         utils.grant_privilege(target_schema, grantees, redshift.grant_usage_on_schema)
         utils.grant_privilege(target_schema, grantees, redshift.grant_select_on_schema)
 
+        return True
+
     except Exception as exc:
         LOGGER.exception(exc)
         return '{}: {}'.format(table, exc)
@@ -162,7 +165,8 @@ def main_impl():
     # Start loading tables in parallel in spawning processes by
     # utilising all available CPU cores
     with multiprocessing.Pool(cpu_cores) as proc:
-        table_sync_excs = list(filter(None, proc.map(sync_table, args.tables)))
+        table_sync_excs = list(
+            filter(lambda x: not isinstance(x, bool), proc.map(partial(sync_table, args=args), args.tables)))
 
     # Log summary
     end_time = datetime.now()

--- a/tests/units/fastsync/assertions.py
+++ b/tests/units/fastsync/assertions.py
@@ -1,0 +1,181 @@
+import pytest
+import collections
+import multiprocessing
+
+from unittest.mock import patch, Mock
+from argparse import Namespace
+
+
+FASTSYNC_NS = Namespace(
+    **{
+        'tap': {
+            'bucket': 'testBucket'
+        },
+        'properties': {},
+        'target': {},
+        'transform': {},
+        'temp_dir': '',
+        'state': '',
+    })
+
+
+def _create_object_names_to_mock(package_nm: str,
+                                 tap_class_nm: str,
+                                 target_class_nm: str):
+    """Function to generate dynamic object names"""
+    ObjectNames = collections.namedtuple('ObjectNames', ['full_tap_class_nm',
+                                                         'full_target_class_nm',
+                                                         'sync_table_fn_nm',
+                                                         'utils_module_nm',
+                                                         'multiproc_module_nm',
+                                                         'os_module_nm'])
+    return ObjectNames(full_tap_class_nm=f'{package_nm}.{tap_class_nm}',
+                       full_target_class_nm=f'{package_nm}.{target_class_nm}',
+                       sync_table_fn_nm=f'{package_nm}.sync_table',
+                       utils_module_nm=f'{package_nm}.utils',
+                       multiproc_module_nm=f'{package_nm}.multiprocessing',
+                       os_module_nm=f'{package_nm}.os')
+
+
+# pylint: disable=missing-function-docstring,unused-variable
+def assert_sync_table_returns_true_on_success(sync_table: callable,
+                                              package_nm: str,
+                                              tap_class_nm: str,
+                                              target_class_nm: str) -> None:
+    """Tests if fastsync sync table function returns true on success"""
+    objects_to_mock = _create_object_names_to_mock(package_nm, tap_class_nm, target_class_nm)
+
+    class LockMock:
+        """
+        Lock Mock
+        """
+        @staticmethod
+        def acquire():
+            print('Acquired lock')
+
+        @staticmethod
+        def release():
+            print('Released lock')
+
+    with patch(objects_to_mock.full_tap_class_nm) as tap_mock:
+        with patch(objects_to_mock.full_target_class_nm) as target_mock:
+            with patch(objects_to_mock.utils_module_nm) as utils_mock:
+                with patch(objects_to_mock.multiproc_module_nm) as multiproc_mock:
+                    with patch(objects_to_mock.os_module_nm) as os_mock:
+                        utils_mock.get_target_schema.return_value = 'my-target-schema'
+                        tap_mock.return_value.map_column_types_to_target.return_value = {
+                            'columns': ['id INTEGER', 'is_test SMALLINT', 'age INTEGER', 'name VARCHAR'],
+                            'primary_key': 'id,name'
+                        }
+
+                        target_mock.return_value.upload_to_s3.return_value = 's3_key'
+                        utils_mock.return_value.get_bookmark_for_table.return_value = {
+                            'modified_since': '2019-11-18'
+                        }
+                        utils_mock.return_value.get_grantees.return_value = ['role_1', 'role_2']
+                        utils_mock.return_value.get_bookmark_for_table.return_value = None
+
+                        multiproc_mock.lock.return_value = LockMock()
+
+                        res = sync_table('table_1', FASTSYNC_NS)
+
+                        assert isinstance(res, bool)
+                        assert res
+
+
+# pylint: disable=missing-function-docstring,unused-variable,invalid-name
+def assert_sync_table_exception_on_failed_copy(sync_table: callable,
+                                               package_nm: str,
+                                               tap_class_nm: str,
+                                               target_class_nm: str) -> None:
+    objects_to_mock = _create_object_names_to_mock(package_nm, tap_class_nm, target_class_nm)
+
+    with patch(objects_to_mock.full_tap_class_nm) as tap_mock:
+        with patch(objects_to_mock.full_target_class_nm) as target_mock:
+            with patch(objects_to_mock.utils_module_nm) as utils_mock:
+                with patch(objects_to_mock.multiproc_module_nm) as multiproc_mock:
+                    utils_mock.get_target_schema.return_value = 'my-target-schema'
+                    tap_mock.return_value.copy_table.side_effect = Exception('Boooom')
+
+                    assert sync_table('table_1', FASTSYNC_NS) == 'table_1: Boooom'
+
+                    utils_mock.get_target_schema.assert_called_once()
+                    tap_mock.return_value.copy_table.assert_called_once()
+
+
+# pylint: disable=missing-function-docstring,unused-variable,invalid-name
+def assert_main_impl_exit_normally_on_success(main_impl: callable,
+                                              package_nm: str,
+                                              tap_class_nm: str,
+                                              target_class_nm: str) -> None:
+    objects_to_mock = _create_object_names_to_mock(package_nm, tap_class_nm, target_class_nm)
+
+    with patch(objects_to_mock.utils_module_nm) as utils_mock:
+        with patch(objects_to_mock.full_target_class_nm) as target_mock:
+            with patch(objects_to_mock.sync_table_fn_nm) as sync_table_mock:
+                with patch(objects_to_mock.multiproc_module_nm) as multiproc_mock:
+                    ns = Namespace(**{
+                        'tables': ['table_1', 'table_2', 'table_3', 'table_4'],
+                        'target': 'sf',
+                        'transform': None
+                    })
+
+                    utils_mock.parse_args.return_value = ns
+                    utils_mock.get_cpu_cores.return_value = 10
+
+                    mock_enter = Mock()
+                    mock_enter.return_value.map.return_value = [True, True, True, True]
+
+                    pool_mock = Mock(spec_set=multiprocessing.Pool).return_value
+
+                    # to mock variable p in with statement, we need __enter__ and __exist__
+                    pool_mock.__enter__ = mock_enter
+                    pool_mock.__exit__ = Mock()
+                    multiproc_mock.Pool.return_value = pool_mock
+
+                    # call function
+                    main_impl()
+
+                    # assertions
+                    utils_mock.parse_args.assert_called_once()
+                    utils_mock.get_cpu_cores.assert_called_once()
+                    mock_enter.return_value.map.assert_called_once()
+
+
+# pylint: disable=missing-function-docstring,unused-variable,invalid-name
+def assert_main_impl_should_exit_with_error_on_failure(main_impl: callable,
+                                                       package_nm: str,
+                                                       tap_class_nm: str,
+                                                       target_class_nm: str) -> None:
+    objects_to_mock = _create_object_names_to_mock(package_nm, tap_class_nm, target_class_nm)
+
+    with patch(objects_to_mock.utils_module_nm) as utils_mock:
+        with patch(objects_to_mock.full_target_class_nm) as target_mock:
+            with patch(objects_to_mock.sync_table_fn_nm) as sync_table_mock:
+                with patch(objects_to_mock.multiproc_module_nm) as multiproc_mock:
+                    ns = Namespace(**{
+                        'tables': ['table_1', 'table_2', 'table_3', 'table_4'],
+                        'target': 'sf',
+                        'transform': None
+                    })
+
+                    utils_mock.parse_args.return_value = ns
+                    utils_mock.get_cpu_cores.return_value = 10
+
+                    mock_enter = Mock()
+                    mock_enter.return_value.map.return_value = [True, True, 'Critical: random error', True]
+
+                    pool_mock = Mock(spec_set=multiprocessing.Pool).return_value
+
+                    # to mock variable p in with statement, we need __enter__ and __exist__
+                    pool_mock.__enter__ = mock_enter
+                    pool_mock.__exit__ = Mock()
+                    multiproc_mock.Pool.return_value = pool_mock
+
+                    with pytest.raises(SystemExit):
+                        main_impl()
+
+                        # assertions
+                        utils_mock.parse_args.assert_called_once()
+                        utils_mock.get_cpu_cores.assert_called_once()
+                        mock_enter.return_value.map.assert_called_once()

--- a/tests/units/fastsync/commons/test_fastsync_tap_s3_csv.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_s3_csv.py
@@ -180,7 +180,7 @@ class TestFastSyncTapS3Csv(TestCase):
 
     def test_get_table_columns(self):
         output = list(
-            self.fs_tap_s3_csv._get_table_columns(f'{os.path.dirname(__file__)}/commons/resources/dummy_data.csv.gz'))
+            self.fs_tap_s3_csv._get_table_columns(f'{os.path.dirname(__file__)}/resources/dummy_data.csv.gz'))
 
         self.assertListEqual([
             ('Region', 'string'),
@@ -201,7 +201,7 @@ class TestFastSyncTapS3Csv(TestCase):
 
     def test_map_column_types_to_target(self):
         output = self.fs_tap_s3_csv.map_column_types_to_target(
-            f'{os.path.dirname(__file__)}/commons/resources/dummy_data.csv.gz', 'table 1')
+            f'{os.path.dirname(__file__)}/resources/dummy_data.csv.gz', 'table 1')
 
         self.assertDictEqual({
             'columns': [

--- a/tests/units/fastsync/test_mysql_to_postgres.py
+++ b/tests/units/fastsync/test_mysql_to_postgres.py
@@ -1,23 +1,23 @@
 import unittest
 from . import assertions
 
-from pipelinewise.fastsync.s3_csv_to_snowflake import tap_type_to_target_type, sync_table, main_impl
+from pipelinewise.fastsync.mysql_to_postgres import tap_type_to_target_type, sync_table, main_impl
 
-PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.s3_csv_to_snowflake'
-TAP = 'FastSyncTapS3Csv'
-TARGET = 'FastSyncTargetSnowflake'
+PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.mysql_to_postgres'
+TAP = 'FastSyncTapMySql'
+TARGET = 'FastSyncTargetPostgres'
 
 
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
 class S3CsvToPostgres(unittest.TestCase):
     """
-    Unit tests for fastsync s3 csv to snowflake
+    Unit tests for fastsync mysql to postgres
     """
     def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(self):
-        self.assertEqual('INTEGER', tap_type_to_target_type('integer'))
+        self.assertEqual('CHARACTER VARYING', tap_type_to_target_type('binary', None))
 
     def test_tap_type_to_target_type_with_undefined_tap_type_returns_CHARACTER_VARYING(self):
-        self.assertEqual('VARCHAR', tap_type_to_target_type('random-type'))
+        self.assertEqual('CHARACTER VARYING', tap_type_to_target_type('random-type', 'random-type'))
 
     @staticmethod
     def test_sync_table_runs_successfully_returns_true():

--- a/tests/units/fastsync/test_mysql_to_redshift.py
+++ b/tests/units/fastsync/test_mysql_to_redshift.py
@@ -1,23 +1,23 @@
 import unittest
 from . import assertions
 
-from pipelinewise.fastsync.s3_csv_to_snowflake import tap_type_to_target_type, sync_table, main_impl
+from pipelinewise.fastsync.mysql_to_redshift import tap_type_to_target_type, sync_table, main_impl
 
-PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.s3_csv_to_snowflake'
-TAP = 'FastSyncTapS3Csv'
-TARGET = 'FastSyncTargetSnowflake'
+PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.mysql_to_redshift'
+TAP = 'FastSyncTapMySql'
+TARGET = 'FastSyncTargetRedshift'
 
 
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
 class S3CsvToPostgres(unittest.TestCase):
     """
-    Unit tests for fastsync s3 csv to snowflake
+    Unit tests for fastsync mysql to redshift
     """
     def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(self):
-        self.assertEqual('INTEGER', tap_type_to_target_type('integer'))
+        self.assertEqual('CHARACTER VARYING(65535)', tap_type_to_target_type('binary', None))
 
     def test_tap_type_to_target_type_with_undefined_tap_type_returns_CHARACTER_VARYING(self):
-        self.assertEqual('VARCHAR', tap_type_to_target_type('random-type'))
+        self.assertEqual('CHARACTER VARYING(10000)', tap_type_to_target_type('random-type', 'random-type'))
 
     @staticmethod
     def test_sync_table_runs_successfully_returns_true():

--- a/tests/units/fastsync/test_mysql_to_snowflake.py
+++ b/tests/units/fastsync/test_mysql_to_snowflake.py
@@ -1,23 +1,23 @@
 import unittest
 from . import assertions
 
-from pipelinewise.fastsync.s3_csv_to_snowflake import tap_type_to_target_type, sync_table, main_impl
+from pipelinewise.fastsync.mysql_to_snowflake import tap_type_to_target_type, sync_table, main_impl
 
-PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.s3_csv_to_snowflake'
-TAP = 'FastSyncTapS3Csv'
+PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.mysql_to_snowflake'
+TAP = 'FastSyncTapMySql'
 TARGET = 'FastSyncTargetSnowflake'
 
 
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
 class S3CsvToPostgres(unittest.TestCase):
     """
-    Unit tests for fastsync s3 csv to snowflake
+    Unit tests for fastsync mysql to snowflake
     """
     def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(self):
-        self.assertEqual('INTEGER', tap_type_to_target_type('integer'))
+        self.assertEqual('BINARY', tap_type_to_target_type('binary', None))
 
     def test_tap_type_to_target_type_with_undefined_tap_type_returns_CHARACTER_VARYING(self):
-        self.assertEqual('VARCHAR', tap_type_to_target_type('random-type'))
+        self.assertEqual('VARCHAR', tap_type_to_target_type('random-type', 'random-type'))
 
     @staticmethod
     def test_sync_table_runs_successfully_returns_true():

--- a/tests/units/fastsync/test_postgres_to_postgres.py
+++ b/tests/units/fastsync/test_postgres_to_postgres.py
@@ -1,23 +1,23 @@
 import unittest
 from . import assertions
 
-from pipelinewise.fastsync.s3_csv_to_snowflake import tap_type_to_target_type, sync_table, main_impl
+from pipelinewise.fastsync.postgres_to_postgres import tap_type_to_target_type, sync_table, main_impl
 
-PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.s3_csv_to_snowflake'
-TAP = 'FastSyncTapS3Csv'
-TARGET = 'FastSyncTargetSnowflake'
+PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.postgres_to_postgres'
+TAP = 'FastSyncTapPostgres'
+TARGET = 'FastSyncTargetPostgres'
 
 
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
 class S3CsvToPostgres(unittest.TestCase):
     """
-    Unit tests for fastsync s3 csv to snowflake
+    Unit tests for postgres postgres to postgres
     """
     def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(self):
-        self.assertEqual('INTEGER', tap_type_to_target_type('integer'))
+        self.assertEqual('DOUBLE PRECISION', tap_type_to_target_type('serial'))
 
     def test_tap_type_to_target_type_with_undefined_tap_type_returns_CHARACTER_VARYING(self):
-        self.assertEqual('VARCHAR', tap_type_to_target_type('random-type'))
+        self.assertEqual('CHARACTER VARYING', tap_type_to_target_type('random-type'))
 
     @staticmethod
     def test_sync_table_runs_successfully_returns_true():

--- a/tests/units/fastsync/test_postgres_to_redshift.py
+++ b/tests/units/fastsync/test_postgres_to_redshift.py
@@ -1,23 +1,23 @@
 import unittest
 from . import assertions
 
-from pipelinewise.fastsync.s3_csv_to_snowflake import tap_type_to_target_type, sync_table, main_impl
+from pipelinewise.fastsync.postgres_to_redshift import tap_type_to_target_type, sync_table, main_impl
 
-PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.s3_csv_to_snowflake'
-TAP = 'FastSyncTapS3Csv'
-TARGET = 'FastSyncTargetSnowflake'
+PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.postgres_to_redshift'
+TAP = 'FastSyncTapPostgres'
+TARGET = 'FastSyncTargetRedshift'
 
 
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
 class S3CsvToPostgres(unittest.TestCase):
     """
-    Unit tests for fastsync s3 csv to snowflake
+    Unit tests for postgres postgres to redshift
     """
     def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(self):
-        self.assertEqual('INTEGER', tap_type_to_target_type('integer'))
+        self.assertEqual('NUMERIC NULL', tap_type_to_target_type('serial'))
 
     def test_tap_type_to_target_type_with_undefined_tap_type_returns_CHARACTER_VARYING(self):
-        self.assertEqual('VARCHAR', tap_type_to_target_type('random-type'))
+        self.assertEqual('CHARACTER VARYING(10000)', tap_type_to_target_type('random-type'))
 
     @staticmethod
     def test_sync_table_runs_successfully_returns_true():

--- a/tests/units/fastsync/test_postgres_to_snowflake.py
+++ b/tests/units/fastsync/test_postgres_to_snowflake.py
@@ -1,20 +1,20 @@
 import unittest
 from . import assertions
 
-from pipelinewise.fastsync.s3_csv_to_snowflake import tap_type_to_target_type, sync_table, main_impl
+from pipelinewise.fastsync.postgres_to_snowflake import tap_type_to_target_type, sync_table, main_impl
 
-PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.s3_csv_to_snowflake'
-TAP = 'FastSyncTapS3Csv'
+PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.postgres_to_snowflake'
+TAP = 'FastSyncTapPostgres'
 TARGET = 'FastSyncTargetSnowflake'
 
 
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
 class S3CsvToPostgres(unittest.TestCase):
     """
-    Unit tests for fastsync s3 csv to snowflake
+    Unit tests for fastsync postgres to snowflake
     """
     def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(self):
-        self.assertEqual('INTEGER', tap_type_to_target_type('integer'))
+        self.assertEqual('NUMBER', tap_type_to_target_type('serial'))
 
     def test_tap_type_to_target_type_with_undefined_tap_type_returns_CHARACTER_VARYING(self):
         self.assertEqual('VARCHAR', tap_type_to_target_type('random-type'))

--- a/tests/units/fastsync/test_s3_csv_to_postgres.py
+++ b/tests/units/fastsync/test_s3_csv_to_postgres.py
@@ -1,23 +1,23 @@
 import unittest
 from . import assertions
 
-from pipelinewise.fastsync.s3_csv_to_snowflake import tap_type_to_target_type, sync_table, main_impl
+from pipelinewise.fastsync.s3_csv_to_postgres import tap_type_to_target_type, sync_table, main_impl
 
-PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.s3_csv_to_snowflake'
+PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.s3_csv_to_postgres'
 TAP = 'FastSyncTapS3Csv'
-TARGET = 'FastSyncTargetSnowflake'
+TARGET = 'FastSyncTargetPostgres'
 
 
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
 class S3CsvToPostgres(unittest.TestCase):
     """
-    Unit tests for fastsync s3 csv to snowflake
+    Unit tests for fastsync s3 csv to postgres
     """
     def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(self):
-        self.assertEqual('INTEGER', tap_type_to_target_type('integer'))
+        self.assertEqual('DOUBLE PRECISION', tap_type_to_target_type('number'))
 
     def test_tap_type_to_target_type_with_undefined_tap_type_returns_CHARACTER_VARYING(self):
-        self.assertEqual('VARCHAR', tap_type_to_target_type('random-type'))
+        self.assertEqual('CHARACTER VARYING', tap_type_to_target_type('random-type'))
 
     @staticmethod
     def test_sync_table_runs_successfully_returns_true():


### PR DESCRIPTION
## Description

This PR adds unit tests for every fastsync component by reusing the existing `s3-csv-to-snowflake.py`.

Some minor refactoring applied in some fastsync components as well. This allows to reuse the existing test cases and it gives the same behaviour to every fastsync executable.

The fastsync components and unit tests are very similar. Would be great removing the duplicates in the fastsync executables by creating base class for common fastsync functionalities. This exercise is not part of this PR. 

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
