### PR TITLE
[AP-716] Add code contribution guide

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+### Subject of the issue
+Describe your issue here.
+
+### Your environment
+* Version of PipelineWise, e.g branch/commit #/release/tag
+* Source type and setup
+* Target type and setup
+
+### Steps to reproduce
+Tell us how to reproduce this issue.
+
+### Expected behaviour
+Tell us what should happen
+
+### Actual behaviour
+Tell us what happens instead
+
+### Further notes
+Tell us why you think this might be happening, or stuff you tried that didn't work

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,33 @@
-## Description
+## Problem
 
-<< Write here the description of your PR. Without description won't be approved! >>
+_Describe the problem your PR is trying to solve_
+
+## Proposed changes
+
+_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
+If it fixes a bug or resolves a feature request, be sure to link to that issue._
+
+
+## Types of changes
+
+What types of changes does your code introduce to PipelineWise?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation Update (if none of the other choices apply)
+
 
 ## Checklist
 
+- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
 - [ ] Description above provides context of the change
-- [ ] Unit tests coverage for changes (not needed for documentation changes)
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] Unit tests for changes (not needed for documentation changes)
+- [ ] CI checks pass with my changes
 - [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
-- [ ] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
-- [ ] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
+- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
+- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
 - [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
 - [ ] Relevant documentation is updated including usage instructions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to PipelineWise
+
+When contributing to this repository, please first discuss the change you wish to make via issue, [slack channel](https://singer-io.slack.com/archives/CNL7DL597), or any other method with the owners of this repository before making a change.
+
+We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
+
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing new features
+- Becoming a maintainer
+
+Please keep all your communication respectful. 
+
+## On PipelineWise at TransferWise
+PipelineWise is the ELT engine used at TransferWise to move data from +150 sources to different targets, 
+the main sources include Mysql/MariaDB, Postgres, S3 buckets and targets include Snowflake and S3 buckets, 
+this means we are extra careful when making changes to/dealing with PRs touching any of the connectors that are used at TransferWise.
+
+
+## We Develop with Github
+We use github to host code, to track public issues and feature requests from the community, as well as accept pull requests.
+
+
+## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html), So All Code Changes Happen Through Pull Requests
+Pull requests are the best way to propose changes to the codebase (we use [Github Flow](https://guides.github.com/introduction/flow/index.html)). We actively welcome your pull requests:
+
+1. Clone the repo and create your branch from `master`.
+2. If you've added code that should be tested, add tests: unit and End-2-End if possible.
+3. If you've added a new feature or changed the behavior of existing one, update the tests and the relevant documentation in [README.md](./README.md) and [online documentation code](./docs).
+4. Ensure the test suite passes.
+5. Make sure your code lints.
+6. Issue that pull request!
+
+Pull requests trigger CI checks which run on a private CircleCI hosted on TransferWise's infrastructure.  
+
+
+## Any contributions you make will be under the Apache License Version 2.0.
+In short, when you submit code changes, your submissions are understood to be under the same [Apache License Version 2.0](./LICENSE) that covers the project. Feel free to contact the maintainers if that's a concern.
+
+## Report bugs using Github's [issues](https://github.com/transferwise/pipelinewise/issues)
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/transferwise/pipelinewise/issues/new); it's that easy!
+
+## Write bug reports with detail, background and setup
+Here's [a great example from Craig Hockenberry](http://www.openradar.me/11905408)
+
+**Great Bug Reports** tend to have:
+
+- A quick summary and/or background
+- Steps to reproduce
+  - Be specific!
+  - Describe your source/target setup.
+- What you expected would happen
+- What actually happens
+- Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+
+People *love* thorough bug reports. I'm not even kidding.
+
+## Use a Consistent Coding Style
+
+* Tabs for indentation 
+* Google docstring format for Python documentation.
+* Single quotes for string literals 
+* We've started using SonarLint PyCharm plugin to detect code complexity among other issues to improve code quality.
+* You can try running `find pipelinewise tests -type f -name '*.py' | xargs unify --check-only` and `pylint pipelinewise tests` for style unification
+
+## Versioning
+We use [Semantic versioning](https://semver.org/).
+
+## License
+By contributing, you agree that your contributions will be licensed under its Apache License Version 2.0

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ For further instructions about setting up local development environment go to
 ## Contribution
 
 To add new taps and targets follow the instructions on
-[Contribution Page](https://transferwise.github.io/pipelinewise/project/contribution.html)
+* [Contribution Page](https://transferwise.github.io/pipelinewise/project/contribution.html)
+* [Code contribution guide](./CONTRIBUTING.md)
 
 
 ## Links


### PR DESCRIPTION
## Description

PipelineWise needs code contribution guide for the community.
The PR includes:
* New contribution guide
* New issue template
* Updated PR template
* Updated Readme

## Checklist

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` if applicable. AP-NNNN = JIRA ID
- [ ] Branch name starts with `AP-NNN` if applicable. AP-NNN = JIRA ID
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
