### PR TITLE
[AP-803] Fix data loss when syncing from postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,10 @@ references:
           TAP_MONGODB_ROOT_PASSWORD: Password1
 
       # PostgreSQL service container image used as test source database (for tap-postgres)
-      - image: postgres:11.4
+      - image: debezium/postgres:12-alpine
         name: db_postgres_source
+        # enable logical decoding
+        command: -c "wal_level=logical" -c "max_replication_slots=5" -c "max_wal_senders=5"
         environment:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test

--- a/singer-connectors/tap-postgres/requirements.txt
+++ b/singer-connectors/tap-postgres/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-postgres==1.6.2
+pipelinewise-tap-postgres==1.6.3

--- a/tests/end_to_end/test-project/tap_postgres_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_pg.yml.template
@@ -14,9 +14,9 @@ owner: "test-runner"
 # ------------------------------------------------------------------------------
 db_conn:
   host: "${TAP_POSTGRES_HOST}"          # PostgreSQL host
-  logical_poll_total_seconds: 5         # Time out if no LOG_BASED changes received for 3 seconds
-  break_at_end_lsn: false
-  max_run_seconds: 7
+  logical_poll_total_seconds: 5         # Time out if no LOG_BASED changes received for 5 seconds
+  break_at_end_lsn: false               # continue listening on changes
+  max_run_seconds: 7                    
   port: ${TAP_POSTGRES_PORT}            # PostgreSQL port
   user: "${TAP_POSTGRES_USER}"          # PostgreSQL user
   password: "${TAP_POSTGRES_PASSWORD}"  # Plain string or vault encrypted

--- a/tests/end_to_end/test-project/tap_postgres_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_pg.yml.template
@@ -14,7 +14,9 @@ owner: "test-runner"
 # ------------------------------------------------------------------------------
 db_conn:
   host: "${TAP_POSTGRES_HOST}"          # PostgreSQL host
-  logical_poll_total_seconds: 3         # Time out if no LOG_BASED changes received for 3 seconds
+  logical_poll_total_seconds: 5         # Time out if no LOG_BASED changes received for 3 seconds
+  break_at_end_lsn: false
+  max_run_seconds: 7
   port: ${TAP_POSTGRES_PORT}            # PostgreSQL port
   user: "${TAP_POSTGRES_USER}"          # PostgreSQL user
   password: "${TAP_POSTGRES_PASSWORD}"  # Plain string or vault encrypted
@@ -87,14 +89,13 @@ schemas:
         replication_method: "INCREMENTAL"
         replication_key: "cid"
 
-  # Logical replication is currently disabled in end to end
   ### SOURCE SCHEMA 3: logical 1
-  #- source_schema: "logical1"
-  #  target_schema: "ppw_e2e_tap_postgres_logical1"
-  #
-  #  tables:
-  #    - table_name: "logical1_table1"
-  #      replication_method: "LOG_BASED"
+  - source_schema: "logical1"
+    target_schema: "ppw_e2e_tap_postgres_logical1"
+
+    tables:
+      - table_name: "logical1_table1"
+        replication_method: "LOG_BASED"
   #    - table_name: "logical1_table2"
   #    - table_name: "logical1_edgydata"
 

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -126,6 +126,12 @@ class TestTargetPostgres:
         #  FULL_TABLE
         self.run_query_tap_postgres("DELETE FROM public.country WHERE code = 'UMI'")
 
+        #  LOG_BASED
+        self.run_query_tap_postgres('ALTER TABLE logical1.logical1_table1 ADD COLUMN bool_col bool;')
+        self.run_query_tap_postgres('ALTER TABLE logical1.logical1_table1 RENAME COLUMN cvarchar2 to varchar_col;')
+        self.run_query_tap_postgres('INSERT INTO logical1.logical1_table1 (cvarchar, varchar_col, bool_col) values '
+                                    '(\'insert after alter table\', \'this is renamed column\', true);')
+
         # 3. Run tap second time - both fastsync and a singer should be triggered, there are some FULL_TABLE
         assertions.assert_run_tap_success(TAP_POSTGRES_ID, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_postgres, self.run_query_target_postgres)


### PR DESCRIPTION
## Problem

When running tap-postgres `log_based`, new/renamed columns are not detected due the schema in the `properties.json` file being out of date. This results in data loss.

## Proposed changes

1. At the beginning of every sync, run new discovery of selected streams to get their latest schema representation then send the SCHEMA message to target
2. While doing logical replication, if the WAL payload contains a new column that the stream doesn't know about, refresh the stream schema and send a SCHEMA message to target before the RECORD message.

This should make the target up to date and receive the data in the new/renamed columns.

This change is in [pipelinewise-tap-postgres release v.1.6.3](https://github.com/transferwise/pipelinewise-tap-postgres/releases/tag/v1.6.3) 

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
