### PR TITLE
[AP-XXXX] Bump python docker base images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ references:
   container_config: &container_config
     docker:
       # Main python container
-      - image: circleci/python:3.7.4
+      - image: circleci/python:3.7.7
         environment:
           TAP_MYSQL_HOST: db_mysql_source
           TAP_MYSQL_PORT: 3306
@@ -113,7 +113,7 @@ jobs:
   # GH_TOKEN (the personal Git token with pushes enabled)
   deploy-doc:
     docker:
-      - image: circleci/python:3.7.4
+      - image: circleci/python:3.7.7
     working_directory: ~/gh_doc_automation
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-buster
+FROM python:3.7.7-slim-buster
 
 RUN apt-get -qq update && apt-get -qqy install \
         apt-utils \


### PR DESCRIPTION
## Description

This PR is a minor improvement to bump the docker images from 3.7.4 to the latest 3.7.7.

At the same time it's switching to use the python **slim** buster image when running PPW from 
Docker. The slimified python image removing extra files that are normally not necessary within containers, such as man pages and documentation, resulting a much smaller image size but keeping the same runtime libraries.

## Checklist

- [X] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [X] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [X] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [ ] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
