### PR TITLE
[AP-733] Add stream_buffer_size option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get -qq update && apt-get -qqy install \
         alien \
         libaio1 \
         mongo-tools \
+        mbuffer \
     && pip install --upgrade pip
 
 # Oracle Instant Clinet for tap-oracle

--- a/dev-project/entrypoint.sh
+++ b/dev-project/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Install OS dependencies
 apt-get update
-apt-get install -y mariadb-client postgresql-client alien libaio1 mongo-tools
+apt-get install -y mariadb-client postgresql-client alien libaio1 mongo-tools mbuffer
 
 wget https://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.2/multiverse/binary-amd64/mongodb-org-shell_4.2.7_amd64.deb
 dpkg -i ./mongodb-org-shell_4.2.7_amd64.deb && rm mongodb-org-shell_4.2.7_amd64.deb

--- a/dev-project/pipelinewise-config/tap_mongodb_to_pg.yaml
+++ b/dev-project/pipelinewise-config/tap_mongodb_to_pg.yaml
@@ -25,8 +25,9 @@ db_conn:
 # Destination (Target) - Target properties
 # Connection details should be in the relevant target YAML file
 # ------------------------------------------------------------------------------
-target: "postgres_dwh"                   # ID of the target connector where the data will be loaded
+target: "postgres_dwh"                 # ID of the target connector where the data will be loaded
 batch_size_rows: 1000                  # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 
 # ------------------------------------------------------------------------------
 # Source to target Schema mapping

--- a/dev-project/pipelinewise-config/tap_mysql_mariadb.yml
+++ b/dev-project/pipelinewise-config/tap_mysql_mariadb.yml
@@ -29,6 +29,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "postgres_dwh"                 # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                 # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 
 
 # ------------------------------------------------------------------------------

--- a/dev-project/pipelinewise-config/tap_postgres.yml
+++ b/dev-project/pipelinewise-config/tap_postgres.yml
@@ -29,6 +29,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "postgres_dwh"                 # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 flush_all_streams: false               # Target to flush all streams if any stream reaches batch_size_rows. Default false
 
 

--- a/dev-project/pipelinewise-config/tap_postgres_logical.yml
+++ b/dev-project/pipelinewise-config/tap_postgres_logical.yml
@@ -33,6 +33,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "postgres_dwh"                 # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 flush_all_streams: true                # Target to flush all streams if any stream reaches batch_size_rows. Default false
 
 

--- a/docs/concept/fastsync.rst
+++ b/docs/concept/fastsync.rst
@@ -43,6 +43,6 @@ Fast Sync exists only between the following tap and target components:
 +----------------------------+----------------------------------+
 | :ref:`tap-s3-csv`          | **->** :ref:`target-postgres`    |
 +----------------------------+----------------------------------+
-| :ref:`tap-mongodb`         | **->** :ref:`target-postgres`   |
+| :ref:`tap-mongodb`         | **->** :ref:`target-postgres`    |
 +----------------------------+----------------------------------+
 

--- a/docs/concept/linux_pipes.rst
+++ b/docs/concept/linux_pipes.rst
@@ -1,0 +1,68 @@
+.. _linux_pipes:
+
+Linux Pipes in PipelineWise
+===========================
+
+A pipe is unidirectional interprocess communication channel. The term was coined by
+`Douglas McIlroy <https://en.wikipedia.org/wiki/Douglas_McIlroy>`_ for Unix shell and
+named by analogy with the pipeline.
+
+Pipes are most often used in shell-scripts to connect multiple commands by redirecting the output of
+one command (stdout) to the input (stdin) followed by using a pipe symbol '`|`'. :ref:`singer` specification,
+hence PipelineWise is also using linux pipes to connect :ref:`taps_list` and :ref:`targets_list` connectors.
+
+For example in the following command ``tap-postgres`` Extracts data from a postgres database and the
+extracted data sent to ``target-snowflake`` to Load it into a Snowflake database:
+
+.. code-block:: bash
+
+    tap-postgres | target-snowflake
+
+Logic
+-----
+
+Pipes provide asynchronous execution of commands using buffered I/O routines. Thus, all the commands
+in the pipeline operate in parallel, each in its own process.
+
+The size of the buffer since kernel version 2.6.11 is 65536 bytes (64K) and is equal to the page memory
+in older kernels. When attempting to read from an empty buffer, the read process is blocked until data
+appears. Similarly, if you attempt to write to a full buffer, the recording process will be blocked until
+the necessary amount of space is available.
+
+It is important to note, that despite the fact that pipes operates using file descriptor I/O streams,
+operations are performed in memory without loading to/from the disc.
+
+All the information given below is for bash shell 4.2 and kernel 3.10.10. Further details in the
+original `Linux Pipes Tips & Tricks <https://blog.dataart.com/linux-pipes-tips-tricks>`_ post.
+
+Increasing buffer size
+----------------------
+
+Sometimes the default 64K buffer size that provided by the Linux kernel is too small. For example in the
+example above when you extracting data from a busy postgres database and loading into a busy Snowflake
+database sometimes you will find that that ``tap-postgres`` is blocked by ``target-snowflake``.
+
+This happens when the target cannot load the data fast enough. For example if you have lot of concurrent
+queries in the target database the database can queue up new queries (at least in case of a Snowflake database)
+and this is blocking the tap to extract more data. This scenario can cause unexpected timeout in
+``tap-postgres`` and other tap connectors. To avoid this scenario you can consider to increase the buffer size
+between the tap and target.
+
+
+.. warning::
+
+  PipelineWise doesn't modify the kernel buffer size. When you need more buffer than
+  the defualt 64K that's provided by the kernel, PipelineWise will use its own
+  buffering mechanism between taps and targets.
+
+  PipelineWise is using `mbuffer <https://www.maier-komor.de/mbuffer.html>`_ to
+  create custom sized buffer between taps and targets.
+
+You can set custom buffer sizes in the tap YAML files by setting the ``stream_buffer_size``
+value. If ``stream_buffer_size`` is greater than 0 then the following piped command will be
+generated to create larger buffer between taps and targets than the default
+buffer that's provided by the Linux kernel:
+
+.. code-block:: bash
+
+    tap-postgres | mbuffer -m 10M | target-snowflake

