### PR TITLE
[AP-784] Fix FastSync mongoDB

### DIFF
--- a/docs/connectors/taps/mongodb.rst
+++ b/docs/connectors/taps/mongodb.rst
@@ -95,12 +95,14 @@ Example YAML for ``tap-mongodb``:
 	# ------------------------------------------------------------------------------
 	db_conn:
 		host: "mongodb_host1,mongodb_host2,mongodb_host3" 	# Mongodb host(s)
-		port: 27017                           			# Mongodb port
-		user: "PipelineWiseUser"                  		# Mongodb user
-		password: "mY_VerY_StRonG_PaSSwoRd"                 	# Mongodb plain string or vault encrypted
-		auth_database: "admin"            			# Mongodb database to authenticate on
-		dbname: "my_db"           				# Mongodb database name to sync from
-		replica_set: "my_replica_set"        			# Optional, Mongodb replica set name, default null
+		port: 27017                           				# Mongodb port
+		user: "PipelineWiseUser"                  			# Mongodb user
+		password: "mY_VerY_StRonG_PaSSwoRd"                 # Mongodb plain string or vault encrypted
+		auth_database: "admin"            					# Mongodb database to authenticate on
+		dbname: "my_db"           							# Mongodb database name to sync from
+		replica_set: "my_replica_set"        				# Optional, Mongodb replica set name, default null
+  		write_batch_rows: <int>								# Optional: Number of rows to write to csv file
+                                       						#           in one batch. Default is 50000.
 
 	# ------------------------------------------------------------------------------
 	# Destination (Target) - Target properties
@@ -114,7 +116,7 @@ Example YAML for ``tap-mongodb``:
 	# Source to target Schema mapping
 	# ------------------------------------------------------------------------------
 	schemas:
-	  	- source_schema: "my_db"			# Same name as dbname
+	  	- source_schema: "my_db"					# Same name as dbname
 		  target_schema: "ppw_e2e_tap_mongodb"		# Name of target schema to load to
 
 		  # List of collections to sync

--- a/pipelinewise/cli/samples/tap_mongodb.yml.sample
+++ b/pipelinewise/cli/samples/tap_mongodb.yml.sample
@@ -19,7 +19,9 @@ db_conn:
   username: "<USERNAME>"							# User with read roles
   password: "<PASSWORD>"                            # Plain string or vault encrypted
   password: "secret"                    			# Mongodb plain string or vault encrypted
-  replica_set: "<replicaSet name>"        		# Mongodb replica set name, default null
+  replica_set: "<replicaSet name>"        			# Optional: Mongodb replica set name, default null
+  write_batch_rows: <int>							# Optional: Number of rows to write to csv file
+                                       				#           in one batch. Default is 50000.
 
 # ------------------------------------------------------------------------------
 # Destination (Target) - Target properties

--- a/tests/end_to_end/test-project/tap_mongodb_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_mongodb_to_pg.yml.template
@@ -19,7 +19,8 @@ db_conn:
   password: "${TAP_MONGODB_PASSWORD}"           # Mongodb plain string or vault encrypted
   auth_database: "admin"            			# Mongodb database to authenticate on
   dbname: "${TAP_MONGODB_DB}"           		# Mongodb database name to sync from
-#  replica_set: rs0      						# Mongodb replica set name, default null
+  replica_set: rs0      						# Mongodb replica set name, default null
+  write_batch_rows: 500
 
 # ------------------------------------------------------------------------------
 # Destination (Target) - Target properties

--- a/tests/end_to_end/test-project/tap_mongodb_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_mongodb_to_sf.yml.template
@@ -19,7 +19,8 @@ db_conn:
   password: "${TAP_MONGODB_PASSWORD}"           # Mongodb plain string or vault encrypted
   auth_database: "admin"            			# Mongodb database to authenticate on
   dbname: "${TAP_MONGODB_DB}"           		# Mongodb database name to sync from
-#  replica_set: rs0      						# Mongodb replica set name, default null
+  replica_set: rs0      						# Mongodb replica set name, default null
+  write_batch_rows: 500
 
 # ------------------------------------------------------------------------------
 # Destination (Target) - Target properties

