### PR TITLE
[AP-772] Fix MySQL MEDIUMINT column type mapping in fastsync

### DIFF
--- a/dev-project/pipelinewise-config/tap_mysql_mariadb.yml
+++ b/dev-project/pipelinewise-config/tap_mysql_mariadb.yml
@@ -86,3 +86,7 @@ schemas:
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_space and UPPERCase"
         replication_method: "LOG_BASED"
+
+      ### Table with all possible data types
+      - table_name: "all_datatypes"
+        replication_method: "LOG_BASED"

--- a/pipelinewise/fastsync/mysql_to_postgres.py
+++ b/pipelinewise/fastsync/mysql_to_postgres.py
@@ -53,6 +53,7 @@ def tap_type_to_target_type(mysql_type, mysql_column_type):
         'int': 'INTEGER NULL',
         'tinyint': 'BOOLEAN' if mysql_column_type == 'tinyint(1)' else 'SMALLINT NULL',
         'smallint': 'SMALLINT NULL',
+        'mediumint': 'INTEGER NULL',
         'bigint': 'BIGINT NULL',
         'bit': 'BOOLEAN',
         'decimal': 'DOUBLE PRECISION',

--- a/pipelinewise/fastsync/mysql_to_redshift.py
+++ b/pipelinewise/fastsync/mysql_to_redshift.py
@@ -59,6 +59,7 @@ def tap_type_to_target_type(mysql_type, mysql_column_type):
         'int': 'NUMERIC NULL',
         'tinyint': 'BOOLEAN' if mysql_column_type == 'tinyint(1)' else 'NUMERIC NULL',
         'smallint': 'NUMERIC NULL',
+        'mediumint': 'NUMERIC NULL',
         'bigint': 'NUMERIC NULL',
         'bit': 'BOOLEAN',
         'decimal': 'FLOAT',

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -57,6 +57,7 @@ def tap_type_to_target_type(mysql_type, mysql_column_type):
         'int': 'NUMBER',
         'tinyint': 'BOOLEAN' if mysql_column_type == 'tinyint(1)' else 'NUMBER',
         'smallint': 'NUMBER',
+        'mediumint': 'NUMBER',
         'bigint': 'NUMBER',
         'bit': 'BOOLEAN',
         'decimal': 'FLOAT',

