### PR TITLE
[AP-700] Fixed an issue when JSON type columns not loaded correctly

### DIFF
--- a/pipelinewise/fastsync/mysql_to_postgres.py
+++ b/pipelinewise/fastsync/mysql_to_postgres.py
@@ -63,6 +63,7 @@ def tap_type_to_target_type(mysql_type, mysql_column_type):
         'date': 'TIMESTAMP WITHOUT TIME ZONE',
         'datetime': 'TIMESTAMP WITHOUT TIME ZONE',
         'timestamp': 'TIMESTAMP WITHOUT TIME ZONE',
+        'json': 'JSONB'
     }.get(
         mysql_type,
         'CHARACTER VARYING',

--- a/pipelinewise/fastsync/mysql_to_redshift.py
+++ b/pipelinewise/fastsync/mysql_to_redshift.py
@@ -69,6 +69,7 @@ def tap_type_to_target_type(mysql_type, mysql_column_type):
         'date': 'TIMESTAMP WITHOUT TIME ZONE',
         'datetime': 'TIMESTAMP WITHOUT TIME ZONE',
         'timestamp': 'TIMESTAMP WITHOUT TIME ZONE',
+        'json': 'CHARACTER VARYING({})'.format(LONG_VARCHAR_LENGTH)
     }.get(
         mysql_type,
         'CHARACTER VARYING({})'.format(DEFAULT_VARCHAR_LENGTH),

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -67,6 +67,7 @@ def tap_type_to_target_type(mysql_type, mysql_column_type):
         'date': 'TIMESTAMP_NTZ',
         'datetime': 'TIMESTAMP_NTZ',
         'timestamp': 'TIMESTAMP_NTZ',
+        'json': 'VARIANT'
     }.get(mysql_type, 'VARCHAR')
 
 

--- a/singer-connectors/tap-postgres/requirements.txt
+++ b/singer-connectors/tap-postgres/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-postgres==1.6.1
+pipelinewise-tap-postgres==1.6.2

