### PR TITLE
[AP-814] Integrate tap-mysql and tap-mongodb changes

### DIFF
--- a/pipelinewise/cli/samples/tap_mongodb.yml.sample
+++ b/pipelinewise/cli/samples/tap_mongodb.yml.sample
@@ -24,6 +24,11 @@ db_conn:
   write_batch_rows: <int>							# Optional: Number of rows to write to csv file
                                        				#           in one batch. Default is 50000.
 
+  update_buffer_size: <int> 						# Optional: [LOG_BASED] The size of the buffer that holds detected update
+  													# operations in memory, the buffer is flushed once the size is reached. Default is 1.
+  await_time_ms: <int>								# Optional: [LOG_BASED] The maximum amount of time in milliseconds
+  													# the loge_base method waits for new data changes before exiting. Default is 1000 ms.
+
 # ------------------------------------------------------------------------------
 # Destination (Target) - Target properties
 # Connection details should be in the relevant target YAML file
@@ -45,7 +50,7 @@ schemas:
       - grp_stats
 
  	# Available replication methods: FULL_TABLE & LOG_BASED
-    # Default replicayion method is LOG_BASED
+    # Default replication method is LOG_BASED
     tables:
       - table_name: "table1"
         replication_method: "FULL_TABLE"

--- a/pipelinewise/cli/schemas/tap.json
+++ b/pipelinewise/cli/schemas/tap.json
@@ -143,6 +143,20 @@
         },
         {
           "properties": {
+            "db_conn": {
+              "type": "object",
+              "properties": {
+                "update_buffer_size": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 1000
+                },
+                "await_time_ms": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
             "schemas": {
             "type": "array",
             "items": {
@@ -154,8 +168,7 @@
                       "replication_method": {
                         "enum": ["LOG_BASED", "FULL_TABLE"]
                       }
-                    },
-                    "required": ["replication_method"]
+                    }
                   }
                 }
               },

--- a/singer-connectors/tap-mongodb/requirements.txt
+++ b/singer-connectors/tap-mongodb/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/transferwise/pipelinewise-tap-mongodb.git@master#egg=pipelinewise-tap-mongodb
+pipelinewise-tap-mongodb==1.1.0

--- a/singer-connectors/tap-mongodb/requirements.txt
+++ b/singer-connectors/tap-mongodb/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mongodb==1.0.1
+-e git+https://github.com/transferwise/pipelinewise-tap-mongodb.git@master#egg=pipelinewise-tap-mongodb

--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/transferwise/pipelinewise-tap-mysql.git@master#egg=pipelinewise-tap-mysql
+pipelinewise-tap-mysql=1.3.3

--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mysql==1.3.2
+-e git+https://github.com/transferwise/pipelinewise-tap-mysql.git@master#egg=pipelinewise-tap-mysql

--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mysql=1.3.3
+pipelinewise-tap-mysql==1.3.3

--- a/tests/end_to_end/test-project/tap_mongodb_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_mongodb_to_pg.yml.template
@@ -21,6 +21,8 @@ db_conn:
   dbname: "${TAP_MONGODB_DB}"           		# Mongodb database name to sync from
   replica_set: rs0      						# Mongodb replica set name, default null
   write_batch_rows: 500
+#  update_buffer_size: 1
+  await_time_ms: 5000 # 5 sec
 
 # ------------------------------------------------------------------------------
 # Destination (Target) - Target properties
@@ -39,7 +41,6 @@ schemas:
 
     tables:
       - table_name: "listings"
-        replication_method: "FULL_TABLE"
 
       - table_name: "my_collection"
         replication_method: "LOG_BASED"

--- a/tests/end_to_end/test-project/tap_mongodb_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_mongodb_to_sf.yml.template
@@ -21,6 +21,8 @@ db_conn:
   dbname: "${TAP_MONGODB_DB}"           		# Mongodb database name to sync from
   replica_set: rs0      						# Mongodb replica set name, default null
   write_batch_rows: 500
