### PR TITLE
[AP-781] Upgrade non-pinned dependencies when new version is available

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ make_virtualenv() {
     python3 -m pip install --upgrade pip setuptools
 
     if [ -f "requirements.txt" ]; then
-        python3 -m pip install -r requirements.txt
+        python3 -m pip install --upgrade -r requirements.txt
     fi
     if [ -f "setup.py" ]; then
         PIP_ARGS=
@@ -70,7 +70,7 @@ make_virtualenv() {
             PIP_ARGS=$PIP_ARGS"[test]"
         fi
 
-        python3 -m pip install -e .$PIP_ARGS
+        python3 -m pip install --upgrade -e .$PIP_ARGS
     fi
 
     echo ""


### PR DESCRIPTION
## Problem

During the latest deployment of PPW, we had an issue with install script not upgrading `pipelinewise-singer-python` to the latest version, that is because we don't delete the existing `.virtualenvs` when deploying, running `pip install` only will not upgrade these non-pinned dependencies.

## Proposed changes

Dependencies in PipleneWise or in its connectors that are not pinned to a specific version, such as `pipelinewise-singer-python-1.*` need to be upgraded whenever a new version that fits the pattern is present, adding `--upgrade` option will make sure of that.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