--- a/docs/connectors/taps/google_analytics.rst
+++ b/docs/connectors/taps/google_analytics.rst
@@ -69,6 +69,7 @@ Example YAML for ``tap-google-analytics``:
     # ------------------------------------------------------------------------------
     target: "snowflake"                        # ID of the target connector where the data will be loaded
     batch_size_rows: 20000                     # Batch size for the stream to optimise load performance
+    stream_buffer_size: 0                      # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
     default_target_schema: "google-analytic"   # Target schema where the data will be loaded
     #default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
     #  - grp_power

--- a/docs/connectors/taps/jira.rst
+++ b/docs/connectors/taps/jira.rst
@@ -51,6 +51,7 @@ Example YAML for ``tap-jira``:
     # ------------------------------------------------------------------------------
     target: "snowflake"                       # ID of the target connector where the data will be loaded
     batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+    stream_buffer_size: 0                     # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
     default_target_schema: "jira"             # Target schema where the data will be loaded 
     default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
       - grp_power

--- a/docs/connectors/taps/kafka.rst
+++ b/docs/connectors/taps/kafka.rst
@@ -75,6 +75,7 @@ Example YAML for ``tap-kafka``:
     # ------------------------------------------------------------------------------
     target: "snowflake"                       # ID of the target connector where the data will be loaded
     batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+    stream_buffer_size: 0                     # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
     default_target_schema: "kafka"            # Target schema where the data will be loaded
     default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
       - grp_stats

--- a/docs/connectors/taps/mongodb.rst
+++ b/docs/connectors/taps/mongodb.rst
@@ -108,6 +108,7 @@ Example YAML for ``tap-mongodb``:
 	# ------------------------------------------------------------------------------
 	target: "my_target"                   			# ID of the target connector where the data will be loaded
 	batch_size_rows: 1000                  			# Batch size for the stream to optimise load performance
+	stream_buffer_size: 0                           # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 
 	# ------------------------------------------------------------------------------
 	# Source to target Schema mapping

--- a/docs/connectors/taps/mysql.rst
+++ b/docs/connectors/taps/mysql.rst
@@ -124,6 +124,7 @@ Example YAML for ``tap-mysql``:
   # ------------------------------------------------------------------------------
   target: "snowflake"                    # ID of the target connector where the data will be loaded
   batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+  stream_buffer_size: 0                  # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 
 
   # ------------------------------------------------------------------------------

--- a/docs/connectors/taps/oracle.rst
+++ b/docs/connectors/taps/oracle.rst
@@ -170,6 +170,7 @@ Example YAML for ``tap-oracle``:
     # ------------------------------------------------------------------------------
     target: "snowflake"                    # ID of the target connector where the data will be loaded
     batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+    stream_buffer_size: 0                  # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 
 
     # ------------------------------------------------------------------------------

--- a/docs/connectors/taps/postgres.rst
+++ b/docs/connectors/taps/postgres.rst
@@ -152,6 +152,7 @@ Example YAML for ``tap-postgres``:
     # ------------------------------------------------------------------------------
     target: "snowflake"                    # ID of the target connector where the data will be loaded
     batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+    stream_buffer_size: 0                  # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 
 
     # ------------------------------------------------------------------------------

--- a/docs/connectors/taps/s3_csv.rst
+++ b/docs/connectors/taps/s3_csv.rst
@@ -44,6 +44,7 @@ Example YAML for ``tap-s3-csv``:
     # ------------------------------------------------------------------------------
     target: "snowflake"                       # ID of the target connector where the data will be loaded
     batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+    stream_buffer_size: 0                     # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
     default_target_schema: "s3_feeds"         # Target schema where the data will be loaded 
     default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
       - grp_power

--- a/docs/connectors/taps/salesforce.rst
+++ b/docs/connectors/taps/salesforce.rst
@@ -59,6 +59,7 @@ Example YAML for tap-salesforce:
     # ------------------------------------------------------------------------------
     target: "snowflake"                       # ID of the target connector where the data will be loaded
     batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+    stream_buffer_size: 0                     # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
     default_target_schema: "salesforce"       # Target schema where the data will be loaded
     default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
       - grp_power

--- a/docs/connectors/taps/snowflake.rst
+++ b/docs/connectors/taps/snowflake.rst
@@ -51,6 +51,7 @@ Example YAML for tap-snowflake:
     # ------------------------------------------------------------------------------
     target: "snowflake"                    # ID of the target connector where the data will be loaded
     batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+    stream_buffer_size: 0                  # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 
 
     # ------------------------------------------------------------------------------

--- a/docs/connectors/taps/zendesk.rst
+++ b/docs/connectors/taps/zendesk.rst
@@ -42,6 +42,7 @@ Example YAML for tap-zendesk:
     # ------------------------------------------------------------------------------
     target: "snowflake"                       # ID of the target connector where the data will be loaded
     batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+    stream_buffer_size: 0                     # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
     default_target_schema: "zendesk"          # Target schema where the data will be loaded 
     default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
       - grp_power

--- a/docs/connectors/taps/zuora.rst
+++ b/docs/connectors/taps/zuora.rst
@@ -58,6 +58,7 @@ Example YAML for tap-zuora:
     # ------------------------------------------------------------------------------
     target: "snowflake"                       # ID of the target connector where the data will be loaded
     batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+    stream_buffer_size: 0                     # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
     default_target_schema: "zuora"       # Target schema where the data will be loaded
     default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
       - grp_power

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -239,6 +239,7 @@ Content
    concept/singer
    concept/replication_methods
    concept/fastsync
