### PR TITLE
Support ACL for S3 uploads

### DIFF
--- a/docs/connectors/targets/redshift.rst
+++ b/docs/connectors/targets/redshift.rst
@@ -52,6 +52,7 @@ Example YAML for target-redshift:
                                                     #           Used instead of the given AWS keys for the COPY operation if provided
       s3_bucket: "<BUCKET_NAME>"                    # S3 external bucket name
       s3_key_prefix: "redshift-imports/"            # Optional: S3 key prefix
+      s3_acl: "bucket-owner-full-control"           # Optional: ACL for S3 objects
 
       # Optional: Overrides the default COPY options to load data into Redshift
       #           The values below are the defaults and fit for purpose for most cases.

--- a/docs/connectors/targets/snowflake.rst
+++ b/docs/connectors/targets/snowflake.rst
@@ -106,6 +106,7 @@ Example YAML for target-snowflake:
       #aws_session_token: "<SESSION_TOKEN>"         # S3 - Plain string or vault encrypted - If not provided, AWS_SESSION_TOKEN environment variable or IAM role will be used
       s3_bucket: "<BUCKET_NAME>"                    # S3 external stbucket name
       s3_key_prefix: "snowflake-imports/"           # Optional: S3 key prefix
+      s3_acl: "bucket-owner-full-control"           # Optional: ACL for S3 objects
 
       # stage and file_format are pre-created objects in Snowflake that requires to load and
       # merge data correctly from S3 to tables in one step without using temp tables

--- a/pipelinewise/cli/schemas/target.json
+++ b/pipelinewise/cli/schemas/target.json
@@ -24,6 +24,9 @@
         "s3_key_prefix": {
           "type": "string"
         },
+        "s3_acl": {
+          "type": "string"
+        },
         "stage": {
           "type": "string"
         },
@@ -81,6 +84,9 @@
         },
         "s3_key_prefix": {
           "type": "string"
+        },
+        "s3_acl": {
+          "type": "string"
         }
       },
       "required": [
@@ -134,6 +140,9 @@
           "type": "string"
         },
         "s3_key_prefix": {
+          "type": "string"
+        },
+        "s3_acl": {
           "type": "string"
         },
         "delimiter": {

--- a/pipelinewise/fastsync/commons/target_redshift.py
+++ b/pipelinewise/fastsync/commons/target_redshift.py
@@ -77,12 +77,15 @@ class FastSyncTargetRedshift:
 
     def upload_to_s3(self, file, table):
         bucket = self.connection_config['s3_bucket']
+        s3_acl = self.connection_config.get('s3_acl')
         s3_key_prefix = self.connection_config.get('s3_key_prefix', '')
         s3_key = '{}pipelinewise_{}_{}.csv.gz'.format(s3_key_prefix, table, time.strftime('%Y%m%d-%H%M%S'))
 
+        extra_args = {'ACL': s3_acl} if s3_acl else None
+
         LOGGER.info('Uploading to S3 bucket: %s, local file: %s, S3 key: %s', bucket, file, s3_key)
 
-        self.s3.upload_file(file, bucket, s3_key)
+        self.s3.upload_file(file, bucket, s3_key, ExtraArgs=extra_args)
 
         return s3_key
 

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -54,6 +54,7 @@ class FastSyncTargetSnowflake:
 
     def upload_to_s3(self, file, table, tmp_dir=None):
         bucket = self.connection_config['s3_bucket']
+        s3_acl = self.connection_config.get('s3_acl')
         s3_key_prefix = self.connection_config.get('s3_key_prefix', '')
         s3_key = '{}pipelinewise_{}_{}.csv.gz'.format(s3_key_prefix, table, time.strftime('%Y%m%d-%H%M%S'))
 
@@ -76,19 +77,22 @@ class FastSyncTargetSnowflake:
             )
 
             # Upload to s3
+            extra_args = {'ACL': s3_acl} if s3_acl else dict()
+
             # Send key and iv in the metadata, that will be required to decrypt and upload the encrypted file
-            metadata = {
+            extra_args['Metadata'] = {
                 'x-amz-key': encryption_metadata.key,
                 'x-amz-iv': encryption_metadata.iv
             }
-            self.s3.upload_file(encrypted_file, bucket, s3_key, ExtraArgs={'Metadata': metadata})
+            self.s3.upload_file(encrypted_file, bucket, s3_key, ExtraArgs=extra_args)
 
             # Remove the uploaded encrypted file
             os.remove(encrypted_file)
 
         # Upload to S3 without encrypting
         else:
-            self.s3.upload_file(file, bucket, s3_key)
+            extra_args = {'ACL': s3_acl} if s3_acl else None
+            self.s3.upload_file(file, bucket, s3_key, ExtraArgs=extra_args)
 
         return s3_key
 

--- a/singer-connectors/target-redshift/requirements.txt
+++ b/singer-connectors/target-redshift/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-redshift==1.4.1
+pipelinewise-target-redshift==1.5.0

--- a/singer-connectors/target-snowflake/requirements.txt
+++ b/singer-connectors/target-snowflake/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-snowflake==1.6.6
+pipelinewise-target-snowflake==1.7.0

--- a/tests/end_to_end/helpers/env.py
+++ b/tests/end_to_end/helpers/env.py
@@ -136,6 +136,7 @@ class E2EEnv:
                                                'optional': True},
                     'S3_BUCKET'             : {'value': os.environ.get('TARGET_SNOWFLAKE_S3_BUCKET')},
                     'S3_KEY_PREFIX'         : {'value': os.environ.get('TARGET_SNOWFLAKE_S3_KEY_PREFIX')},