--- a/tests/units/fastsync/commons/test_fastsync_tap_mongodb.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_mongodb.py
@@ -89,7 +89,8 @@ class TestFastSyncTapMongoDB(TestCase):
 
             call_mock.assert_called_once_with([
                 'mongodump',
-                '--uri', '"mongodb://my_user:secret@foo.com:3306/my_db?authSource=admin&readPreference=secondaryPreferred"',
+                '--uri', '"mongodb://my_user:secret@foo.com:3306/my_db'
+                         '?authSource=admin&readPreference=secondaryPreferred"',
                 '--forceTableScan',
                 '--gzip',
                 '-c', 'my_col',
@@ -114,7 +115,8 @@ class TestFastSyncTapMongoDB(TestCase):
                 with patch('pipelinewise.fastsync.commons.tap_mongodb.gzip') as gzip_mock:
                     mock_enter = Mock()
 
-                    with patch('pipelinewise.fastsync.commons.tap_mongodb.bson.decode_file_iter') as bson_decode_iter_mock:
+                    with patch('pipelinewise.fastsync.commons.tap_mongodb.bson.decode_file_iter') as \
+                            bson_decode_iter_mock:
 
                         bson_decode_iter_mock.return_value = [
                             {'_id': ObjectId('0123456789ab0123456789aa'), 'key1': 1, 'key2': time.time()},
@@ -131,7 +133,8 @@ class TestFastSyncTapMongoDB(TestCase):
 
                         call_mock.assert_called_once_with([
                             'mongodump',
-                            '--uri', '"mongodb://my_user:secret@foo.com:3306/my_db?authSource=admin&readPreference=secondaryPreferred"',
+                            '--uri', '"mongodb://my_user:secret@foo.com:3306/my_db'
+                                     '?authSource=admin&readPreference=secondaryPreferred"',
                             '--forceTableScan',
                             '--gzip',
                             '-c', 'my_col',

--- a/tests/units/fastsync/commons/test_fastsync_tap_mongodb.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_mongodb.py
@@ -89,7 +89,7 @@ class TestFastSyncTapMongoDB(TestCase):
 
             call_mock.assert_called_once_with([
                 'mongodump',
-                '--uri', '"mongodb://my_user:secret@foo.com:3306/my_db?authSource=admin"',
+                '--uri', '"mongodb://my_user:secret@foo.com:3306/my_db?authSource=admin&readPreference=secondaryPreferred"',
                 '--forceTableScan',
                 '--gzip',
                 '-c', 'my_col',
@@ -114,7 +114,7 @@ class TestFastSyncTapMongoDB(TestCase):
                 with patch('pipelinewise.fastsync.commons.tap_mongodb.gzip') as gzip_mock:
                     mock_enter = Mock()
 
-                    with patch('pipelinewise.fastsync.commons.tap_mongodb.bson.decode_iter') as bson_decode_iter_mock:
+                    with patch('pipelinewise.fastsync.commons.tap_mongodb.bson.decode_file_iter') as bson_decode_iter_mock:
 
                         bson_decode_iter_mock.return_value = [
                             {'_id': ObjectId('0123456789ab0123456789aa'), 'key1': 1, 'key2': time.time()},
@@ -131,7 +131,7 @@ class TestFastSyncTapMongoDB(TestCase):
 
                         call_mock.assert_called_once_with([
                             'mongodump',
-                            '--uri', '"mongodb://my_user:secret@foo.com:3306/my_db?authSource=admin"',
+                            '--uri', '"mongodb://my_user:secret@foo.com:3306/my_db?authSource=admin&readPreference=secondaryPreferred"',
                             '--forceTableScan',
                             '--gzip',
                             '-c', 'my_col',


### PR DESCRIPTION
## Problem

* Scalability

There is an a memory/scalability issue in this [line](https://github.com/transferwise/pipelinewise/blob/25f16fea25fab8d10eb71be5e7aa4acc2512744c/pipelinewise/fastsync/commons/tap_mongodb.py#L161), if the collection is big, e.g 1.5GB compressed or 25M documents, the statement `export_file.read()` will load all the documents into memory, which either cause a Memory error or take hours if not days for collections of size  30GB compressed just for `bson.decode_iter` to parse the data.

* Logging
There are no logs when a collection is being processed with FastSync which makes it hard to follow/know the progress.

## Proposed changes

* Scalability

The `bson` library has a function `decode_file_iter` which according to the doc:
> Decode bson data from a file to multiple documents as a generator.
Works similarly to the decode_all function, but reads from the file object in chunks and parses bson in chunks, yielding one document at a time.

This is is perfect, it indeed improves memory consumption as only one document at a time is present in memory.

* Logging
Add batch writing with logging messages. 


I run a test with collection that has 24M documents, ~1.6GB compressed. It took 1 hour with limited resources on PPW container
![image](https://user-images.githubusercontent.com/54845154/86462607-84ab7680-bd34-11ea-9045-dd655ec5df51.png)

-> The container memory consumption when from 100% to a constant 17% (~175MB) .


Here are the logs: 
```
time=2020-07-02 16:32:57 logger_name=pipelinewise.fastsync.mongodb_to_postgres log_level=INFO message=
        -------------------------------------------------------
        STARTING SYNC
        -------------------------------------------------------
            Tables selected to sync        : ['mongo_source_db.big_collection']
            Total tables selected to sync  : 1
            CPU cores                      : 8
        -------------------------------------------------------

time=2020-07-02 16:32:57 logger_name=pipelinewise.fastsync.commons.target_postgres log_level=INFO message=Running query: CREATE SCHEMA IF NOT EXISTS ppw_dev_tap_mongodb
time=2020-07-02 16:32:57 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=Starting export of table "big_collection"
time=2020-07-02 16:32:57 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=export "/opt/pipelinewise/big_collection.bson.gz"
time=2020-07-02 16:32:57 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=Starting bson data processing...
time=2020-07-02 16:32:58 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=Exporting batch from 0 to 10000 rows from mongo_source_db.big_collection...
time=2020-07-02 16:32:59 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=Exporting batch from 10000 to 20000 rows from mongo_source_db.big_collection...
time=2020-07-02 16:33:01 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=Exporting batch from 20000 to 30000 rows from mongo_source_db.big_collection...
time=2020-07-02 16:33:02 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=Exporting batch from 30000 to 40000 rows from mongo_source_db.big_collection...
time=2020-07-02 16:33:04 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=Exporting batch from 40000 to 50000 rows from mongo_source_db.big_collection...
time=2020-07-02 16:33:05 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=Exporting batch from 50000 to 60000 rows from mongo_source_db.big_collection...
time=2020-07-02 16:33:07 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=Exporting batch from 60000 to 70000 rows from mongo_source_db.big_collection...
.
.
.
time=2020-07-02 17:34:14 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=Exporting batch from 24940000 to 24950000 rows from mongo_source_db.big_collection...
time=2020-07-02 17:34:16 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=Exporting batch from 24950000 to 24960000 rows from mongo_source_db.big_collection...
time=2020-07-02 17:34:17 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=Exporting batch from 24960000 to 24970000 rows from mongo_source_db.big_collection...
time=2020-07-02 17:34:18 logger_name=pipelinewise.fastsync.commons.tap_mongodb log_level=INFO message=Exported total of 24975700 rows from mongo_source_db.big_collection...

```

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