+  update_buffer_size: 30
+#  await_time_ms: 5000 # 5 sec
 
 # ------------------------------------------------------------------------------
 # Destination (Target) - Target properties
@@ -39,7 +41,6 @@ schemas:
 
     tables:
       - table_name: "listings"
-        replication_method: "FULL_TABLE"
 
       - table_name: "my_collection"
         replication_method: "LOG_BASED"

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -75,6 +75,12 @@ class TestTargetPostgres:
         # 2. Make changes in MariaDB source database
         #  LOG_BASED
         self.run_query_tap_mysql('UPDATE weight_unit SET isactive = 0 WHERE weight_unit_id IN (2, 3, 4)')
+        self.run_query_tap_mysql('ALTER table weight_unit add column bool_col bool;')
+        self.run_query_tap_mysql('INSERT into weight_unit(weight_unit_name, isActive, original_date_created, bool_col) '
+                                 'values (\'Oz\', false, \'2020-07-23 10:00:00\', true);')
+        self.run_query_tap_mysql('ALTER table weight_unit change column bool_col is_imperial bool;')
+        self.run_query_tap_mysql('UPDATE weight_unit SET is_imperial = true WHERE weight_unit_name like \'%oz%\'')
+
         #  INCREMENTAL
         self.run_query_tap_mysql('INSERT INTO address(isactive, street_number, date_created, date_updated,'
                                  ' supplier_supplier_id, zip_code_zip_code_id)'
@@ -104,7 +110,7 @@ class TestTargetPostgres:
     def test_replicate_mariadb_to_pg_with_custom_buffer_size(self):
         """Replicate data from MariaDB to Postgres DWH with custom buffer size
         Same tests cases as test_replicate_mariadb_to_pg but using another tap with custom stream buffer size"""
-        self.test_replicate_mariadb_to_pg(tap_mariadb_id=TAP_MARIADB_BUFFERED_STREAM_ID)
+        self.test_resync_mariadb_to_pg(tap_mariadb_id=TAP_MARIADB_BUFFERED_STREAM_ID)
 
     @pytest.mark.dependency(depends=['import_config'])
     def test_replicate_pg_to_pg(self):

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -211,7 +211,7 @@ class TestTargetPostgres:
 
         result_update = self.mongodb_con.my_collection.update_many({}, {'$set': {'id': 0}})
 
-        assertions.assert_run_tap_success(TAP_MONGODB_ID, TARGET_ID, ['fastsync', 'singer'])
+        assertions.assert_run_tap_success(TAP_MONGODB_ID, TARGET_ID, ['singer'])
 
         assert result_update.modified_count == self.run_query_target_postgres(
             'select count(_id) from ppw_e2e_tap_mongodb.my_collection where cast(document->>\'id\' as int) = 0')[0][0]

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -204,7 +204,7 @@ class TestTargetSnowflake:
 
         result_update = self.mongodb_con.my_collection.update_many({}, {'$set': {'id': 0}})
 
-        assertions.assert_run_tap_success(TAP_MONGODB_ID, TARGET_ID, ['fastsync', 'singer'])
+        assertions.assert_run_tap_success(TAP_MONGODB_ID, TARGET_ID, ['singer'])
 
         assert result_update.modified_count == self.run_query_target_snowflake(
             'select count(_id) from ppw_e2e_tap_mongodb.my_collection where document:id = 0')[0][0]


### PR DESCRIPTION
## Problem

1. tap-mongodb LOG_BASED has some hardcoded parameters.
2. tap-mysql log_based not detecting new/renamed columns during runtime.

## Proposed changes

1. Make buffer size and await time configurable, [changes](https://github.com/transferwise/pipelinewise-tap-mongodb/pull/10) in connector. 
2 add check for new columns during log_based and send new schema message to target with up to date schema. [Changes](https://github.com/transferwise/pipelinewise-tap-mysql/pull/27) in connector,

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
