### PR TITLE
Decrease timeout to set-up for better testing

### DIFF
--- a/dev-project/pipelinewise-config/tap_postgres_logical.yml
+++ b/dev-project/pipelinewise-config/tap_postgres_logical.yml
@@ -14,6 +14,10 @@ owner: "somebody@foo.com"              # Data owner to contact
 # ------------------------------------------------------------------------------
 db_conn:
   host: "db_postgres_source"
+  logical_poll_total_seconds: 3        # seconds before exiting if no changes received from source
+                                       #    Warning: this can cause a tap to exit before receiving any
+                                       #    data, because PostgreSQL can take a long time to find the
+                                       #    position of the start lsn in the wal file.
   port: 5432                           # PostgreSQL port
   user: "pipelinewise"                 # PostfreSQL user
   password: "secret"                   # Plain string or vault encrypted

--- a/tests/end_to_end/test-project/tap_postgres_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_pg.yml.template
@@ -14,6 +14,7 @@ owner: "test-runner"
 # ------------------------------------------------------------------------------
 db_conn:
   host: "${TAP_POSTGRES_HOST}"          # PostgreSQL host
+  logical_poll_total_seconds: 3         # Time out if no LOG_BASED changes received for 3 seconds
   port: ${TAP_POSTGRES_PORT}            # PostgreSQL port
   user: "${TAP_POSTGRES_USER}"          # PostgreSQL user
   password: "${TAP_POSTGRES_PASSWORD}"  # Plain string or vault encrypted

--- a/tests/end_to_end/test-project/tap_postgres_to_rs.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_rs.yml.template
@@ -14,6 +14,7 @@ owner: "test-runner"
 # ------------------------------------------------------------------------------
 db_conn:
   host: "${TAP_POSTGRES_HOST}"          # PostgreSQL host
+  logical_poll_total_seconds: 3         # Time out if no LOG_BASED changes received for 3 seconds
   port: ${TAP_POSTGRES_PORT}            # PostgreSQL port
   user: "${TAP_POSTGRES_USER}"          # PostgreSQL user
   password: "${TAP_POSTGRES_PASSWORD}"  # Plain string or vault encrypted

--- a/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
@@ -14,6 +14,7 @@ owner: "test-runner"
 # ------------------------------------------------------------------------------
 db_conn:
   host: "${TAP_POSTGRES_HOST}"          # PostgreSQL host
+  logical_poll_total_seconds: 3         # Time out if no LOG_BASED changes received for 3 seconds
   port: ${TAP_POSTGRES_PORT}            # PostgreSQL port
   user: "${TAP_POSTGRES_USER}"          # PostgreSQL user
   password: "${TAP_POSTGRES_PASSWORD}"  # Plain string or vault encrypted


### PR DESCRIPTION
## Description

Decrease timeout of tap-postgres logical example to set-up for better testing.
Currently, automatically testing LOG_BASED is difficult due to this excessive timeout.

## Checklist

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [ ] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
