### PR TITLE
[AP-372] Add optional session_sqls connection parameter

### DIFF
--- a/docs/connectors/taps/mysql.rst
+++ b/docs/connectors/taps/mysql.rst
@@ -111,6 +111,11 @@ Example YAML for ``tap-mysql``:
                                          #           data extraction
     #export_batch_rows                   # Optional: Number of rows to export from MySQL
                                          #           in one batch. Default is 20000.
+    #session_sqls:                       # Optional: Run SQLs to set session variables
+    #  - SET @@session.time_zone="+0:00"             # when the connection made
+    #  - SET @@session.wait_timeout=28800            # Defaults to the values listed here
+    #  - SET @@session.net_read_timeout=3600
+    #  - SET @@session.innodb_lock_wait_timeout=3600
 
 
   # ------------------------------------------------------------------------------

--- a/pipelinewise/fastsync/commons/tap_mysql.py
+++ b/pipelinewise/fastsync/commons/tap_mysql.py
@@ -12,6 +12,13 @@ from ...utils import safe_column_name
 
 LOGGER = logging.getLogger(__name__)
 
+DEFAULT_CHARSET = 'utf8'
+DEFAULT_EXPORT_BATCH_ROWS = 50000
+DEFAULT_SESSION_SQLS = ['SET @@session.time_zone="+0:00"',
+                        'SET @@session.wait_timeout=28800',
+                        'SET @@session.net_read_timeout=3600',
+                        'SET @@session.innodb_lock_wait_timeout=3600']
+
 
 class FastSyncTapMySql:
     """
@@ -20,8 +27,10 @@ class FastSyncTapMySql:
 
     def __init__(self, connection_config, tap_type_to_target_type):
         self.connection_config = connection_config
-        self.connection_config['charset'] = connection_config.get('charset', 'utf8')
-        self.connection_config['export_batch_rows'] = connection_config.get('export_batch_rows', 50000)
+        self.connection_config['charset'] = connection_config.get('charset', DEFAULT_CHARSET)
+        self.connection_config['export_batch_rows'] = connection_config.get('export_batch_rows',
+                                                                            DEFAULT_EXPORT_BATCH_ROWS)
+        self.connection_config['session_sqls'] = connection_config.get('session_sqls', DEFAULT_SESSION_SQLS)
         self.tap_type_to_target_type = tap_type_to_target_type
         self.conn = None
         self.conn_unbuffered = None
@@ -55,6 +64,24 @@ class FastSyncTapMySql:
             charset=self.connection_config['charset'],
             cursorclass=pymysql.cursors.SSCursor)
 
+        # Set session variables by running a list of SQLs which is defined
+        # in the optional session_sqls connection parameters
+        self.run_session_sqls()
+
+    def run_session_sqls(self):
+        """
+        Run list of SQLs from the "session_sqls" optional connection parameter
+        """
+        session_sqls = self.connection_config.get('session_sqls', DEFAULT_SESSION_SQLS)
+
+        if session_sqls and isinstance(session_sqls, list):
+            for sql in session_sqls:
+                try:
+                    self.query(sql)
+                    self.query(sql, self.conn_unbuffered)
+                except pymysql.err.InternalError:
+                    LOGGER.info('Could not set session variable: %s', sql)
+
     def close_connections(self, silent=False):
         """
         Close connection
@@ -67,13 +94,17 @@ class FastSyncTapMySql:
                 LOGGER.exception(exc)
                 LOGGER.info('Connections seem to be already closed.')
 
-    def query(self, query, params=None, return_as_cursor=False, n_retry=1):
+    # pylint: disable=too-many-arguments
+    def query(self, query, conn=None, params=None, return_as_cursor=False, n_retry=1):
         """
         Run query
         """
         LOGGER.info('Running query: %s', query)
+        if conn is None:
+            conn = self.conn
+
         try:
-            with self.conn as cur:
+            with conn as cur:
                 cur.execute(query, params)
 
                 if return_as_cursor:

--- a/pipelinewise/fastsync/commons/tap_mysql.py
+++ b/pipelinewise/fastsync/commons/tap_mysql.py
@@ -74,13 +74,19 @@ class FastSyncTapMySql:
         """
         session_sqls = self.connection_config.get('session_sqls', DEFAULT_SESSION_SQLS)
 
+        warnings = []
         if session_sqls and isinstance(session_sqls, list):
             for sql in session_sqls:
                 try:
                     self.query(sql)
                     self.query(sql, self.conn_unbuffered)
                 except pymysql.err.InternalError:
-                    LOGGER.info('Could not set session variable: %s', sql)
+                    warnings.append(f'Could not set session variable: {sql}')
+
+        if warnings:
+            LOGGER.warning('Encountered non-fatal errors when configuring session that could impact performance:')
+        for warning in warnings:
+            LOGGER.warning(warning)
 
     def close_connections(self, silent=False):
         """

