### PR TITLE
[AP-639] Fix install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -175,8 +175,8 @@ DEFAULT_CONNECTORS=(
     target-snowflake
     target-redshift
     target-postgres
-    transform-field,
-    tap-mongodb,
+    transform-field
+    tap-mongodb
 )
 EXTRA_CONNECTORS=(
     tap-adwords


### PR DESCRIPTION
## Description

Circleci on master is currently failing when it's building and publishing the Docker image. Seems like the reason is a syntax error when trying to install the connectors into the image

## Checklist

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
