### PR TITLE
Rename dev project tap mongo target schema

### DIFF
--- a/dev-project/pipelinewise-config/tap_mongodb_to_pg.yaml
+++ b/dev-project/pipelinewise-config/tap_mongodb_to_pg.yaml
@@ -33,7 +33,7 @@ batch_size_rows: 1000                  # Batch size for the stream to optimise l
 # ------------------------------------------------------------------------------
 schemas:
   - source_schema: "mongo_source_db"
-    target_schema: "mongodb_sync"
+    target_schema: "ppw_dev_tap_mongo"
 
     tables:
       - table_name: "listings"

--- a/dev-project/pipelinewise-config/tap_mongodb_to_pg.yaml
+++ b/dev-project/pipelinewise-config/tap_mongodb_to_pg.yaml
@@ -33,7 +33,7 @@ batch_size_rows: 1000                  # Batch size for the stream to optimise l
 # ------------------------------------------------------------------------------
 schemas:
   - source_schema: "mongo_source_db"
-    target_schema: "ppw_dev_tap_mongo"
+    target_schema: "ppw_dev_tap_mongodb"
 
     tables:
       - table_name: "listings"


### PR DESCRIPTION
## Problem

tap_mongo in dev env loading into a schema called `mongodb_sync`. This works fine but maybe can consider to keep the naming in sync with other tap target schemas:
* `ppw_dev_tap_mysql`
* `ppw_dev_tap_postgres`
* `ppw_e2e_tap_mysql`
* `ppw_e2e_tap_postgres`
* `ppw_e2e_tap_mongodb` <- this is already in sync with the current naming convention

## Proposed changes

Following the naming convention above tap_mongo target schema in the dev env renamed to `ppw_dev_tap_mongodb`

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
