### PR TITLE
[AP-810] Resume token not JSON serializable

### DIFF
--- a/pipelinewise/fastsync/commons/tap_mongodb.py
+++ b/pipelinewise/fastsync/commons/tap_mongodb.py
@@ -237,8 +237,19 @@ class FastSyncTapMongoDB:
                 if token is not None:
                     break
 
+        # Token can look like:
+        #       {'_data': 'A_LONG_HEX_DECIMAL_STRING'}
+        #    or {'_data': 'A_LONG_HEX_DECIMAL_STRING', '_typeBits': b'SOME_HEX'}
+        # https://github.com/mongodb/mongo/blob/master/src/mongo/db/pipeline/resume_token.cpp#L82-L96
+
+        # Get the '_data' only from resume token
+        # token can contain a property '_typeBits' of type bytes which cannot be json
+        # serialized when saving the state in the function 'utils.save_state_file'.
+        # '_data' is enough to resume LOG_BASED Singer replication after FastSync
         return {
-            'token': token
+            'token': {
+                '_data': token['_data']
+            }
         }
 
     # pylint: disable=invalid-name

--- a/singer-connectors/tap-mongodb/requirements.txt
+++ b/singer-connectors/tap-mongodb/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mongodb==1.0.0
+pipelinewise-tap-mongodb==1.0.1


### PR DESCRIPTION
## Problem

In some cases, for an unknown reason, Mongodb servers generate a resume token that can look like this:

```py
{'_data': '825F167E8C000000322B022C2EC22461E5F6964002E128A18AC0004', '_typeBits': b'\x81\x80'}
```

The unexpected bytes property `_typeBits` causes replication to break as this token is not JSON serializable when saving the state to json file.


*Problematic server*
MongoDB sharded cluster v4.2.2-3

## Proposed changes

Extract the `_data` hex property only and save it as the token.
Manual test against the problematic server  proved this works, the server can still send in new changes streams with a token that has `_data` only.

Similar change in [pipelinewise-tap-mongodb](https://github.com/transferwise/pipelinewise-tap-mongodb/pull/8)

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
