### PR TITLE
Create pgcrypto extension in dev env postgres target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
             ./tests/db/tap_mysql_db.sh
             ./tests/db/tap_postgres_db.sh
             ./tests/db/tap_mongodb.sh
+            ./tests/db/target_postgres.sh
       - run:
           name: 'Installing PipelineWise components and connectors'
           command: ./install.sh --acceptlicenses --connectors=target-snowflake,target-postgres,tap-mysql,tap-postgres,tap-mongodb,transform-field,tap-s3-csv

--- a/dev-project/entrypoint.sh
+++ b/dev-project/entrypoint.sh
@@ -24,6 +24,8 @@ cd dev-project
 ./mongo/init_rs.sh
 ../tests/db/tap_mongodb.sh
 
+../tests/db/target_postgres.sh
+
 # Install PipelineWise in the container
 ../install.sh --acceptlicenses --nousage --connectors=target-snowflake,target-postgres,tap-mysql,tap-postgres,tap-mongodb,transform-field,tap-s3-csv
 if [[ $? != 0 ]]; then

--- a/tests/db/target_postgres.sh
+++ b/tests/db/target_postgres.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+#
+# Building a test PostgreSQL target database for integration testing of tap-postgres
+PWD="$(dirname "$0")"
+
+echo "Building test PostgreSQL target database..."
+
+# To run this script some environment variables must be set.
+# Normally it's defined in .circleci/config.yml
+if [[ -z "${TARGET_POSTGRES_HOST}" || -z "${TARGET_POSTGRES_PORT}" || -z "${TARGET_POSTGRES_USER}" || -z "${TARGET_POSTGRES_PASSWORD}" || -z "${TARGET_POSTGRES_DB}" ]]; then
+    echo "ERROR: One or more required environment variable is not defined:"
+    echo "       - TARGET_POSTGRES_HOST"
+    echo "       - TARGET_POSTGRES_PORT"
+    echo "       - TARGET_POSTGRES_USER"
+    echo "       - TARGET_POSTGRES_PASSWORD"
+    echo "       - TARGET_POSTGRES_DB"
+    exit 1
+fi
+
+# Create a postgres password file for non-interaction connection
+PGPASSFILE=~/.pgpass
+echo ${TARGET_POSTGRES_HOST}:${TARGET_POSTGRES_PORT}:${TARGET_POSTGRES_DB}:${TARGET_POSTGRES_USER}:${TARGET_POSTGRES_PASSWORD} > ${PGPASSFILE}
+chmod 0600 ${PGPASSFILE}
+
+# Build the test Databases
+TEST_DB_SQL=${PWD}/target_postgres_data.sql
+psql -U ${TARGET_POSTGRES_USER} -h ${TARGET_POSTGRES_HOST} -f ${TEST_DB_SQL} -d ${TARGET_POSTGRES_DB}

--- a/tests/db/target_postgres_data.sql
+++ b/tests/db/target_postgres_data.sql
@@ -1,0 +1,5 @@
+--
+-- Postgres as a target data store requires the pgcrypto extension to apply transformation
+-- and obfuscation rules. The required DIGEST function available in the pgcrypto extension
+--
+CREATE EXTENSION IF NOT EXISTS pgcrypto;


### PR DESCRIPTION
## Problem

This PR creates the `pgcrypto` extension automatically in the dev env postgres target database.

Using `target_postgres` in the dev environment gives `ERROR: function digest(unknown, unknown) does not exist`, when do fast-sync on a table with SHA transformations.

This is because the `DIGEST` function exists in the pgcrypto extension that is not installed by default in the postgres container.

## Proposed changes

Install `pgcrypto` extensions automatically when starting the dev env.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