--- a/tests/db/tap_mysql_data.sql
+++ b/tests/db/tap_mysql_data.sql
@@ -268,6 +268,109 @@ INSERT INTO `table_with_space and UPPERCase`(end) VALUES (10),(9),(8),(7),(6),(3
 /*!40000 ALTER TABLE `table_with_space and UPPERCase` ENABLE KEYS */;
 UNLOCK TABLES;
 
+--
+-- Table structure for table `ALL_DATATYPES`
+--
+
+DROP TABLE IF EXISTS `all_datatypes`;
+CREATE TABLE `all_datatypes` (
+    c_char          CHAR        PRIMARY KEY,
+    c_varchar       VARCHAR(100),
+    c_binary        BINARY,
+    c_varbinary     VARBINARY(100),
+    c_blob          BLOB,
+    c_tinyblob      TINYBLOB,
+    c_mediumblob    MEDIUMBLOB,
+    c_longblob      LONGBLOB,
+    c_geometry      GEOMETRY,
+    c_text          TEXT,
+    c_tinytext      TINYTEXT,
+    c_mediumtext    MEDIUMTEXT,
+    c_longtext      LONGTEXT,
+    c_enum          ENUM('one', 'two', 'three'),
+    c_tinyint_bool  TINYINT(1),
+    c_tinyint       TINYINT,
+    c_smallint      SMALLINT,
+    c_mediumint     MEDIUMINT,
+    c_bigint        BIGINT,
+    c_bit           BIT,
+    c_decimal       DECIMAL,
+    c_double        DOUBLE,
+    c_float         FLOAT,
+    c_bool          BOOLEAN,
+    c_date          DATE,
+    c_datetime      DATETIME,
+    c_timestamp     TIMESTAMP,
+    c_json          JSON
+)
+ENGINE=MyISAM AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `table_with_space and UPPERCase`
+--
+
+LOCK TABLES `all_datatypes` WRITE;
+/*!40000 ALTER TABLE `all_datatypes` DISABLE KEYS */;
+INSERT INTO all_datatypes (c_char,
+                           c_varchar,
+                           c_binary,
+                           c_varbinary,
+                           c_blob,
+                           c_tinyblob,
+                           c_mediumblob,
+                           c_longblob,
+                           c_geometry,
+                           c_text,
+                           c_tinytext,
+                           c_mediumtext,
+                           c_longtext,
+                           c_enum,
+                           c_tinyint_bool,
+                           c_tinyint,
+                           c_smallint,
+                           c_mediumint,
+                           c_bigint,
+                           c_bit,
+                           c_decimal,
+                           c_double,
+                           c_float,
+                           c_bool,
+                           c_date,
+                           c_datetime,
+                           c_timestamp,
+                           c_json)
+VALUES ('x',
+        'c_varchar',
+        X'01',
+        X'0123456789abcdef',
+        X'0123456789abcdef',
+        X'0123456789abcdef',
+        X'0123456789abcdef',
+        X'0123456789abcdef',
+        POINT(1, 1),
+        'c_text',
+        'c_tinytext',
+        'c_mediumtext',
+        'c_longtext',
+        'one',
+        1,
+        123,
+        123,
+        123,
+        123,
+        1,
+        10,
+        10.2,
+        10.2,
+        true,
+        '2020-06-01',
+        '2100-06-01 10:00:00',
+        '2020-06-01 10:00:00',
+        '{"k1": "value", "k2": 10}'
+);
+/*!40000 ALTER TABLE `all_datatypes` ENABLE KEYS */;
+UNLOCK TABLES;
+
 
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/tests/end_to_end/helpers/assertions.py
+++ b/tests/end_to_end/helpers/assertions.py
@@ -159,12 +159,15 @@ def assert_row_counts_equal(tap_query_runner_fn: callable, target_query_runner_f
     assert row_counts_in_target == row_counts_in_source
 
 
-def assert_all_columns_exist(tap_query_runner_fn: callable, target_query_runner_fn: callable) -> None:
+def assert_all_columns_exist(tap_query_runner_fn: callable,
+                             target_query_runner_fn: callable,
+                             colum_type_mapper_fn: callable = None) -> None:
     """Takes two query runner methods, gets the columns list for every table in both the
     source and target database and tests if every column in source exists in the target database.
 
     :param tap_query_runner_fn: method to run queries in the first connection
-    :param target_query_runner_fn: method to run queries in the second connection"""
+    :param target_query_runner_fn: method to run queries in the second connection
+    :param colum_type_mapper_fn: method to convert source to target column types"""
     # Generate a map of source and target specific functions
     funcs = _map_tap_to_target_functions(tap_query_runner_fn, target_query_runner_fn)
 
@@ -180,20 +183,56 @@ def assert_all_columns_exist(tap_query_runner_fn: callable, target_query_runner_
     source_table_cols = _run_sql(tap_query_runner_fn, source_sql_get_cols)
     target_table_cols = _run_sql(target_query_runner_fn, target_sql_get_cols)
 
+    def _cols_list_to_dict(cols: List) -> dict:
+        """
+        Converts list of columns with char separators to dictionary
+
+        :param cols: list of ':' separated strings using the format of
+                     column_name:column_type:column_type_extra
+        :return: Dictionary of columns where key is the column_name
+        """
+        cols_dict = {}
+        for col in cols:
+            col_props = col.split(':')
+            cols_dict[col_props[0]] = {
+                'type': col_props[1],
+                'type_extra': col_props[2]
+            }
+
+        return cols_dict
+
     # Compare the two dataset
     for table_cols in source_table_cols:
         table_to_check = table_cols[0].lower()
-        source_cols = table_cols[1].lower().split(',')
+        source_cols = table_cols[1].lower().split(';')
 
         try:
-            target_cols = next(t[1] for t in target_table_cols if t[0].lower() == table_to_check).lower().split(',')
+            target_cols = next(t[1] for t in target_table_cols if t[0].lower() == table_to_check).lower().split(';')
         except StopIteration as ex:
             ex.args += ('Error', f'{table_to_check} table not found in target')
             raise
 
-        for col in source_cols:
+        source_cols_dict = _cols_list_to_dict(source_cols)
+        target_cols_dict = _cols_list_to_dict(target_cols)
+        print(target_cols_dict)
+        for col_name, col_props in source_cols_dict.items():
+            # Check if column exists in the target table
             try:
-                assert col in target_cols
+                assert col_name in target_cols_dict
             except AssertionError as ex:
-                ex.args += ('Error', f'{col} column not found in target table {table_to_check}')
+                ex.args += ('Error', f'{col_name} column not found in target table {table_to_check}')
                 raise
+
+            # Check if column type is expected in the target table, if mapper function provided
+            if colum_type_mapper_fn:
+                try:
+                    target_col = target_cols_dict[col_name]
+                    exp_col_type = colum_type_mapper_fn(col_props['type'], col_props['type_extra'])\
+                        .replace(' NULL', '').lower()
+                    act_col_type = target_col['type'].lower()
+                    assert act_col_type == exp_col_type
+                except AssertionError as ex:
+                    ex.args += ('Error', f'{col_name} column type is not as expected. '
+                                         f'Expected: {exp_col_type} '
+                                         f'Actual: {act_col_type}')
+                    raise

--- a/tests/end_to_end/helpers/assertions.py
+++ b/tests/end_to_end/helpers/assertions.py
@@ -159,6 +159,7 @@ def assert_row_counts_equal(tap_query_runner_fn: callable, target_query_runner_f
     assert row_counts_in_target == row_counts_in_source
 
 
+# pylint: disable=too-many-locals
 def assert_all_columns_exist(tap_query_runner_fn: callable,
                              target_query_runner_fn: callable,
                              colum_type_mapper_fn: callable = None) -> None:

--- a/tests/end_to_end/test-project/tap_mysql_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_pg.yml.template
@@ -73,3 +73,7 @@ schemas:
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_space and UPPERCase"
         replication_method: "LOG_BASED"
+
+      ### Table with all possible data types
+      - table_name: "all_datatypes"
+        replication_method: "LOG_BASED"

--- a/tests/end_to_end/test-project/tap_mysql_to_pg_buffered_stream.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_pg_buffered_stream.yml.template
@@ -73,3 +73,8 @@ schemas:
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_space and UPPERCase"
         replication_method: "LOG_BASED"
+
+      ### Table with all possible data types
+      - table_name: "all_datatypes"
+        replication_method: "LOG_BASED"
+

--- a/tests/end_to_end/test-project/tap_mysql_to_rs.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_rs.yml.template
@@ -73,3 +73,8 @@ schemas:
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_space and UPPERCase"
         replication_method: "LOG_BASED"
+
+      ### Table with all possible data types
+      - table_name: "all_datatypes"
+        replication_method: "LOG_BASED"
+

--- a/tests/end_to_end/test-project/tap_mysql_to_rs_buffered_stream.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_rs_buffered_stream.yml.template
@@ -73,3 +73,8 @@ schemas:
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_space and UPPERCase"
         replication_method: "LOG_BASED"
+
+      ### Table with all possible data types
+      - table_name: "all_datatypes"
+        replication_method: "LOG_BASED"
+

--- a/tests/end_to_end/test-project/tap_mysql_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_sf.yml.template
@@ -73,3 +73,8 @@ schemas:
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_space and UPPERCase"
         replication_method: "LOG_BASED"
+
+      ### Table with all possible data types
+      - table_name: "all_datatypes"
+        replication_method: "LOG_BASED"
+

--- a/tests/end_to_end/test-project/tap_mysql_to_sf_buffered_stream.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_sf_buffered_stream.yml.template
@@ -73,3 +73,8 @@ schemas:
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_space and UPPERCase"
         replication_method: "LOG_BASED"
+
+      ### Table with all possible data types
+      - table_name: "all_datatypes"
+        replication_method: "LOG_BASED"
+

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -6,6 +6,7 @@ from random import randint
 import bson
 import pytest
 from bson import Timestamp
+from pipelinewise.fastsync import mysql_to_postgres
 
 from .helpers import tasks
 from .helpers import assertions
@@ -68,7 +69,8 @@ class TestTargetPostgres:
         # 1. Run tap first time - both fastsync and a singer should be triggered
         assertions.assert_run_tap_success(tap_mariadb_id, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_mysql, self.run_query_target_postgres)
-        assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.e2e.run_query_target_postgres)
+        assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.run_query_target_postgres,
+                                            mysql_to_postgres.tap_type_to_target_type)
 
         # 2. Make changes in MariaDB source database
         #  LOG_BASED
@@ -85,7 +87,8 @@ class TestTargetPostgres:
         # 3. Run tap second time - both fastsync and a singer should be triggered, there are some FULL_TABLE
         assertions.assert_run_tap_success(tap_mariadb_id, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_mysql, self.run_query_target_postgres)
-        assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.e2e.run_query_target_postgres)
+        assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.run_query_target_postgres,
+                                            mysql_to_postgres.tap_type_to_target_type)
 
     # pylint: disable=invalid-name
     @pytest.mark.dependency(depends=['import_config'])
@@ -100,7 +103,7 @@ class TestTargetPostgres:
         # 1. Run tap first time - both fastsync and a singer should be triggered
         assertions.assert_run_tap_success(TAP_POSTGRES_ID, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_postgres, self.run_query_target_postgres)
-        assertions.assert_all_columns_exist(self.run_query_tap_postgres, self.e2e.run_query_target_postgres)
+        assertions.assert_all_columns_exist(self.run_query_tap_postgres, self.run_query_target_postgres)
 
         # 2. Make changes in pg source database
         #  LOG_BASED - Missing due to some changes that's required in tap-postgres to test it automatically
@@ -117,7 +120,7 @@ class TestTargetPostgres:
         # 3. Run tap second time - both fastsync and a singer should be triggered, there are some FULL_TABLE
         assertions.assert_run_tap_success(TAP_POSTGRES_ID, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_postgres, self.run_query_target_postgres)
-        assertions.assert_all_columns_exist(self.run_query_tap_postgres, self.e2e.run_query_target_postgres)
+        assertions.assert_all_columns_exist(self.run_query_tap_postgres, self.run_query_target_postgres)
 
     @pytest.mark.dependency(depends=['import_config'])
     def test_replicate_s3_to_pg(self):

--- a/tests/end_to_end/test_target_redshift.py
+++ b/tests/end_to_end/test_target_redshift.py
@@ -1,5 +1,7 @@
 import os
+
 import pytest
+from pipelinewise.fastsync import mysql_to_redshift
 
 from .helpers import tasks
 from .helpers import assertions
@@ -59,7 +61,8 @@ class TestTargetRedshift:
         # 1. Run tap first time - both fastsync and a singer should be triggered
         assertions.assert_run_tap_success(tap_mariadb_id, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_mysql, self.run_query_target_redshift)
-        assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.run_query_target_redshift)
+        assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.run_query_target_redshift,
+                                            mysql_to_redshift.tap_type_to_target_type)
 
         # 2. Make changes in MariaDB source database
         #  LOG_BASED
@@ -76,7 +79,8 @@ class TestTargetRedshift:
         # 3. Run tap second time - both fastsync and a singer should be triggered, there are some FULL_TABLE
         assertions.assert_run_tap_success(tap_mariadb_id, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_mysql, self.run_query_target_redshift)
-        assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.run_query_target_redshift)
+        assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.run_query_target_redshift,
+                                            mysql_to_redshift.tap_type_to_target_type)
 
     # pylint: disable=invalid-name
     @pytest.mark.dependency(depends=['import_config'])

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -6,6 +6,7 @@ from random import randint
 import bson
 import pytest
 from bson import Timestamp
+from pipelinewise.fastsync import mysql_to_snowflake
 
 from .helpers import tasks
 from .helpers import assertions
@@ -68,7 +69,8 @@ class TestTargetSnowflake:
         # 1. Run tap first time - both fastsync and a singer should be triggered
         assertions.assert_run_tap_success(tap_mariadb_id, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_mysql, self.run_query_target_snowflake)
-        assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.e2e.run_query_target_snowflake)
+        assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.e2e.run_query_target_snowflake,
+                                            mysql_to_snowflake.tap_type_to_target_type)
 
         # 2. Make changes in MariaDB source database
         #  LOG_BASED
@@ -85,7 +87,8 @@ class TestTargetSnowflake:
         # 3. Run tap second time - both fastsync and a singer should be triggered, there are some FULL_TABLE
         assertions.assert_run_tap_success(tap_mariadb_id, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_mysql, self.run_query_target_snowflake)
-        assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.e2e.run_query_target_snowflake)
+        assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.e2e.run_query_target_snowflake,
+                                            mysql_to_snowflake.tap_type_to_target_type)
 
     # pylint: disable=invalid-name
     @pytest.mark.dependency(depends=['import_config'])


### PR DESCRIPTION
## Problem

Fastsync is loading mariadb/mysql `MEDIUMINT` column type into wrong `VARCHAR` column in postgres, snowflake and redshift.

This is incorrect and not in sync with tap-mysql. Due to this issue fastsync first loads the data into a `VARCHAR` column than later singer sends the same column as `INTEGER`. This behaviour results a not necessary column versioning, and the data is loaded into two different columns.


This bug is reported as part of https://github.com/transferwise/pipelinewise/issues/389

## Proposed changes

1) Fastsync should map mysql/mariadb `MEDIUMINT` to `INTEGER` column types in every fastsync variant.
2) End to end test cases should check column type mappings. This PR extends the assertions.assert_all_columns_exist function to check target data types according to the expected type mapping.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
