### PR TITLE
[AP-742] tap-mysql: detect schema changes during log_based

### DIFF
--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/transferwise/pipelinewise-tap-mysql.git@AP-742#egg=pipelinewise-tap-mysql
+-e git+https://github.com/transferwise/pipelinewise-tap-mysql.git@master#egg=pipelinewise-tap-mysql

--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/transferwise/pipelinewise-tap-mysql.git@master#egg=pipelinewise-tap-mysql
+pipelinewise-tap-mysql==1.3.4

--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mysql==1.3.2
+-e git+https://github.com/transferwise/pipelinewise-tap-mysql.git@master#egg=pipelinewise-tap-mysql

--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/transferwise/pipelinewise-tap-mysql.git@master#egg=pipelinewise-tap-mysql
+-e git+https://github.com/transferwise/pipelinewise-tap-mysql.git@AP-742#egg=pipelinewise-tap-mysql

--- a/tests/end_to_end/helpers/assertions.py
+++ b/tests/end_to_end/helpers/assertions.py
@@ -172,7 +172,8 @@ def assert_row_counts_equal(tap_query_runner_fn: callable, target_query_runner_f
 # pylint: disable=too-many-locals
 def assert_all_columns_exist(tap_query_runner_fn: callable,
                              target_query_runner_fn: callable,
-                             colum_type_mapper_fn: callable = None) -> None:
+                             colum_type_mapper_fn: callable = None,
+                             ignore_cols = set()) -> None:
     """Takes two query runner methods, gets the columns list for every table in both the
     source and target database and tests if every column in source exists in the target database.
 
@@ -228,6 +229,10 @@ def assert_all_columns_exist(tap_query_runner_fn: callable,
         print(target_cols_dict)
         for col_name, col_props in source_cols_dict.items():
             # Check if column exists in the target table
+
+            if col_name in ignore_cols:
+                continue
+
             try:
                 assert col_name in target_cols_dict
             except AssertionError as ex:

--- a/tests/end_to_end/helpers/assertions.py
+++ b/tests/end_to_end/helpers/assertions.py
@@ -176,10 +176,13 @@ def assert_all_columns_exist(tap_query_runner_fn: callable,
                              ignore_cols: Union[Set, List] = None) -> None:
     """Takes two query runner methods, gets the columns list for every table in both the
     source and target database and tests if every column in source exists in the target database.
+    Some taps have unsupported column types and these are not part of the schemas published to the target thus
+    target table doesn't have such columns.
 
     :param tap_query_runner_fn: method to run queries in the first connection
     :param target_query_runner_fn: method to run queries in the second connection
-    :param column_type_mapper_fn: method to convert source to target column types"""
+    :param column_type_mapper_fn: method to convert source to target column types
+    :param ignore_cols: List or set of columns to ignore if we know target table won't have them"""
     # Generate a map of source and target specific functions
     funcs = _map_tap_to_target_functions(tap_query_runner_fn, target_query_runner_fn)
 

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -75,6 +75,14 @@ class TestTargetPostgres:
         # 2. Make changes in MariaDB source database
         #  LOG_BASED
         self.run_query_tap_mysql('UPDATE weight_unit SET isactive = 0 WHERE weight_unit_id IN (2, 3, 4)')
+        self.run_query_tap_mysql('ALTER table weight_unit add column bool_col bool;')
+        self.run_query_tap_mysql('INSERT into weight_unit(weight_unit_name, isActive, original_date_created, bool_col) '
+                                 'values (\'Oz\', false, \'2020-07-23 10:00:00\', true);')
+        self.run_query_tap_mysql('ALTER table weight_unit add column blob_col blob;')
+        self.run_query_tap_mysql('INSERT into weight_unit(weight_unit_name, isActive, original_date_created, blob_col) '
+                                 'values (\'Oz\', false, \'2020-07-23 10:00:00\', \'blob content\');')
+        self.run_query_tap_mysql('ALTER table weight_unit change column bool_col is_imperial bool;')
+        self.run_query_tap_mysql('UPDATE weight_unit SET is_imperial = false WHERE weight_unit_name like \'%oz%\'')
 
         #  INCREMENTAL
         self.run_query_tap_mysql('INSERT INTO address(isactive, street_number, date_created, date_updated,'
@@ -105,7 +113,7 @@ class TestTargetPostgres:
     def test_replicate_mariadb_to_pg_with_custom_buffer_size(self):
         """Replicate data from MariaDB to Postgres DWH with custom buffer size
         Same tests cases as test_replicate_mariadb_to_pg but using another tap with custom stream buffer size"""
-        self.test_replicate_mariadb_to_pg(tap_mariadb_id=TAP_MARIADB_BUFFERED_STREAM_ID)
+        self.test_resync_mariadb_to_pg(tap_mariadb_id=TAP_MARIADB_BUFFERED_STREAM_ID)
 
     @pytest.mark.dependency(depends=['import_config'])
     def test_replicate_pg_to_pg(self):

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -97,7 +97,7 @@ class TestTargetPostgres:
         assertions.assert_run_tap_success(tap_mariadb_id, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_mysql, self.run_query_target_postgres)
         assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.run_query_target_postgres,
-                                            mysql_to_postgres.tap_type_to_target_type)
+                                            mysql_to_postgres.tap_type_to_target_type, {'blob_col'})
 
     @pytest.mark.dependency(depends=['import_config'])
     def test_resync_mariadb_to_pg(self, tap_mariadb_id=TAP_MARIADB_ID):

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -75,15 +75,6 @@ class TestTargetSnowflake:
         # 2. Make changes in MariaDB source database
         #  LOG_BASED
         self.run_query_tap_mysql('UPDATE weight_unit SET isactive = 0 WHERE weight_unit_id IN (2, 3, 4)')
