### PR TITLE
[AP-822] Bump target-s3-csv

### DIFF
--- a/docs/connectors/targets/s3_csv.rst
+++ b/docs/connectors/targets/s3_csv.rst
@@ -12,6 +12,20 @@ Loading data to S3 in CSV file format is straightforward. You need to have
 access to an S3 bucket and you can generate data files on S3 from all the
 supported :ref:`taps_list`.
 
+
+.. warning::
+
+  **Authentication Methods**
+
+   * **Profile based authentication**: This is the default authentication method. Credentials taken from
+     the ``default`` AWS profile, that's available on the host where PipelineWise is running.
+     To use anoter profile set the ``aws_profile`` parameter.
+   * **Non-profile based authentication**: To provide fixed credentials set ``aws_access_key_id``,
+     ``aws_secret_access_key`` and optionally the ``aws_session_token`` parameters.
+
+     Optionally the credentials can be vault-encrypted in the YAML. Please check :ref:`encrypting_passwords`
+     for further details.
+
 Configuring where to replicate data
 '''''''''''''''''''''''''''''''''''
 
@@ -37,12 +51,18 @@ Example YAML for ``target-s3-csv``:
     # Target - S3 details
     # ------------------------------------------------------------------------------
     db_conn:
-      aws_access_key_id: "<ACCESS_KEY>"             # S3 - Plain string or vault encrypted
-      aws_secret_access_key: "<SECRET_ACCESS_KEY>"  # S3 - Plain string or vault encrypted
-      s3_bucket: "<BUCKET_NAME>"                    # S3 external stbucket name
+      # Profile based authentication
+      aws_profile: "<AWS_PROFILE>"                   # AWS profile name, if not provided, the 'default' profile will be used
 
-      s3_key_prefix: "pipelinewise-exports/"        # (Default: None) A static prefix before the generated S3 key names
-      delimiter: ","                                # (Default: ',') A one-character string used to separate fields.
-      quotechar: "\""                               # Default: '\"') A one-character string used to quote fields containing
-                                                      special characters, such as the delimiter or quotechar, or which contain
-                                                      new-line characters.
+      # Non-profile based authentication
+      #aws_access_key_id: "<ACCESS_KEY>"             # AWS access key id - Plain string or vault encrypted
+      #aws_secret_access_key: "<SECRET_ACCESS_KEY"   # AWS secret access key - Plain string or vault encrypted
+      #aws_session_token: "<AWS_SESSION_TOKEN>"      # AWS session token - Plain string or vault encrypted
+
+      s3_bucket: "<BUCKET_NAME>"                     # S3 bucket name
+
+      s3_key_prefix: "pipelinewise-exports/"         # (Default: None) A static prefix before the generated S3 key names
+      delimiter: ","                                 # (Default: ',') A one-character string used to separate fields.
+      quotechar: "\""                                # Default: '\"') A one-character string used to quote fields containing
+                                                       special characters, such as the delimiter or quotechar, or which contain
+                                                       new-line characters.

--- a/pipelinewise/cli/samples/target_s3_csv.yml.sample
+++ b/pipelinewise/cli/samples/target_s3_csv.yml.sample
@@ -12,9 +12,15 @@ type: "target-s3-csv"                  # !! THIS SHOULD NOT CHANGE !!
 # Target - S3 details
 # ------------------------------------------------------------------------------
 db_conn:
-  aws_access_key_id: "<ACCESS_KEY>"             # S3 access key id - Plain string or vault encrypted
-  aws_secret_access_key: "<SECRET_ACCESS_KEY"   # S3 secret access key - Plain string or vault encrypted
-  s3_bucket: "<BUCKET_NAME>"                    # S3 bucket name
+  # Profile based authentication
+  aws_profile: "<AWS_PROFILE>"                   # AWS profile name, if not provided, the 'default' profile will be used
+
+  # Non-profile based authentication
+  #aws_access_key_id: "<ACCESS_KEY>"             # AWS access key id - Plain string or vault encrypted
+  #aws_secret_access_key: "<SECRET_ACCESS_KEY"   # AWS secret access key - Plain string or vault encrypted
+  #aws_session_token: "<AWS_SESSION_TOKEN>"      # AWS session token - Plain string or vault encrypted
+
+  s3_bucket: "<BUCKET_NAME>"                     # S3 bucket name
 
   # Optional keys
   #s3_key_prefix: "pipelinewise-exports/"        # (Default: None) A static prefix before the generated S3 key names

--- a/singer-connectors/target-s3-csv/requirements.txt
+++ b/singer-connectors/target-s3-csv/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-s3-csv==1.2.1
+pipelinewise-target-s3-csv==1.3.0


### PR DESCRIPTION
## Problem

target-s3-csv is using hard coded `aws_access_key_id` and `aws_secret_access_key` to connect to S3. This is not great because it requires hard coded credentials in tap YAMLs.

## Proposed changes

Bump to pipelinewise-target-s3-csv 1.3.0 that adds suppoort for profile based authentication and to provide credentials as environment variables.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
