### PR TITLE
Increase MAX_STREAM_BUFFER_SIZE to 2.5G

### DIFF
--- a/pipelinewise/cli/commands.py
+++ b/pipelinewise/cli/commands.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_STREAM_BUFFER_SIZE = 0          # Disabled by default
 DEFAULT_STREAM_BUFFER_BIN = 'mbuffer'
 MIN_STREAM_BUFFER_SIZE = 10
-MAX_STREAM_BUFFER_SIZE = 1000
+MAX_STREAM_BUFFER_SIZE = 2500
 
 STATUS_RUNNING = 'running'
 STATUS_FAILED = 'failed'


### PR DESCRIPTION
## Problem

Taps currently failing if stream_buffer_size is greater than 1G.

[This PR](https://github.com/transferwise/pipelinewise/pull/506/files) changed the jsonschema to allow up to 2.5G `stream_buffer_size` in the config YAML files but the tap is failing at runtime because `MAX_STREAM_BUFFER_SIZE` constant value [here](https://github.com/transferwise/pipelinewise/blob/6e2c1591e90bfd2b31d9aa8afe084388572ba223/pipelinewise/cli/commands.py#L17) doesn't allow more than 1G.

## Proposed changes

Increase the `MAX_STREAM_BUFFER_SIZE` [here](https://github.com/transferwise/pipelinewise/blob/6e2c1591e90bfd2b31d9aa8afe084388572ba223/pipelinewise/cli/commands.py#L17) to be in sync with the max allowed value in the jsonschema.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