--- a/tests/db/tap_mysql_data.sql
+++ b/tests/db/tap_mysql_data.sql
@@ -27,7 +27,8 @@ CREATE TABLE `edgydata` (
   `order` int(11) PRIMARY KEY AUTO_INCREMENT,
   `c_varchar` varchar(128),
   `group` int,
-  `case` varchar(1)
+  `case` varchar(1),
+  `cjson` json
 ) ENGINE=MyISAM AUTO_INCREMENT=1001 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -38,16 +39,16 @@ CREATE TABLE `edgydata` (
 LOCK TABLES `edgydata` WRITE;
 /*!40000 ALTER TABLE `edgydata` DISABLE KEYS */;
 INSERT INTO `edgydata` VALUES
-  (1, 'Lorem ipsum dolor sit amet', 10, 'A'),
-  (2, 'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช', 20, 'A'),
-  (3, 'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.', null, 'B'),
-  (4, 'Special Characters: ["\\,''!@£$%^&*()]\\\\', null, 'B'),
-  (5, '	', 20, 'B'),
+  (1, 'Lorem ipsum dolor sit amet', 10, 'A', '[]'),
+  (2, 'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช', 20, 'A', '{}'),
+  (3, 'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.', null, 'B', '[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]'),
+  (4, 'Special Characters: ["\\,''!@£$%^&*()]\\\\', null, 'B', null),
+  (5, '	', 20, 'B', null),
   (6,'Enter	The
-Ninja', 10, 'A'),
+Ninja', 10, 'A', null),
   (7,'Liewe
-Maatjies', 20, 'A'),
-  (8,'Liewe	Maatjies', 10, null)
+Maatjies', 20, 'A', null),
+  (8,'Liewe	Maatjies', 10, null, '[{"key": "Value''s One", "actions": []},{"key": "Value\U00000027s Two", "actions": []}]')
 ;
 
 /*!40000 ALTER TABLE `edgydata` ENABLE KEYS */;

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -90,7 +90,10 @@ class TestTargetPostgres:
         #  INCREMENTAL
         self.run_query_tap_postgres('INSERT INTO public.city (id, name, countrycode, district, population) '
                                     "VALUES (4080, 'Bath', 'GBR', 'England', 88859)")
-        self.run_query_tap_postgres("UPDATE public.edgydata SET cvarchar = 'Liewe Maatjies UPDATED' WHERE cid = 23")
+        self.run_query_tap_postgres("UPDATE public.edgydata SET "
+                                    "cjson = json '{\"data\": 1234}', "
+                                    "cjsonb = jsonb '{\"data\": 2345}', "
+                                    "cvarchar = 'Liewe Maatjies UPDATED' WHERE cid = 23")
         #  FULL_TABLE
         self.run_query_tap_postgres("DELETE FROM public.country WHERE code = 'UMI'")
 

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -90,7 +90,7 @@ class TestTargetPostgres:
         #  INCREMENTAL
         self.run_query_tap_postgres('INSERT INTO public.city (id, name, countrycode, district, population) '
                                     "VALUES (4080, 'Bath', 'GBR', 'England', 88859)")
-        self.run_query_tap_postgres("UPDATE public.edgydata SET "
+        self.run_query_tap_postgres('UPDATE public.edgydata SET '
                                     "cjson = json '{\"data\": 1234}', "
                                     "cjsonb = jsonb '{\"data\": 2345}', "
                                     "cvarchar = 'Liewe Maatjies UPDATED' WHERE cid = 23")

--- a/tests/end_to_end/test_target_redshift.py
+++ b/tests/end_to_end/test_target_redshift.py
@@ -90,7 +90,7 @@ class TestTargetRedshift:
         #  INCREMENTAL
         self.run_query_tap_postgres('INSERT INTO public.city (id, name, countrycode, district, population) '
                                     "VALUES (4080, 'Bath', 'GBR', 'England', 88859)")
-        self.run_query_tap_postgres("UPDATE public.edgydata SET "
+        self.run_query_tap_postgres('UPDATE public.edgydata SET '
                                     "cjson = json '{\"data\": 1234}', "
                                     "cjsonb = jsonb '{\"data\": 2345}', "
                                     "cvarchar = 'Liewe Maatjies UPDATED' WHERE cid = 23")

--- a/tests/end_to_end/test_target_redshift.py
+++ b/tests/end_to_end/test_target_redshift.py
@@ -90,7 +90,10 @@ class TestTargetRedshift:
         #  INCREMENTAL
         self.run_query_tap_postgres('INSERT INTO public.city (id, name, countrycode, district, population) '
                                     "VALUES (4080, 'Bath', 'GBR', 'England', 88859)")
-        self.run_query_tap_postgres("UPDATE public.edgydata SET cvarchar = 'Liewe Maatjies UPDATED' WHERE cid = 23")
+        self.run_query_tap_postgres("UPDATE public.edgydata SET "
+                                    "cjson = json '{\"data\": 1234}', "
+                                    "cjsonb = jsonb '{\"data\": 2345}', "
+                                    "cvarchar = 'Liewe Maatjies UPDATED' WHERE cid = 23")
         #  FULL_TABLE
         self.run_query_tap_postgres("DELETE FROM public.country WHERE code = 'UMI'")
 

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -90,7 +90,7 @@ class TestTargetSnowflake:
         #  INCREMENTAL
         self.run_query_tap_postgres('INSERT INTO public.city (id, name, countrycode, district, population) '
                                     "VALUES (4080, 'Bath', 'GBR', 'England', 88859)")
-        self.run_query_tap_postgres("UPDATE public.edgydata SET "
+        self.run_query_tap_postgres('UPDATE public.edgydata SET '
                                     "cjson = json '{\"data\": 1234}', "
                                     "cjsonb = jsonb '{\"data\": 2345}', "
                                     "cvarchar = 'Liewe Maatjies UPDATED' WHERE cid = 23")

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -90,7 +90,10 @@ class TestTargetSnowflake:
         #  INCREMENTAL
         self.run_query_tap_postgres('INSERT INTO public.city (id, name, countrycode, district, population) '
                                     "VALUES (4080, 'Bath', 'GBR', 'England', 88859)")
-        self.run_query_tap_postgres("UPDATE public.edgydata SET cvarchar = 'Liewe Maatjies UPDATED' WHERE cid = 23")
+        self.run_query_tap_postgres("UPDATE public.edgydata SET "
+                                    "cjson = json '{\"data\": 1234}', "
+                                    "cjsonb = jsonb '{\"data\": 2345}', "
+                                    "cvarchar = 'Liewe Maatjies UPDATED' WHERE cid = 23")
         #  FULL_TABLE
         self.run_query_tap_postgres("DELETE FROM public.country WHERE code = 'UMI'")
 


### PR DESCRIPTION
## Description

Fixed an issue when JSON type columns not loaded correctly into target databases.

The PR bumps `pipelinewise-tap-postgres` to 1.6.2 to include the main fix and extending the end to end tests suite to load JSON data from tap-mysql, tap-postgres to target-snowfake, target-postgres and target-redshift.



## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
