### PR TITLE
[AP-XXXX] Bump tap-zendesk to make rate_limit configurable

### DIFF
--- a/docs/connectors/taps/zendesk.rst
+++ b/docs/connectors/taps/zendesk.rst
@@ -35,6 +35,9 @@ Example YAML for tap-zendesk:
       access_token: "<ACCESS_TOKEN>"       # Plain string or vault encrypted
       subdomain: "zendesk_subdomain"       #
       start_date: "2000-01-01T00:00:00Z"   # Data before this date will be ignored
+      #rate_limit: 1000                    # If you wish to avoid ever hitting the rate limit
+      #max_workers: 10                     # Max concurrent threads when communicating to zendesk API
+      #batch_size: 50                      # Number of tickets to query in one batch
 
 
     # ------------------------------------------------------------------------------

--- a/pipelinewise/cli/samples/tap_zendesk.yml.sample
+++ b/pipelinewise/cli/samples/tap_zendesk.yml.sample
@@ -17,6 +17,9 @@ db_conn:
   access_token: "<ACCESS_TOKEN>"       # Plain string or vault encrypted
   subdomain: "zendesk_subdomain"       #
   start_date: "2000-01-01T00:00:00Z"   # Data before this date will be ignored
+  #rate_limit: 1000                    # If you wish to avoid ever hitting the rate limit
+  #max_workers: 10                     # Max concurrent threads when communicating to zendesk API
+  #batch_size: 50                      # Number of tickets to query in one batch
 
 
 # ------------------------------------------------------------------------------

--- a/singer-connectors/tap-zendesk/requirements.txt
+++ b/singer-connectors/tap-zendesk/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-zendesk==1.1.0
+pipelinewise-tap-zendesk==1.2.0


### PR DESCRIPTION
## Problem

`rate_limit`, `max_workers` and `batch_size` tap-zendesk parameters are not configurable.

## Proposed changes

Bump pipelinewise-tap-zendesk to 1.2.0 that allows the user to configure`rate_limit`, `max_workers` and `batch_size` parameters.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