+   concept/linux_pipes
 
 .. toctree::
    :maxdepth: 2

--- a/pipelinewise/cli/commands.py
+++ b/pipelinewise/cli/commands.py
@@ -173,7 +173,7 @@ def build_singer_command(tap: TapParams, target: TargetParams, transform: Transf
     stream_buffer_command = build_stream_buffer_command(stream_buffer_size)
 
     # Generate the final piped command with all the required components
-    sub_commands = [tap_command, stream_buffer_command, transformation_command, target_command]
+    sub_commands = [tap_command, transformation_command, stream_buffer_command, target_command]
     command = ' | '.join(list(filter(None, sub_commands)))
 
     return command

--- a/pipelinewise/cli/commands.py
+++ b/pipelinewise/cli/commands.py
@@ -1,0 +1,212 @@
+"""
+PipelineWise CLI - Commands
+"""
+import os
+import logging
+from collections import namedtuple
+
+from . import utils
+from .errors import StreamBufferTooLargeException
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_STREAM_BUFFER_SIZE = 0          # Disabled by default
+DEFAULT_STREAM_BUFFER_BIN = 'mbuffer'
+MIN_STREAM_BUFFER_SIZE = 10
+MAX_STREAM_BUFFER_SIZE = 1000
+
+
+TapParams = namedtuple('TapParams', ['type', 'bin', 'config', 'properties', 'state'])
+TargetParams = namedtuple('TargetParams', ['type', 'bin', 'config'])
+TransformParams = namedtuple('TransformParams', ['bin', 'config'])
+
+
+def exists_and_executable(bin_path: str) -> bool:
+    """
+    Checks if a given file exists and executable.
+    It checks if the file exists and executable using the given
+    absolute or relative path or via one of the path in the
+    PATH environment variable
+
+    Args:
+         bin_path: Absolute or relative path
+    Returns:
+        boolean: True if file exists and executable, otherwise False
+
+    """
+    if not os.access(bin_path, os.X_OK):
+        try:
+            paths = f"{os.environ['PATH']}".split(':')
+            (p for p in paths if os.access(f'{p}/{bin_path}', os.X_OK)).__next__()
+        except StopIteration:
+            return False
+
+    return True
+
+
+def build_tap_command(tap_type: str, tap_bin: str, config: str, properties: str, state: str = None) -> str:
+    """
+    Builds a command that starts a singer tap connector with the
+    required command line arguments
+
+    Args:
+        tap_type: One of tap types defined in tap_properties.py
+        tap_bin: path the tap python executable
+        config: path to config json file
+        properties: path to the properties json file
+        state: path to the state json file
+
+    Returns:
+        string of command line executable
+    """
+    # Following the singer spec the catalog JSON file needs to be passed by the --catalog argument
+    # However some tap (i.e. tap-mysql and tap-postgres) requires it as --properties
+    # This is probably for historical reasons and need to clarify on Singer slack channels
+    catalog_argument = utils.get_tap_property_by_tap_type(tap_type, 'tap_catalog_argument')
+
+    state_arg = ''
+    if state and os.path.isfile(state):
+        state_arg = f'--state {state}'
+
+    tap_command = f'{tap_bin} --config {config} {catalog_argument} {properties} {state_arg}'
+    return tap_command
+
+
+def build_target_command(target_bin: str, config: str) -> str:
+    """
+    Builds a command that starts a singer target connector with the
+    required command line arguments
+
+    Args:
+        target_bin: path the target python executable
+        config: path to config json file
+
+    Returns:
+        string of command line executable
+    """
+    target_command = f'{target_bin} --config {config}'
+    return target_command
+
+
+def build_transformation_command(transform_bin: str, config: str) -> str:
+    """
+    Builds a command that starts a singer transformation connector
+    with the required command line arguments
+
+    Args:
+        transform_bin: path to the transform python executable
+        config: path to config json file
+
+    Returns:
+        string of command line executable if transformation found,
+        None otherwise
+    """
+    trans_command = None
+
+    # Detect if transformation is needed
+    if os.path.isfile(config):
+        trans = utils.load_json(config)
+        if 'transformations' in trans and len(trans['transformations']) > 0:
+            trans_command = f'{transform_bin} --config {config}'
+
+    return trans_command
+
+
+def build_stream_buffer_command(buffer_size: int = 0, stream_buffer_bin: str = DEFAULT_STREAM_BUFFER_BIN) -> str:
+    """
+    Builds a command that buffers data between tap and target
+    connectors to stream data asynchronously. Buffering streams
+    avoids blocking taps to extract new data while targets
+    is busy with loading the previous batch
+
+    Args:
+        buffer_size: Size of buffer in megabytes
+        stream_buffer_bin: binary executable of buffer implementation
+                           (Default is mbuffer)
+
+    Returns:
+        string of command line executable
+    Raises:
+        StreamBufferTooLargeException if buffer size is greater than
+            MAX_STREAM_BUFFER_SIZE
+        StreamBufferBinaryNotFound if stream_buffer_bin binary executable
+            not found
+    """
+    buffer_command = None
+
+    if buffer_size and buffer_size > 0:
+        # Buffer size cannot be less than min stream buffer size
+        if buffer_size < MIN_STREAM_BUFFER_SIZE:
+            buffer_size = MIN_STREAM_BUFFER_SIZE
+        elif buffer_size > MAX_STREAM_BUFFER_SIZE:
+            raise StreamBufferTooLargeException(buffer_size, MAX_STREAM_BUFFER_SIZE)
+
+        buffer_command = f'{stream_buffer_bin} -m {buffer_size}M'
+
+    return buffer_command
+
+
+def build_singer_command(tap: TapParams, target: TargetParams, transform: TransformParams,
+                         stream_buffer_size: int = 0) -> str:
+    """
+    Builds a command that starts a full singer command with tap,
+    target and optional transformation connectors. The connectors are
+    connected by linux pipes, following the singer specification.
+
+    Args:
+        tap: NamedTuple with tap properties
+        target: NamedTuple with target properties
+        transform: NamedTuple with transform properties
+        stream_buffer_size: in-memory buffer size between tap and target
+
+    Returns:
+        string of command line executable
+    """
+    tap_command = build_tap_command(tap.type,
+                                    tap.bin,
+                                    tap.config,
+                                    tap.properties,
+                                    tap.state)
+    target_command = build_target_command(target.bin,
+                                          target.config)
+    transformation_command = build_transformation_command(transform.bin,
+                                                          transform.config)
+    stream_buffer_command = build_stream_buffer_command(stream_buffer_size)
+
+    # Generate the final piped command with all the required components
+    sub_commands = [tap_command, stream_buffer_command, transformation_command, target_command]
+    command = ' | '.join(list(filter(None, sub_commands)))
+
+    return command
+
+
+# pylint: disable=too-many-arguments
+def build_fastsync_command(tap: TapParams, target: TargetParams, transform: TransformParams,
+                           venv_dir: str, temp_dir: str, tables: str = None) -> str:
+    """
+    Builds a command that starts fastsync from a given tap to a
+    given target with optional transformations.
+
+    Args:
+        tap: NamedTuple with tap properties
+        target: NamedTuple with target properties
+        transform: NamedTuple with transform properties
+        venv_dir:
+        temp_dir: Temporary dir to generate export temp files
+        tables: List of specific tables to fastsync
+                (Default is None, to sync every table)
+
+    Returns:
+        string of command line executable
+    """
+    fastsync_bin = utils.get_fastsync_bin(venv_dir, tap.type, target.type)
+    command = ' '.join(list(filter(None, [
+        f'{fastsync_bin}',
+        f'--tap {tap.config}',
+        f'--properties {tap.properties}',
+        f'--state {tap.state}',
+        f'--target {target.config}',
+        f'--temp_dir {temp_dir}',
+        f'--transform {transform.config}' if transform.config and os.path.isfile(transform.config) else '',
+        f'--tables {tables}' if tables else ''])))
+
+    return command

--- a/pipelinewise/cli/config.py
+++ b/pipelinewise/cli/config.py
@@ -171,6 +171,7 @@ class Config:
                     'name': tap.get('name'),
                     'type': tap.get('type'),
                     'owner': tap.get('owner'),
+                    'stream_buffer_size': tap.get('stream_buffer_size'),
                     'enabled': True
                 })
 