-        self.run_query_tap_mysql('ALTER table weight_unit add column bool_col bool;')
-        self.run_query_tap_mysql('INSERT into weight_unit(weight_unit_name, isActive, original_date_created, bool_col) '
-                                 'values (\'Oz\', false, \'2020-07-23 10:00:00\', true);')
-        self.run_query_tap_mysql('ALTER table weight_unit add column blob_col blob;')
-        self.run_query_tap_mysql('INSERT into weight_unit(weight_unit_name, isActive, original_date_created, blob_col) '
-                                 'values (\'Oz\', false, \'2020-07-23 10:00:00\', \'blob content\');')
-        self.run_query_tap_mysql('ALTER table weight_unit change column bool_col is_imperial bool;')
-        self.run_query_tap_mysql('UPDATE weight_unit SET is_imperial = false WHERE weight_unit_name like \'%oz%\'')
-
         #  INCREMENTAL
         self.run_query_tap_mysql('INSERT INTO address(isactive, street_number, date_created, date_updated,'
                                  ' supplier_supplier_id, zip_code_zip_code_id)'

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -75,6 +75,15 @@ class TestTargetSnowflake:
         # 2. Make changes in MariaDB source database
         #  LOG_BASED
         self.run_query_tap_mysql('UPDATE weight_unit SET isactive = 0 WHERE weight_unit_id IN (2, 3, 4)')
+        self.run_query_tap_mysql('ALTER table weight_unit add column bool_col bool;')
+        self.run_query_tap_mysql('INSERT into weight_unit(weight_unit_name, isActive, original_date_created, bool_col) '
+                                 'values (\'Oz\', false, \'2020-07-23 10:00:00\', true);')
+        self.run_query_tap_mysql('ALTER table weight_unit add column blob_col blob;')
+        self.run_query_tap_mysql('INSERT into weight_unit(weight_unit_name, isActive, original_date_created, blob_col) '
+                                 'values (\'Oz\', false, \'2020-07-23 10:00:00\', \'blob content\');')
+        self.run_query_tap_mysql('ALTER table weight_unit change column bool_col is_imperial bool;')
+        self.run_query_tap_mysql('UPDATE weight_unit SET is_imperial = false WHERE weight_unit_name like \'%oz%\'')
+
         #  INCREMENTAL
         self.run_query_tap_mysql('INSERT INTO address(isactive, street_number, date_created, date_updated,'
                                  ' supplier_supplier_id, zip_code_zip_code_id)'
@@ -88,7 +97,7 @@ class TestTargetSnowflake:
         assertions.assert_run_tap_success(tap_mariadb_id, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_mysql, self.run_query_target_snowflake)
         assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.e2e.run_query_target_snowflake,
-                                            mysql_to_snowflake.tap_type_to_target_type)
+                                            mysql_to_snowflake.tap_type_to_target_type, {'blob_col'})
 
     @pytest.mark.dependency(depends=['import_config'])
     def test_resync_mariadb_to_sf(self, tap_mariadb_id=TAP_MARIADB_ID):
@@ -100,9 +109,9 @@ class TestTargetSnowflake:
 
     # pylint: disable=invalid-name
     @pytest.mark.dependency(depends=['import_config'])
-    def test_replicate_mariadb_to_pg_with_custom_buffer_size(self):
+    def test_replicate_mariadb_to_sf_with_custom_buffer_size(self):
         """Replicate data from MariaDB to Snowflake with custom buffer size
-        Same tests cases as test_replicate_mariadb_to_pg but using another tap with custom stream buffer size"""
+        Same tests cases as test_replicate_mariadb_to_sf but using another tap with custom stream buffer size"""
         self.test_replicate_mariadb_to_sf(tap_mariadb_id=TAP_MARIADB_BUFFERED_STREAM_ID)
 
     @pytest.mark.dependency(depends=['import_config'])


### PR DESCRIPTION
## Problem

1. The tap fails with error:

```
TypeError: argument of type 'NoneType' is not iterable
in the function tap_mysql/sync_strategies/binlog.py:row_to_singer_record
```

2. The target fails with:
```
    if list(v.values())[0][0]['type'] == 'string':
TypeError: string indices must be integers
```

## Proposed changes

1. https://github.com/transferwise/pipelinewise-tap-mysql/pull/29
2. https://github.com/transferwise/pipelinewise-tap-mysql/pull/30


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