+                    'S3_ACL'                : {'value': os.environ.get('TARGET_SNOWFLAKE_S3_ACL'), 'optional': True},
                     'STAGE'                 : {'value': os.environ.get('TARGET_SNOWFLAKE_STAGE')},
                     'FILE_FORMAT'           : {'value': os.environ.get('TARGET_SNOWFLAKE_FILE_FORMAT')},
                     'CLIENT_SIDE_ENCRYPTION_MASTER_KEY':
@@ -164,8 +165,9 @@ class E2EEnv:
                                                'optional': True},
                     'COPY_ROLE_ARN'         : {'value': os.environ.get('TARGET_REDSHIFT_COPY_ROLE_ARN'),
                                                'optional': True},
-                    'S3_BUCKET'              : {'value': os.environ.get('TARGET_REDSHIFT_S3_BUCKET')},
-                    'S3_KEY_PREFIX'         : {'value': os.environ.get('TARGET_REDSHIFT_S3_KEY_PREFIX')}
+                    'S3_BUCKET'             : {'value': os.environ.get('TARGET_REDSHIFT_S3_BUCKET')},
+                    'S3_KEY_PREFIX'         : {'value': os.environ.get('TARGET_REDSHIFT_S3_KEY_PREFIX')},
+                    'S3_ACL'                : {'value': os.environ.get('TARGET_REDSHIFT_S3_ACL'), 'optional': True}
                 }
             }
         }

--- a/tests/end_to_end/test-project/target_redshift.yml.template
+++ b/tests/end_to_end/test-project/target_redshift.yml.template
@@ -27,6 +27,7 @@ db_conn:
                                                                      #           Used instead of the given AWS keys for the COPY operation if provided
   s3_bucket: "${TARGET_REDSHIFT_S3_BUCKET}"             # S3 external bucket name
   s3_key_prefix: "${TARGET_REDSHIFT_S3_KEY_PREFIX}"     # Optional: S3 key prefix
+  s3_acl: "${TARGET_REDSHIFT_S3_ACL}"                   # Optional: ACL for S3 objects
 
   # Optional: Overrides the default COPY options to load data into Redshift
   #           The values below are the defaults and fit for purpose for most cases.

--- a/tests/end_to_end/test-project/target_snowflake.yml.template
+++ b/tests/end_to_end/test-project/target_snowflake.yml.template
@@ -23,7 +23,8 @@ db_conn:
   aws_secret_access_key: "${TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY}"  # S3 - Plain string or vault encrypted
   s3_bucket: "${TARGET_SNOWFLAKE_S3_BUCKET}"                    # S3 external stbucket name
   s3_key_prefix: "${TARGET_SNOWFLAKE_S3_KEY_PREFIX}"           # Optional: S3 key prefix
-
+  s3_acl: "${TARGET_SNOWFLAKE_S3_ACL}"                          # Optional: ACL for S3 objects
+  
   # stage and file_format are pre-created objects in Snowflake that requires to load and
   # merge data correctly from S3 to tables in one step without using temp tables
   #  stage      : External stage object pointing to an S3 bucket


### PR DESCRIPTION
## Problem

There is no way to update/alter the ACL on an S3 object when uploading (redshift/snowflake).

## Proposed changes

Allow `s3_acl` to be set in the target's configuration file. This is especially helpful when configuring S3 access through IAM and moving data across aws accounts. For example: `s3_acl: bucket-owner-full-control`.

## Types of changes

What types of changes does your code introduce to PipelineWise?
*Put an `x` in the boxes that apply*

- [ ]  Bugfix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x]  Documentation Update (if none of the other choices apply)

## Checklist

- [x]  I have read the [CONTRIBUTING](notion://www.notion.so/CONTRIBUTING.md) doc
- [x]  Description above provides context of the change
- [x]  I have added tests that prove my fix is effective or that my feature works
- [ ]  Unit tests for changes (not needed for documentation changes)
- [ ]  CI checks pass with my changes
- [ ]  Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ]  Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ]  Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ]  Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x]  Relevant documentation is updated including usage instructions