--- a/pipelinewise/cli/errors.py
+++ b/pipelinewise/cli/errors.py
@@ -1,0 +1,15 @@
+class BinaryExecutableNotFound(Exception):
+    """Raised if binary executable not found"""
+
+    def __init__(self, bin_path):
+        msg = f'{bin_path} not found.'
+        super(BinaryExecutableNotFound, self).__init__(msg)
+
+
+class StreamBufferTooLargeException(Exception):
+    """Raised if stream buffer size is greater than the max allowed size"""
+
+    def __init__(self, buffer_size, max_buffer_size):
+        msg = f'{buffer_size}M buffer size is too large. The maximum allowed stream buffer size is ' \
+              f'{max_buffer_size}M'
+        super(StreamBufferTooLargeException, self).__init__(msg)

--- a/pipelinewise/cli/samples/tap_google_analytics.yml.sample
+++ b/pipelinewise/cli/samples/tap_google_analytics.yml.sample
@@ -33,6 +33,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                        # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                     # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                      # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 default_target_schema: "google-analytic"   # Target schema where the data will be loaded
 #default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
 #  - grp_power

--- a/pipelinewise/cli/samples/tap_jira.yml.sample
+++ b/pipelinewise/cli/samples/tap_jira.yml.sample
@@ -34,6 +34,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                       # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                     # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 default_target_schema: "jira"             # Target schema where the data will be loaded 
 #default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
 #  - grp_power

--- a/pipelinewise/cli/samples/tap_kafka.yml.sample
+++ b/pipelinewise/cli/samples/tap_kafka.yml.sample
@@ -42,6 +42,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                       # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                     # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 default_target_schema: "kafka"            # Target schema where the data will be loaded 
 default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
   - grp_stats

--- a/pipelinewise/cli/samples/tap_mongodb.yml.sample
+++ b/pipelinewise/cli/samples/tap_mongodb.yml.sample
@@ -27,6 +27,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                   				# ID of the target connector where the data will be loaded
 batch_size_rows: 1000                  				# Batch size for the stream to optimise load performance
+stream_buffer_size: 0                               # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 default_target_schema: "<sync db name>"             # Optional: Default target schema where the data will be loaded
 #default_target_schema_select_permission:  			# Optional: Grant SELECT on schema and tables that created
 #  - grp_power

--- a/pipelinewise/cli/samples/tap_mysql_mariadb.yml.sample
+++ b/pipelinewise/cli/samples/tap_mysql_mariadb.yml.sample
@@ -31,6 +31,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                    # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 
 
 # ------------------------------------------------------------------------------

--- a/pipelinewise/cli/samples/tap_oracle.yml.sample
+++ b/pipelinewise/cli/samples/tap_oracle.yml.sample
@@ -29,6 +29,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                    # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 
 
 # ------------------------------------------------------------------------------

--- a/pipelinewise/cli/samples/tap_postgres.yml.sample
+++ b/pipelinewise/cli/samples/tap_postgres.yml.sample
@@ -29,6 +29,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                    # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 
 
 # ------------------------------------------------------------------------------