--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mysql==1.2.0
+pipelinewise-tap-mysql==1.3.0

--- a/tests/units/fastsync/commons/test_fastsync_tap_mysql.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_mysql.py
@@ -1,0 +1,89 @@
+from unittest import TestCase
+from unittest.mock import patch
+import pymysql
+
+import pipelinewise.fastsync.commons.tap_mysql as tap_mysql
+from pipelinewise.fastsync.commons.tap_mysql import FastSyncTapMySql
+
+
+class FastSyncTapMySqlMock(FastSyncTapMySql):
+    """
+    Mocked FastSyncTapMySql class
+    """
+    def __init__(self, connection_config, tap_type_to_target_type=None):
+        super().__init__(connection_config, tap_type_to_target_type)
+
+        self.executed_queries_unbuffered = []
+        self.executed_queries = []
+
+    # pylint: disable=too-many-arguments
+    def query(self, query, conn=None, params=None, return_as_cursor=False, n_retry=1):
+        if query.startswith('INVALID-SQL'):
+            raise pymysql.err.InternalError
+
+        if conn == self.conn_unbuffered:
+            self.executed_queries.append(query)
+        else:
+            self.executed_queries_unbuffered.append(query)
+
+        return []
+
+
+# pylint: disable=invalid-name,no-self-use
+class TestFastSyncTapMySql(TestCase):
+    """
+    Unit tests for fastsync tap mysql
+    """
+    def setUp(self) -> None:
+        """Initialise test FastSyncTapPostgres object"""
+        self.connection_config = {'host': 'foo.com',
+                                  'port': 3306,
+                                  'user': 'my_user',
+                                  'password': 'secret',
+                                  'dbname': 'my_db'}
+        self.mysql = None
+
+    def test_open_connections_with_default_session_sqls(self):
+        """Default session parameters should be applied if no custom session SQLs"""
+        self.mysql = FastSyncTapMySqlMock(connection_config=self.connection_config)
+        with patch('pymysql.connect') as mysql_connect_mock:
+            mysql_connect_mock.return_value = []
+            self.mysql.open_connections()
+
+        # Test if session variables applied on both connections
+        assert self.mysql.executed_queries == tap_mysql.DEFAULT_SESSION_SQLS
+        assert self.mysql.executed_queries_unbuffered == self.mysql.executed_queries
+
+    def test_open_connections_with_session_sqls(self):
+        """Custom session parameters should be applied if defined"""
+        session_sqls = [
+            'SET SESSION max_statement_time=0',
+            'SET SESSION wait_timeout=28800'
+        ]
+        self.mysql = FastSyncTapMySqlMock(connection_config={**self.connection_config,
+                                                             **{'session_sqls': session_sqls}})
+        with patch('pymysql.connect') as mysql_connect_mock:
+            mysql_connect_mock.return_value = []
+            self.mysql.open_connections()
+
+        # Test if session variables applied on both connections
+        assert self.mysql.executed_queries == session_sqls
+        assert self.mysql.executed_queries_unbuffered == self.mysql.executed_queries
+
+    def test_open_connections_with_invalid_session_sqls(self):
+        """Invalid SQLs in session_sqls should be ignored"""
+        session_sqls = [
+            'SET SESSION max_statement_time=0',
+            'INVALID-SQL-SHOULD-BE-SILENTLY-IGNORED',
+            'SET SESSION wait_timeout=28800'
+        ]
+        self.mysql = FastSyncTapMySqlMock(connection_config={**self.connection_config,
+                                                             **{'session_sqls': session_sqls}})
+        with patch('pymysql.connect') as mysql_connect_mock:
+            mysql_connect_mock.return_value = []
+            self.mysql.open_connections()
+
+        # Test if session variables applied on both connections
+        assert self.mysql.executed_queries == ['SET SESSION max_statement_time=0',
+                                               'SET SESSION wait_timeout=28800']
+        assert self.mysql.executed_queries_unbuffered == self.mysql.executed_queries


### PR DESCRIPTION
## Description

This PR is getting an optional `session_sqls` parameter from the connection config and running each of them automatically right after the mysql/mariadb connection has made.

Using this approach we don't hardcode session parameters, every tap can have different values and we support different different session parameter names used by the different version of mariadb/mysql.

```
id: "tap_id"
name: "Example Tap"
type: "tap-mysql"
owner: "someone"
sync_period: "*/5 * * * *"
db_conn:
  host: "localhost"
  port: 3306
  user: my_user
  password: secret
  dbname: "my_db"
  session_sqls:
    - SET SESSION max_statement_time=0
    - SET SESSION wait_timeout=28800
    - ... some more SQL ...
``` 

This PR is inline with https://github.com/transferwise/pipelinewise-tap-mysql/pull/19

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
