### PR TITLE
[AP-822] Update json schemas according to new auth methods

### DIFF
--- a/pipelinewise/cli/schemas/target.json
+++ b/pipelinewise/cli/schemas/target.json
@@ -39,6 +39,12 @@
         "aws_secret_access_key": {
           "type": "string"
         },
+        "aws_session_token": {
+          "type": "string"
+        },
+        "aws_profile": {
+          "type": "string"
+        },
         "client_side_encryption_master_key": {
           "type": "string"
         }
@@ -79,6 +85,12 @@
         "aws_secret_access_key": {
           "type": "string"
         },
+        "aws_session_token": {
+          "type": "string"
+        },
+        "aws_profile": {
+          "type": "string"
+        },
         "s3_bucket": {
           "type": "string"
         },
@@ -95,8 +107,6 @@
         "user",
         "password",
         "dbname",
-        "aws_access_key_id",
-        "aws_secret_access_key",
         "s3_bucket"
       ]
     },
@@ -136,6 +146,12 @@
         "aws_secret_access_key": {
           "type": "string"
         },
+        "aws_session_token": {
+          "type": "string"
+        },
+        "aws_profile": {
+          "type": "string"
+        },
         "s3_bucket": {
           "type": "string"
         },
@@ -153,8 +169,6 @@
         }
       },
       "required": [
-        "aws_access_key_id",
-        "aws_secret_access_key",
         "s3_bucket"
       ]
     }

--- a/tests/units/cli/resources/target-invalid-s3-csv.yml
+++ b/tests/units/cli/resources/target-invalid-s3-csv.yml
@@ -1,0 +1,27 @@
+---
+
+# ------------------------------------------------------------------------------
+# General Properties
+# ------------------------------------------------------------------------------
+id: "s3"                               # Unique identifier of the target
+name: "S3 Target connector"            # Name of the target
+type: "target-s3-csv"                  # !! THIS SHOULD NOT CHANGE !!
+
+
+# ------------------------------------------------------------------------------
+# Target - S3 details
+# ------------------------------------------------------------------------------
+db_conn:
+  # Profile based authentication
+  aws_profile: "<AWS_PROFILE>"
+
+  # Non-profile based authentication
+  #aws_access_key_id: "<ACCESS_KEY>"
+  #aws_secret_access_key: "<SECRET_ACCESS_KEY"
+  #aws_session_token: "<AWS_SESSION_TOKEN>"
+
+  s3_bucket_is_required: "<BUCKET_NAME>"
+
+  s3_key_prefix: "pipelinewise-exports/"
+  delimiter: ","
+  quotechar: "\""

--- a/tests/units/cli/resources/target-valid-s3-csv.yml
+++ b/tests/units/cli/resources/target-valid-s3-csv.yml
@@ -1,0 +1,27 @@
+---
+
+# ------------------------------------------------------------------------------
+# General Properties
+# ------------------------------------------------------------------------------
+id: "s3"                               # Unique identifier of the target
+name: "S3 Target connector"            # Name of the target
+type: "target-s3-csv"                  # !! THIS SHOULD NOT CHANGE !!
+
+
+# ------------------------------------------------------------------------------
+# Target - S3 details
+# ------------------------------------------------------------------------------
+db_conn:
+  # Profile based authentication
+  aws_profile: "<AWS_PROFILE>"
+
+  # Non-profile based authentication
+  #aws_access_key_id: "<ACCESS_KEY>"
+  #aws_secret_access_key: "<SECRET_ACCESS_KEY"
+  #aws_session_token: "<AWS_SESSION_TOKEN>"
+
+  s3_bucket: "<BUCKET_NAME>"
+
+  s3_key_prefix: "pipelinewise-exports/"
+  delimiter: ","
+  quotechar: "\""

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -13,6 +13,12 @@ class TestUtils:
     Unit Tests for PipelineWise CLI utility functions
     """
 
+    def assert_json_is_invalid(self, schema, invalid_target):
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            cli.utils.validate(invalid_target, schema)
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == 1
+
     def test_json_detectors(self):
         """Testing JSON detector functions"""
         assert cli.utils.is_json('{Invalid JSON}') is False
@@ -207,8 +213,8 @@ class TestUtils:
             os.path.dirname(__file__)))
         assert cli.utils.load_schema('tap') == tap_schema
 
-    def test_json_validate(self):
-        """Test JSON schema validator functions"""
+    def test_json_validate_tap(self):
+        """Test JSON schema validator functions on taps"""
         schema = cli.utils.load_schema('tap')
 
         # Valid instance should return None
@@ -217,10 +223,19 @@ class TestUtils:
 
         # Invalid instance should exit
         invalid_tap = cli.utils.load_yaml('{}/resources/tap-invalid.yml'.format(os.path.dirname(__file__)))
-        with pytest.raises(SystemExit) as pytest_wrapped_e:
-            cli.utils.validate(invalid_tap, schema)
-        assert pytest_wrapped_e.type == SystemExit
-        assert pytest_wrapped_e.value.code == 1
+        self.assert_json_is_invalid(schema, invalid_tap)
+
+    def test_json_validate_target(self):
+        """Test JSON schema validator functions on targets"""
+        schema = cli.utils.load_schema('target')
+
+        # Valid instance should return None
+        valid_target = cli.utils.load_yaml('{}/resources/target-valid-s3-csv.yml'.format(os.path.dirname(__file__)))
+        assert cli.utils.validate(valid_target, schema) is None
+
+        # Invalid instance should exit
+        invalid_target = cli.utils.load_yaml('{}/resources/target-invalid-s3-csv.yml'.format(os.path.dirname(__file__)))
+        self.assert_json_is_invalid(schema, invalid_target)
 
     def test_delete_keys(self):
         """Test dictionary functions"""

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -14,6 +14,7 @@ class TestUtils:
     """
 
     def assert_json_is_invalid(self, schema, invalid_target):
+        """Simple assertion to check if validate function exits with error"""
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             cli.utils.validate(invalid_target, schema)
         assert pytest_wrapped_e.type == SystemExit


### PR DESCRIPTION
## Problem

JSONSchemas are not in sync with the newly introduced S3 authentication methods by https://github.com/transferwise/pipelinewise/commit/6646f537bd43f80dc98ec5694ec9839c65a80d3f and causing target-s3-csv type of targets to fail if no `aws_access_key_id` and `aws_secret_access_key` keys in the YAML
 
## Proposed changes

1. Update [target.json](https://github.com/transferwise/pipelinewise/blob/55471860cc2871f121ca27ee0e4e2f773ea39a78/pipelinewise/cli/schemas/target.json#L156) schema and remove the `aws_access_key_id` and `aws_secret_access_key` keys from the required list of the target-s3-csv and target-snowflake targets.
2. Add `aws_session_token` and `aws_profile` optional keys to the schemas

## Types of changes

What types of changes does your code introduce to PipelineWise

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