--- a/pipelinewise/cli/samples/tap_s3_csv.yml.sample
+++ b/pipelinewise/cli/samples/tap_s3_csv.yml.sample
@@ -26,6 +26,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                       # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                     # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 default_target_schema: "s3_feeds"         # Target schema where the data will be loaded
 default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
   - grp_power

--- a/pipelinewise/cli/samples/tap_salesforce.yml.sample
+++ b/pipelinewise/cli/samples/tap_salesforce.yml.sample
@@ -34,6 +34,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                       # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                     # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 default_target_schema: "salesforce"       # Target schema where the data will be loaded 
 default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
   - grp_power

--- a/pipelinewise/cli/samples/tap_snowflake.yml.sample
+++ b/pipelinewise/cli/samples/tap_snowflake.yml.sample
@@ -25,6 +25,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                    # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 
 
 # ------------------------------------------------------------------------------

--- a/pipelinewise/cli/samples/tap_zendesk.yml.sample
+++ b/pipelinewise/cli/samples/tap_zendesk.yml.sample
@@ -24,6 +24,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                       # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                     # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 default_target_schema: "zendesk"          # Target schema where the data will be loaded 
 default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
   - grp_power

--- a/pipelinewise/cli/samples/tap_zuora.yml.sample
+++ b/pipelinewise/cli/samples/tap_zuora.yml.sample
@@ -37,6 +37,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                       # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                     # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 default_target_schema: "zuora"       # Target schema where the data will be loaded
 default_target_schema_select_permission:  # Optional: Grant SELECT on schema and tables that created
   - grp_power

--- a/pipelinewise/cli/schemas/tap.json
+++ b/pipelinewise/cli/schemas/tap.json
@@ -213,6 +213,11 @@
       "minimum": 1000,
       "maximum": 500000
     },
