### PR TITLE
[AP-823] Add botocore.exceptions. to known error pattern list

### DIFF
--- a/pipelinewise/cli/commands.py
+++ b/pipelinewise/cli/commands.py
@@ -306,9 +306,8 @@ def run_command(command: str, log_file: str = None, line_callback: callable = No
             # Raise run command exception
             errors = ''.join(utils.find_errors_in_log_file(log_file_failed))
             raise RunCommandException(f'Command failed. Return code: {proc_rc}\n'
-                                      f'Errors found:\n{errors}\n'
-                                      f'Full log: {log_file_failed}\n'
-                                      f'E')
+                                      f'Error(s) found:\n{errors}\n'
+                                      f'Full log: {log_file_failed}')
 
         # Add success status to the log file name
         os.rename(log_file_running, log_file_success)

--- a/pipelinewise/cli/utils.py
+++ b/pipelinewise/cli/utils.py
@@ -469,7 +469,8 @@ def find_errors_in_log_file(file, max_errors=10, error_pattern=None):
         # Basic tap and target connector exception patterns
         r'pymysql\.err|'
         r'psycopg2\.*Error|'
-        r'snowflake\.connector\.errors')
+        r'snowflake\.connector\.errors|'
+        r'botocore\.exceptions\.')
 
     # Use known error patterns by default
     if not error_pattern:

--- a/pipelinewise/cli/utils.py
+++ b/pipelinewise/cli/utils.py
@@ -470,7 +470,10 @@ def find_errors_in_log_file(file, max_errors=10, error_pattern=None):
         r'pymysql\.err|'
         r'psycopg2\.*Error|'
         r'snowflake\.connector\.errors|'
-        r'botocore\.exceptions\.')
+        r'botocore\.exceptions\.|'
+        # Generic python exceptions
+        r'\.[E|e]xception|'
+        r'\.[E|e]rror')
 
     # Use known error patterns by default
     if not error_pattern:

--- a/tests/units/cli/resources/sample_log_files/tap-run-errors.log
+++ b/tests/units/cli/resources/sample_log_files/tap-run-errors.log
@@ -34,5 +34,9 @@ snowflake.connector.errors.ProgrammingError: 091003 (22000): Failure using stage
 # Some botocore error
 botocore.exceptions.HTTPClientError: An HTTP Client raised and unhandled exception: 'No field numbered 1 is present in this asn1crypto.keys.PublicKeyInfo'
 
+# Some generic python exception and error
+foo.exception.FakeException: This is a test exception
+foo.error.FakeError: This is a test exception
+
 # Custom error pattern
 CUSTOM-ERR-PATTERN: This is a custom pattern error message

--- a/tests/units/cli/resources/sample_log_files/tap-run-errors.log
+++ b/tests/units/cli/resources/sample_log_files/tap-run-errors.log
@@ -31,5 +31,8 @@ psycopg2.DatabaseError: error with status PGRES_COPY_BOTH and no message from th
 # Some target-snowflake error
 snowflake.connector.errors.ProgrammingError: 091003 (22000): Failure using stage area. Cause: [Access Denied (Status Code: 403; Error Code: AccessDenied)]
 
+# Some botocore error
+botocore.exceptions.HTTPClientError: An HTTP Client raised and unhandled exception: 'No field numbered 1 is present in this asn1crypto.keys.PublicKeyInfo'
+
 # Custom error pattern
 CUSTOM-ERR-PATTERN: This is a custom pattern error message

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -350,7 +350,9 @@ class TestUtils:
                 'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL '
                 'message=error with status PGRES_COPY_BOTH and no message from the libpq\n',
                 'snowflake.connector.errors.ProgrammingError: 091003 (22000): '
-                'Failure using stage area. Cause: [Access Denied (Status Code: 403; Error Code: AccessDenied)]\n']
+                'Failure using stage area. Cause: [Access Denied (Status Code: 403; Error Code: AccessDenied)]\n',
+                "botocore.exceptions.HTTPClientError: An HTTP Client raised and unhandled exception: "
+                "'No field numbered 1 is present in this asn1crypto.keys.PublicKeyInfo'\n"]
 
         # Should return the default max number of errors
         log_file = '{}/resources/sample_log_files/tap-run-lot-of-errors.log'.format(os.path.dirname(__file__))

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -351,7 +351,7 @@ class TestUtils:
                 'message=error with status PGRES_COPY_BOTH and no message from the libpq\n',
                 'snowflake.connector.errors.ProgrammingError: 091003 (22000): '
                 'Failure using stage area. Cause: [Access Denied (Status Code: 403; Error Code: AccessDenied)]\n',
-                "botocore.exceptions.HTTPClientError: An HTTP Client raised and unhandled exception: "
+                'botocore.exceptions.HTTPClientError: An HTTP Client raised and unhandled exception: '
                 "'No field numbered 1 is present in this asn1crypto.keys.PublicKeyInfo'\n"]
 
         # Should return the default max number of errors

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -352,7 +352,9 @@ class TestUtils:
                 'snowflake.connector.errors.ProgrammingError: 091003 (22000): '
                 'Failure using stage area. Cause: [Access Denied (Status Code: 403; Error Code: AccessDenied)]\n',
                 'botocore.exceptions.HTTPClientError: An HTTP Client raised and unhandled exception: '
-                "'No field numbered 1 is present in this asn1crypto.keys.PublicKeyInfo'\n"]
+                "'No field numbered 1 is present in this asn1crypto.keys.PublicKeyInfo'\n",
+                'foo.exception.FakeException: This is a test exception\n',
+                'foo.error.FakeError: This is a test exception\n']
 
         # Should return the default max number of errors
         log_file = '{}/resources/sample_log_files/tap-run-lot-of-errors.log'.format(os.path.dirname(__file__))


### PR DESCRIPTION
## Problem

Sometimes PPW alerts not including the error. For example botocore exceptions like this one:

```
botocore.exceptions.HTTPClientError: An HTTP Client raised and unhandled exception: 'No field numbered 1 is present in this asn1crypto.keys.PublicKeyInfo'
```

## Proposed changes

Add `botocore.exceptions.` as known PPW error pattern.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
