### PR TITLE
Fix target-postgres port number in dev env

### DIFF
--- a/dev-project/pipelinewise-config/target_postgres.yml
+++ b/dev-project/pipelinewise-config/target_postgres.yml
@@ -13,7 +13,7 @@ type: "target-postgres"                # !! THIS SHOULD NOT CHANGE !!
 # ------------------------------------------------------------------------------
 db_conn:
   host: "db_postgres_dwh"
-  port: 5433                              # Postgres port
+  port: 5432                              # Postgres port
   user: "pipelinewise"                    # Postgres user
   password: "secret"                      # Plain string or vault encrypted
   dbname: "postgres_dwh"                  # Postgres database name


### PR DESCRIPTION
## Description

`target_postgres.yaml` in the dev project is currently using a wrong port number and manual PPW commands when working with target_postgres in the dev env currently gives error messages. This PR fixing it.

The port number accidentally changed by PR #403. Unit and end-to-end tests are not affected, e2e tests using different, dynamically generated YAML files, hence circleci didn't detect the wrong config.

## Checklist

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [ ] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