+    "stream_buffer_size": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1000
+    },
     "schemas": {
       "type": "array",
       "items": {

--- a/tests/end_to_end/test-project/tap_mongodb_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_mongodb_to_pg.yml.template
@@ -27,6 +27,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "postgres_dwh"                   # ID of the target connector where the data will be loaded
 batch_size_rows: 1000                  # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size between taps and targets for asynchronous data pipes
 
 # ------------------------------------------------------------------------------
 # Source to target Schema mapping

--- a/tests/end_to_end/test-project/tap_mongodb_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_mongodb_to_sf.yml.template
@@ -27,6 +27,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                   # ID of the target connector where the data will be loaded
 batch_size_rows: 1000                  # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size between taps and targets for asynchronous data pipes
 
 # ------------------------------------------------------------------------------
 # Source to target Schema mapping

--- a/tests/end_to_end/test-project/tap_mysql_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_pg.yml.template
@@ -26,6 +26,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "postgres_dwh"                 # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size between taps and targets for asynchronous data pipes
 
 
 # ------------------------------------------------------------------------------

--- a/tests/end_to_end/test-project/tap_mysql_to_rs.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_rs.yml.template
@@ -26,6 +26,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "redshift"                     # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size between taps and targets for asynchronous data pipes
 
 
 # ------------------------------------------------------------------------------

--- a/tests/end_to_end/test-project/tap_mysql_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_sf.yml.template
@@ -26,6 +26,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                    # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size between taps and targets for asynchronous data pipes
 
 
 # ------------------------------------------------------------------------------

--- a/tests/end_to_end/test-project/tap_postgres_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_pg.yml.template
@@ -27,6 +27,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "postgres_dwh"                 # ID of the target connector where the data will be loadqed
 batch_size_rows: 20000                 # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size between taps and targets for asynchronous data pipes
 
 
 # ------------------------------------------------------------------------------

--- a/tests/end_to_end/test-project/tap_postgres_to_rs.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_rs.yml.template
@@ -27,6 +27,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "redshift"                     # ID of the target connector where the data will be loaded
 batch_size_rows: 1000                  # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size between taps and targets for asynchronous data pipes
 
 
 # ------------------------------------------------------------------------------

--- a/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
@@ -27,6 +27,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                    # ID of the target connector where the data will be loaded
 batch_size_rows: 1000                  # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size between taps and targets for asynchronous data pipes
 
 
 # ------------------------------------------------------------------------------

--- a/tests/end_to_end/test-project/tap_s3_csv_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_s3_csv_to_pg.yml.template
@@ -25,6 +25,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "postgres_dwh"                    # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                     # In-memory buffer size between taps and targets for asynchronous data pipes
 primary_key_required: False               # Optional: in case you want to load tables without key
                                           #            properties, uncomment this. Please note
                                           #            that files without primary keys will not

--- a/tests/end_to_end/test-project/tap_s3_csv_to_rs.yml.template
+++ b/tests/end_to_end/test-project/tap_s3_csv_to_rs.yml.template
@@ -25,6 +25,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "redshift"                        # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                     # In-memory buffer size between taps and targets for asynchronous data pipes
 primary_key_required: False               # Optional: in case you want to load tables without key
                                           #            properties, uncomment this. Please note
                                           #            that files without primary keys will not

--- a/tests/end_to_end/test-project/tap_s3_csv_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_s3_csv_to_sf.yml.template
@@ -25,6 +25,7 @@ db_conn:
 # ------------------------------------------------------------------------------
 target: "snowflake"                       # ID of the target connector where the data will be loaded
 batch_size_rows: 20000                    # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                     # In-memory buffer size between taps and targets for asynchronous data pipes
 primary_key_required: False               # Optional: in case you want to load tables without key
                                           #            properties, uncomment this. Please note
                                           #            that files without primary keys will not

--- a/tests/units/cli/resources/transform-config-empty.json
+++ b/tests/units/cli/resources/transform-config-empty.json
@@ -1,0 +1,3 @@
+{
+    "transformations": []
+}

--- a/tests/units/cli/resources/transform-config.json
+++ b/tests/units/cli/resources/transform-config.json
@@ -1,0 +1,18 @@
+{
+    "transformations": [
+        {
+            "field_id": "device_name",
+            "safe_field_id": "\"DEVICE_NAME\"",
+            "tap_stream_name": "public-payment_token",
+            "type": "SET-NULL",
+            "when": null
+        },
+        {
+            "field_id": "token_pan",
+            "safe_field_id": "\"TOKEN_PAN\"",
+            "tap_stream_name": "public-payment_token",
+            "type": "SET-NULL",
+            "when": null
+        }
+    ]
+}

--- a/tests/units/cli/test_commands.py
+++ b/tests/units/cli/test_commands.py
@@ -6,6 +6,7 @@ import pipelinewise.cli.commands as commands
 from pipelinewise.cli.errors import StreamBufferTooLargeException
 
 
+# pylint: disable=no-self-use
 class TestCommands:
     """
     Unit tests for PipelineWise CLI commands functions
@@ -72,6 +73,7 @@ class TestCommands:
                                                         config=transform_config)
         assert command == f'/bin/transform_field.py --config {transform_config}'
 
+    # pylint: disable=invalid-name
     def test_build_stream_buffer_command(self):
         """Tests the function that generates stream buffer executable command"""
         # Should return empty string if buffer size is invalid or too small

--- a/tests/units/cli/test_commands.py
+++ b/tests/units/cli/test_commands.py
@@ -1,0 +1,224 @@
+import os
+import sys
+import pytest
+import pipelinewise.cli.commands as commands
+
+from pipelinewise.cli.errors import StreamBufferTooLargeException
+
+
+class TestCommands:
+    """
+    Unit tests for PipelineWise CLI commands functions
+    """
+
+    def test_exists_and_executable(self):
+        """Tests the function that detect if a file exists and executable"""
+        if sys.platform != 'win32':
+            # Should be true if absolute path given to binary executable
+            assert commands.exists_and_executable('/bin/ls') is True
+            # Should be true if executable available via the PATH environment variable
+            assert commands.exists_and_executable('ls') is True
+
+        # Should be false if file not exists
+        assert commands.exists_and_executable('invalid_executable') is False
+        # Should be false if file exists but not executable
+        assert commands.exists_and_executable(__file__) is False
+
+    def test_build_tap_command(self):
+        """Tests the function that generates tap executable command"""
+        # State file should not be included if state file path not passed
+        command = commands.build_tap_command(tap_type='tap_mysql',
+                                             tap_bin='/bin/tap_mysql.py',
+                                             config='.ppw/config.json',
+                                             properties='.ppw/properties.json')
+        assert command == '/bin/tap_mysql.py --config .ppw/config.json --catalog .ppw/properties.json '
+
+        # State file should not be included if state file passed but file not exists
+        command = commands.build_tap_command(tap_type='tap_mysql',
+                                             tap_bin='/bin/tap_mysql.py',
+                                             config='.ppw/config.json',
+                                             properties='.ppw/properties.json',
+                                             state='.pipelinewise/state.json')
+        assert command == '/bin/tap_mysql.py --config .ppw/config.json --catalog .ppw/properties.json '
+
+        # State file should be included if state file passed and file exists
+        state_mock = __file__
+        command = commands.build_tap_command(tap_type='tap_mysql',
+                                             tap_bin='/bin/tap_mysql.py',
+                                             config='.ppw/config.json',
+                                             properties='.ppw/properties.json',
+                                             state=state_mock)
+        assert command == f'/bin/tap_mysql.py --config .ppw/config.json --catalog .ppw/properties.json ' \
+                          f'--state {state_mock}'
+
+    def test_build_target_command(self):
+        """Tests the function that generates target executable command"""
+        # Should return a input piped command with an executable target command
+        command = commands.build_target_command(target_bin='/bin/target_postgres.py',
+                                                config='.ppw/config.json')
+        assert command == '/bin/target_postgres.py --config .ppw/config.json'
+
+    def test_build_transform_command(self):
+        """Tests the function that generates transform executable command"""
+        # Should return empty string if config file exists but no transformation
+        transform_config = '{}/resources/transform-config-empty.json'.format(os.path.dirname(__file__))
+        command = commands.build_transformation_command(transform_bin='/bin/transform_field.py',
+                                                        config=transform_config)
+        assert command is None
+
+        # Should return a input piped command with an executable transform command
+        transform_config = '{}/resources/transform-config.json'.format(os.path.dirname(__file__))
+        command = commands.build_transformation_command(transform_bin='/bin/transform_field.py',
+                                                        config=transform_config)
+        assert command == f'/bin/transform_field.py --config {transform_config}'
+
+    def test_build_stream_buffer_command(self):
+        """Tests the function that generates stream buffer executable command"""
+        # Should return empty string if buffer size is invalid or too small
+        assert commands.build_stream_buffer_command() is None
+        assert commands.build_stream_buffer_command(buffer_size=None) is None
+        assert commands.build_stream_buffer_command(buffer_size=0) is None
+        assert commands.build_stream_buffer_command(buffer_size=-10) is None
+
+        # Should use the minimum buffer size if enabled but less than minimal buffer size
+        assert commands.build_stream_buffer_command(buffer_size=1) == f'mbuffer -m {commands.MIN_STREAM_BUFFER_SIZE}M'
+
+        # Should raise StreamBufferTooLargeException if buffer_size is greater than the max allowed
+        with pytest.raises(StreamBufferTooLargeException):
+            commands.build_stream_buffer_command(buffer_size=commands.MAX_STREAM_BUFFER_SIZE + 1000)
+
+        # Should use custom buffer size if between max and min buffer size
+        assert commands.build_stream_buffer_command(buffer_size=100) == 'mbuffer -m 100M'
+
+        # Should use custom buffer binary executable if bin parameter provided
+        assert commands.build_stream_buffer_command(buffer_size=100, stream_buffer_bin='dummy_buffer') == \
+               f'dummy_buffer -m 100M'
+
+    def test_build_singer_command(self):
+        """Tests the function that generates the full singer singer command
+        that connects the required components with linux pipes"""
+        transform_config = '{}/resources/transform-config.json'.format(os.path.dirname(__file__))
+        transform_config_empty = '{}/resources/transform-config-empty.json'.format(os.path.dirname(__file__))
+        state_mock = __file__
+
+        # Should generate a command with tap state and transformation
+        tap_params = commands.TapParams(type='tap-mysql',
+                                        bin='/bin/tap_mysql.py',
+                                        config='.ppw/config.json',
+                                        properties='.ppw/properties.json',
+                                        state=state_mock)
+        target_params = commands.TargetParams(type='target-postgres',
+                                              bin='/bin/target_postgres.py',
+                                              config='.ppw/config.json')
+        transform_params = commands.TransformParams(bin='/bin/transform_field.py',
+                                                    config=transform_config)
+
+        command = commands.build_singer_command(tap_params, target_params, transform_params)
+
+        assert command == f'/bin/tap_mysql.py --config .ppw/config.json --properties .ppw/properties.json ' \
+                          f'--state {state_mock}' \
+                          f' | /bin/transform_field.py --config {transform_config}' \
+                          ' | /bin/target_postgres.py --config .ppw/config.json'
+
+        # Should generate a command without state and with transformation
+        tap_params = commands.TapParams(type='tap-mysql',
+                                        bin='/bin/tap_mysql.py',
+                                        config='.ppw/config.json',
+                                        properties='.ppw/properties.json',
+                                        state=None)
+        target_params = commands.TargetParams(type='target-postgres',
+                                              bin='/bin/target_postgres.py',
+                                              config='.ppw/config.json')
+        transform_params = commands.TransformParams(bin='/bin/transform_field.py',
+                                                    config=transform_config)
+
+        command = commands.build_singer_command(tap_params, target_params, transform_params)
+
+        assert command == f'/bin/tap_mysql.py --config .ppw/config.json --properties .ppw/properties.json ' \
+                          f' | /bin/transform_field.py --config {transform_config}' \
+                          ' | /bin/target_postgres.py --config .ppw/config.json'
+
+        # Should generate a command with state and without transformation
+        tap_params = commands.TapParams(type='tap-mysql',
+                                        bin='/bin/tap_mysql.py',
+                                        config='.ppw/config.json',
+                                        properties='.ppw/properties.json',
+                                        state=state_mock)
+        target_params = commands.TargetParams(type='target-postgres',
+                                              bin='/bin/target_postgres.py',
+                                              config='.ppw/config.json')
+        transform_params = commands.TransformParams(bin='/bin/transform_field.py',
+                                                    config=transform_config_empty)
+
+        command = commands.build_singer_command(tap_params, target_params, transform_params)
+
+        assert command == f'/bin/tap_mysql.py --config .ppw/config.json --properties .ppw/properties.json ' \
+                          f'--state {state_mock}' \
+                          ' | /bin/target_postgres.py --config .ppw/config.json'
+
+        # Should generate a command without state and transformation
+        tap_params = commands.TapParams(type='tap-mysql',
+                                        bin='/bin/tap_mysql.py',
+                                        config='.ppw/config.json',
+                                        properties='.ppw/properties.json',
+                                        state='.ppw/state.json')
+        target_params = commands.TargetParams(type='target-postgres',
+                                              bin='/bin/target_postgres.py',
+                                              config='.ppw/config.json')
+        transform_params = commands.TransformParams(bin='/bin/transform_field.py',
+                                                    config=transform_config_empty)
+
+        command = commands.build_singer_command(tap_params, target_params, transform_params)
+
+        assert command == '/bin/tap_mysql.py --config .ppw/config.json --properties .ppw/properties.json ' \
+                          ' | /bin/target_postgres.py --config .ppw/config.json'
+
+    def test_build_fastsync_command(self):
+        """Tests the function that generates the fastsync command"""
+        transform_config = '{}/resources/transform-config.json'.format(os.path.dirname(__file__))
+        state_mock = __file__
+        venv_dir = '.dummy_venv_dir'
+        temp_dir = 'dummy_temp_dir'
+
+        # Should generate a fastsync command with transformation
+        tap_params = commands.TapParams(type='tap-mysql',
+                                        bin='/bin/tap_mysql.py',
+                                        config='.ppw/tap_config.json',
+                                        properties='.ppw/properties.json',
+                                        state=state_mock)
+        target_params = commands.TargetParams(type='target-postgres',
+                                              bin='/bin/target_postgres.py',
+                                              config='.ppw/target_config.json')
+        transform_params = commands.TransformParams(bin='/bin/transform_field.py',
+                                                    config=None)
+        command = commands.build_fastsync_command(tap_params, target_params, transform_params, venv_dir, temp_dir)
+        assert command == '.dummy_venv_dir/pipelinewise/bin/mysql-to-postgres' \
+                          ' --tap .ppw/tap_config.json' \
+                          ' --properties .ppw/properties.json' \
+                          f' --state {state_mock}' \
+                          ' --target .ppw/target_config.json' \
+                          ' --temp_dir dummy_temp_dir'
+
+        # Should generate a fastsync command with transformation
+        transform_params = commands.TransformParams(bin='/bin/transform_field.py',
+                                                    config=transform_config)
+        command = commands.build_fastsync_command(tap_params, target_params, transform_params, venv_dir, temp_dir)
+        assert command == '.dummy_venv_dir/pipelinewise/bin/mysql-to-postgres' \
+                          ' --tap .ppw/tap_config.json' \
+                          ' --properties .ppw/properties.json' \
+                          f' --state {state_mock}' \
+                          ' --target .ppw/target_config.json' \
+                          ' --temp_dir dummy_temp_dir' \
+                          f' --transform {transform_config}'
+
+        # Should generate a fastsync command with specific list of tables
+        command = commands.build_fastsync_command(tap_params, target_params, transform_params, venv_dir, temp_dir,
+                                                  tables='public.table_one,public.table_two')
+        assert command == '.dummy_venv_dir/pipelinewise/bin/mysql-to-postgres' \
+                          ' --tap .ppw/tap_config.json' \
+                          ' --properties .ppw/properties.json' \
+                          f' --state {state_mock}' \
+                          ' --target .ppw/target_config.json' \
+                          ' --temp_dir dummy_temp_dir' \
+                          f' --transform {transform_config}' \
+                          ' --tables public.table_one,public.table_two'

--- a/tests/units/cli/test_commands.py
+++ b/tests/units/cli/test_commands.py
@@ -122,6 +122,26 @@ class TestCommands:
                           f' | /bin/transform_field.py --config {transform_config}' \
                           ' | /bin/target_postgres.py --config .ppw/config.json'
 
+        # Should generate a command with tap state and transformation and stream buffer
+        tap_params = commands.TapParams(type='tap-mysql',
+                                        bin='/bin/tap_mysql.py',
+                                        config='.ppw/config.json',
+                                        properties='.ppw/properties.json',
+                                        state=state_mock)
+        target_params = commands.TargetParams(type='target-postgres',
+                                              bin='/bin/target_postgres.py',
+                                              config='.ppw/config.json')
+        transform_params = commands.TransformParams(bin='/bin/transform_field.py',
+                                                    config=transform_config)
+
+        command = commands.build_singer_command(tap_params, target_params, transform_params, stream_buffer_size=10)
+
+        assert command == f'/bin/tap_mysql.py --config .ppw/config.json --properties .ppw/properties.json ' \
+                          f'--state {state_mock}' \
+                          f' | /bin/transform_field.py --config {transform_config}' \
+                          ' | mbuffer -m 10M' \
+                          ' | /bin/target_postgres.py --config .ppw/config.json'
+
         # Should generate a command without state and with transformation
         tap_params = commands.TapParams(type='tap-mysql',
                                         bin='/bin/tap_mysql.py',

--- a/tests/units/cli/test_config.py
+++ b/tests/units/cli/test_config.py
@@ -225,6 +225,7 @@ class TestConfig:
                             'type': 'tap-mysql',
                             'name': 'Sample MySQL Database',
                             'owner': 'somebody@foo.com',
+                            'stream_buffer_size': None,
                             'enabled': True,
                         }
                     ]


### PR DESCRIPTION
## Problem

Target components are blocking tap components to extract more data when it’s running slow Load type of queries and when it cannot load data fast enough. Blocking the tap connector to extract more data can cause timeout in the source database or high CPU load in the tap connector.

The linux kernel provides default 64K of buffer between tap and target connectors. We need to have a mechanism to create bigger buffer size optionally between taps and targets whenever it's required and when we're less tolerant on blocked tap connectors.

## Proposed changes

Linux pipes are asynchronous but provide only 64K buffer size by default. A nice documentation about Linux pipes available at [Linux pipes tips and tricks](https://blog.dataart.com/linux-pipes-tips-tricks).

This PR is using [mbuffer](https://www.maier-komor.de/mbuffer.html) as an optional buffering mechanism  and adds `stream_buffer_size` optional parameter to every tap YAML. If `stream_buffer_size` is greater than zero then mbuffer will be added between taps and targets:

```
tap-something | mbuffer -m <BUFFER_SIZE>M | target-something
```

If `stream_buffer_size` is zero or not defined then the standard singer piped commands will be executed which is using the linux pipes buffer mechanism with default 64K buffer size:

```
tap-something | target-something
```

Changed files

* [commands.py](https://github.com/transferwise/pipelinewise/blob/528199c013b3d233c174a81daa836ebc841bd9c5/pipelinewise/cli/commands.py) : New file with functions that responsible to generate command line executables, like, piped singer commands, fastsync, etc. 
* [test_commands.py](https://github.com/transferwise/pipelinewise/blob/ec2dc016591a2b909eb51aeb499de98da11c5ac4/tests/units/cli/test_commands.py) : Unit tests for [commands.py](https://github.com/transferwise/pipelinewise/blob/528199c013b3d233c174a81daa836ebc841bd9c5/pipelinewise/cli/commands.py)
* [pipelinewise.py](https://github.com/transferwise/pipelinewise/blob/528199c013b3d233c174a81daa836ebc841bd9c5/pipelinewise/cli/commands.py) : Slightly modified, and related functions moved to [commands.py](https://github.com/transferwise/pipelinewise/blob/528199c013b3d233c174a81daa836ebc841bd9c5/pipelinewise/cli/commands.py). [pipelinewise.py](https://github.com/transferwise/pipelinewise/blob/528199c013b3d233c174a81daa836ebc841bd9c5/pipelinewise/cli/commands.py) is too big in general, poorly structured and hard to test. Lot of further improvements should be done in this file, but that's not part of this PR.  
* [linux_pipes.rst](https://github.com/transferwise/pipelinewise/blob/528199c013b3d233c174a81daa836ebc841bd9c5/docs/concept/linux_pipes.rst) : Documentation
* **Others** : Added `stream_buffer_size` with default 0 (disabled) to every example YAML files, dev project YAML files and documentation

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
