### PR TITLE
[AP-689] Disable incremental for tap_mongodb

### DIFF
--- a/pipelinewise/cli/schemas/tap.json
+++ b/pipelinewise/cli/schemas/tap.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "schema": {
       "type": "object",
@@ -134,6 +135,45 @@
       "required": [
         "search_pattern"
       ]
+    },
+    "tap_mongo_implies_ft_and_lb": {
+      "anyOf": [
+        {
+          "not": {"$ref": "#/definitions/tap_mongo"}
+        },
+        {
+          "properties": {
+            "schemas": {
+            "type": "array",
+            "items": {
+              "properties": {
+                "tables": {
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "replication_method": {
+                        "enum": ["LOG_BASED", "FULL_TABLE"]
+                      }
+                    },
+                    "required": ["replication_method"]
+                  }
+                }
+              },
+              "required": ["tables"]
+            }
+          }
+          },
+          "required": ["schemas"]
+        }
+      ]
+    },
+    "tap_mongo": {
+      "properties": {
+        "type": {
+          "enum": ["tap-mongodb"]
+        }
+      },
+      "required": ["type"]
     }
   },
   "type": "object",
@@ -180,6 +220,11 @@
       }
     }
   },
+  "allOf": [
+    {
+      "$ref": "#/definitions/tap_mongo_implies_ft_and_lb"
+    }
+  ],
   "required": [
     "id",
     "name",

--- a/tests/units/cli/resources/test_invalid_tap_mongo_yaml_config/tap_test_invalid_replication_method.yml
+++ b/tests/units/cli/resources/test_invalid_tap_mongo_yaml_config/tap_test_invalid_replication_method.yml
@@ -1,0 +1,27 @@
+---
+
+id: "mysql_sample"
+name: "Sample MySQL Database"
+type: "tap-mongodb"
+owner: "somebody@foo.com"
+
+
+db_conn:
+  host: "<HOST>"
+  port: 3306
+  user: "<USER>"
+  password: "<PASSWORD>"
+  dbname: "<DB_NAME>"
+
+target: "test_snowflake_target"
+batch_size_rows: 20000
+
+schemas:
+  - source_schema: "my_db"
+    target_schema: "repl_my_db"
+    target_schema_select_permissions:
+      - grp_stats
+
+    tables:
+      - table_name: "table_one"
+        replication_method: "INCREMENTAL"

--- a/tests/units/cli/resources/test_invalid_tap_mongo_yaml_config/target_test.yml
+++ b/tests/units/cli/resources/test_invalid_tap_mongo_yaml_config/target_test.yml
@@ -1,0 +1,18 @@
+---
+# This is a minimalistic target configuration that used only for testing purposes
+id: "test_snowflake_target"
+name: "Test Target Connector"
+type: "target-snowflake"
+db_conn:
+  account: "account"
+  dbname: "foo_db"
+  user: "user"
+  password: "secret"
+  warehouse: "MY_WAREHOUSE"
+  s3_bucket: "s3_bucket"
+  s3_key_prefix: "s3_prefix/"
+  aws_access_key_id: "access_key_id"
+  stage: "foo_stage"
+  file_format: "foo_file_format"
+  aws_secret_access_key: "secret_access_key"
+  client_side_encryption_master_key: "master_key"

--- a/tests/units/cli/test_config.py
+++ b/tests/units/cli/test_config.py
@@ -111,6 +111,19 @@ class TestConfig:
             }
         }
 
+    def test_from_invalid_mongodb_yamls(self):
+        """Test creating Config object using invalid YAML configuration directory"""
+
+        # Initialising config object with a tap that's referencing an unknown target should exit
+        yaml_config_dir = '{}/resources/test_invalid_tap_mongo_yaml_config'.format(os.path.dirname(__file__))
+        vault_secret = '{}/resources/vault-secret.txt'.format(os.path.dirname(__file__))
+        print(yaml_config_dir)
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            cli.config.Config.from_yamls(PIPELINEWISE_TEST_HOME, yaml_config_dir, vault_secret)
+
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == 1
+
     def test_from_invalid_yamls(self):
         """Test creating Config object using invalid YAML configuration directory"""
 


### PR DESCRIPTION
## Description

Disable the incremental method with the help of the validation against json schema.
Given that the we can only use Draft4 valid schema currently, I went with the implication pattern to put a condition on the replication methods that can be used for tap_mongodb. 

PS: Example of [the implication pattern](https://stackoverflow.com/questions/51203606/jsonschema-attribute-conditionally-required-depends-on-parent-object?noredirect=1&lq=1).

## Checklist

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [x] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
