### PR TITLE
[AP-774] Properly support Mysql Time column

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,21 @@ jobs:
 
     steps:
       - checkout
+
+      - run:
+          name: 'Check code formatting'
+          command: |
+            . .virtualenvs/pipelinewise/bin/activate
+            pip install unify
+            find pipelinewise tests -type f -name '*.py' | xargs unify --check-only
+
+      - run:
+          name: 'Pylinting'
+          command: |
+            . .virtualenvs/pipelinewise/bin/activate
+            pip install pylint
+            pylint pipelinewise tests
+
       - run:
           name: 'Build source databases for integration tests'
           command: |
@@ -90,15 +105,6 @@ jobs:
       - run:
           name: 'Installing PipelineWise components and connectors'
           command: ./install.sh --acceptlicenses --connectors=all
-      - run:
-          name: 'Check code formatting and do pylinting'
-          command: |
-            . .virtualenvs/pipelinewise/bin/activate
-            pip install unify pylint
-            echo "Checking double quotes..."
-            find pipelinewise tests -type f -name '*.py' | xargs unify --check-only
-            echo "Running pylint..."
-            pylint pipelinewise tests
 
       - run:
           name: 'Run unit tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,14 +78,15 @@ jobs:
       - run:
           name: 'Check code formatting'
           command: |
-            . .virtualenvs/pipelinewise/bin/activate
+            python3 -m venv venv
+            . .venv/bin/activate
             pip install unify
             find pipelinewise tests -type f -name '*.py' | xargs unify --check-only
 
       - run:
           name: 'Pylinting'
           command: |
-            . .virtualenvs/pipelinewise/bin/activate
+            . .venv/bin/activate
             pip install pylint
             pylint pipelinewise tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,14 +80,13 @@ jobs:
           command: |
             python3 -m venv .venv
             . .venv/bin/activate
-            pip install unify
+            pip install -Ue .[test]
             find pipelinewise tests -type f -name '*.py' | xargs unify --check-only
 
       - run:
           name: 'Pylinting'
           command: |
             . .venv/bin/activate
-            pip install pylint
             pylint pipelinewise tests
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
       - run:
           name: 'Check code formatting'
           command: |
-            python3 -m venv venv
+            python3 -m venv .venv
             . .venv/bin/activate
             pip install unify
             find pipelinewise tests -type f -name '*.py' | xargs unify --check-only

--- a/pipelinewise/fastsync/mysql_to_postgres.py
+++ b/pipelinewise/fastsync/mysql_to_postgres.py
@@ -64,7 +64,8 @@ def tap_type_to_target_type(mysql_type, mysql_column_type):
         'date': 'TIMESTAMP WITHOUT TIME ZONE',
         'datetime': 'TIMESTAMP WITHOUT TIME ZONE',
         'timestamp': 'TIMESTAMP WITHOUT TIME ZONE',
-        'json': 'JSONB'
+        'time': 'TIME WITHOUT TIME ZONE',
+        'json': 'JSONB',
     }.get(
         mysql_type,
         'CHARACTER VARYING',

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -68,6 +68,7 @@ def tap_type_to_target_type(mysql_type, mysql_column_type):
         'date': 'TIMESTAMP_NTZ',
         'datetime': 'TIMESTAMP_NTZ',
         'timestamp': 'TIMESTAMP_NTZ',
+        'time': 'TIME',
         'json': 'VARIANT'
     }.get(mysql_type, 'VARCHAR')
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 filterwarnings =
     # https://github.com/boto/boto3/issues/1968
-    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working:DeprecationWarning
+    ignore::DeprecationWarning:botocore
+    ignore::DeprecationWarning:ansible
+    ignore::DeprecationWarning:tabulate

--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mysql==1.3.4
+-e git+https://github.com/transferwise/pipelinewise-tap-mysql.git@AP-774#egg=pipelinewise-tap-mysql

--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/transferwise/pipelinewise-tap-mysql.git@AP-774#egg=pipelinewise-tap-mysql
+pipelinewise-tap-mysql==1.3.5

--- a/tests/db/tap_mysql_data.sql
+++ b/tests/db/tap_mysql_data.sql
@@ -28,7 +28,8 @@ CREATE TABLE `edgydata` (
   `c_varchar` varchar(128),
   `group` int,
   `case` varchar(1),
-  `cjson` json
+  `cjson` json,
+  `c_time` time default current_time
 ) ENGINE=MyISAM AUTO_INCREMENT=1001 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -39,16 +40,16 @@ CREATE TABLE `edgydata` (
 LOCK TABLES `edgydata` WRITE;
 /*!40000 ALTER TABLE `edgydata` DISABLE KEYS */;
 INSERT INTO `edgydata` VALUES
-  (1, 'Lorem ipsum dolor sit amet', 10, 'A', '[]'),
-  (2, 'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช', 20, 'A', '{}'),
-  (3, 'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.', null, 'B', '[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]'),
-  (4, 'Special Characters: ["\\,''!@£$%^&*()]\\\\', null, 'B', null),
-  (5, '	', 20, 'B', null),
+  (1, 'Lorem ipsum dolor sit amet', 10, 'A', '[]', '23:55:01'),
+  (2, 'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช', 20, 'A', '{}', '10:00:59'),
+  (3, 'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.', null, 'B', '[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]', '15:36:10'),
+  (4, 'Special Characters: ["\\,''!@£$%^&*()]\\\\', null, 'B', null, '12:00:00'),
+  (5, '	', 20, 'B', null, '15:36:10'),
   (6,'Enter	The
-Ninja', 10, 'A', null),
+Ninja', 10, 'A', null, '15:36:10'),
   (7,'Liewe
-Maatjies', 20, 'A', null),
-  (8,'Liewe	Maatjies', 10, null, '[{"key": "Value''s One", "actions": []},{"key": "Value\U00000027s Two", "actions": []}]')
+Maatjies', 20, 'A', null, '09:16:10'),
+  (8,'Liewe	Maatjies', 10, null, '[{"key": "Value''s One", "actions": []},{"key": "Value\U00000027s Two", "actions": []}]', '00:30:00')
 ;
 
 /*!40000 ALTER TABLE `edgydata` ENABLE KEYS */;
@@ -301,7 +302,8 @@ CREATE TABLE `all_datatypes` (
     c_date          DATE,
     c_datetime      DATETIME,
     c_timestamp     TIMESTAMP,
-    c_json          JSON
+    c_json          JSON,
+    c_time          TIME
 )
 ENGINE=MyISAM AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;
 
@@ -338,7 +340,8 @@ INSERT INTO all_datatypes (c_char,
                            c_date,
                            c_datetime,
                            c_timestamp,
-                           c_json)
+                           c_json,
+                           c_time)
 VALUES ('x',
         'c_varchar',
         X'01',
@@ -366,7 +369,8 @@ VALUES ('x',
         '2020-06-01',
         '2100-06-01 10:00:00',
         '2020-06-01 10:00:00',
-        '{"k1": "value", "k2": 10}'
+        '{"k1": "value", "k2": 10}',
+        '13:11:45'
 );
 /*!40000 ALTER TABLE `all_datatypes` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/tests/end_to_end/helpers/db.py
+++ b/tests/end_to_end/helpers/db.py
@@ -33,6 +33,7 @@ def run_query_mysql(query, host, port, user, password, database):
                          user=user,
                          password=password,
                          database=database,
+                         charset="utf8mb4",
                          cursorclass=pymysql.cursors.Cursor) as cur:
         cur.execute(query)
         if cur.rowcount > 0:

--- a/tests/end_to_end/helpers/db.py
+++ b/tests/end_to_end/helpers/db.py
@@ -33,7 +33,7 @@ def run_query_mysql(query, host, port, user, password, database):
                          user=user,
                          password=password,
                          database=database,
-                         charset="utf8mb4",
+                         charset='utf8mb4',
                          cursorclass=pymysql.cursors.Cursor) as cur:
         cur.execute(query)
         if cur.rowcount > 0:

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -84,15 +84,15 @@ class TestTargetPostgres:
         self.run_query_tap_mysql('ALTER table weight_unit change column bool_col is_imperial bool;')
         self.run_query_tap_mysql('UPDATE weight_unit SET is_imperial = false WHERE weight_unit_name like \'%oz%\'')
 
-        self.run_query_tap_mysql('INSERT INTO edgydata VALUES'
-                                 '(10, \'Lorem ipsum dolor sit amet\', 10, \'A\', \'[]\', \'00:00:00\'),'
-                                 '(11, \'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช\', 20, \'A\', \'{}\', \'12:00:59\'),'
-                                 '(12, \'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.\', null,\'B\', '
+        self.run_query_tap_mysql('INSERT INTO edgydata (c_varchar, `group`, `case`, cjson, c_time) VALUES'
+                                 '(\'Lorem ipsum dolor sit amet\', 10, \'A\', \'[]\', \'00:00:00\'),'
+                                 '(\'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช\', 20, \'A\', \'{}\', \'12:00:59\'),'
+                                 '(\'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.\', null,\'B\', '
                                  '\'[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]\','
                                  ' \'9:1:00\'),'
-                                 '(13, \'Special Characters: [\"\\,''!@£$%^&*()]\\\\\', null, \'B\', '
+                                 '(\'Special Characters: [\"\\,''!@£$%^&*()]\\\\\', null, \'B\', '
                                  'null, \'12:00:00\'),'
-                                 '(14, \'	\', 20, \'B\', null, \'15:36:10\')')
+                                 '(\'	\', 20, \'B\', null, \'15:36:10\')')
 
         #  INCREMENTAL
         self.run_query_tap_mysql('INSERT INTO address(isactive, street_number, date_created, date_updated,'

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -90,7 +90,8 @@ class TestTargetPostgres:
                                  '(12, \'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.\', null,\'B\', '
                                  '\'[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]\','
                                  ' \'9:1:00\'),'
-                                 '(13, \'Special Characters: [\"\\,''!@£$%^&*()]\\\\\', null, \'B\', null, \'12:00:00\'),'
+                                 '(13, \'Special Characters: [\"\\,''!@£$%^&*()]\\\\\', null, \'B\', '
+                                 'null, \'12:00:00\'),'
                                  '(14, \'	\', 20, \'B\', null, \'15:36:10\')')
 
         #  INCREMENTAL

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -84,13 +84,14 @@ class TestTargetPostgres:
         self.run_query_tap_mysql('ALTER table weight_unit change column bool_col is_imperial bool;')
         self.run_query_tap_mysql('UPDATE weight_unit SET is_imperial = false WHERE weight_unit_name like \'%oz%\'')
 
-        self.run_query_tap_mysql("INSERT INTO edgydata VALUES"
-                                 "(10, 'Lorem ipsum dolor sit amet', 10, 'A', '[]', '00:00:00'),"
-                                 "(11, 'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช', 20, 'A', '{}', '12:00:59'),"
-                                 "(12, 'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.', null, 'B', "
-                                 "'[{\"key\": \"ValueOne\", \"actions\": []}, {\"key\": \"ValueTwo\", \"actions\": []}]', '9:1:00'),"
-                                 "(13, 'Special Characters: [\"\\,''!@£$%^&*()]\\\\', null, 'B', null, '12:00:00'),"
-                                 "(14, '	', 20, 'B', null, '15:36:10')")
+        self.run_query_tap_mysql('INSERT INTO edgydata VALUES'
+                                 '(10, \'Lorem ipsum dolor sit amet\', 10, \'A\', \'[]\', \'00:00:00\'),'
+                                 '(11, \'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช\', 20, \'A\', \'{}\', \'12:00:59\'),'
+                                 '(12, \'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.\', null,\'B\', '
+                                 '\'[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]\','
+                                 ' \'9:1:00\'),'
+                                 '(13, \'Special Characters: [\"\\,''!@£$%^&*()]\\\\\', null, \'B\', null, \'12:00:00\'),'
+                                 '(14, \'	\', 20, \'B\', null, \'15:36:10\')')
 
         #  INCREMENTAL
         self.run_query_tap_mysql('INSERT INTO address(isactive, street_number, date_created, date_updated,'

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -84,6 +84,14 @@ class TestTargetPostgres:
         self.run_query_tap_mysql('ALTER table weight_unit change column bool_col is_imperial bool;')
         self.run_query_tap_mysql('UPDATE weight_unit SET is_imperial = false WHERE weight_unit_name like \'%oz%\'')
 
+        self.run_query_tap_mysql("INSERT INTO edgydata VALUES"
+                                 "(10, 'Lorem ipsum dolor sit amet', 10, 'A', '[]', '00:00:00'),"
+                                 "(11, 'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช', 20, 'A', '{}', '12:00:59'),"
+                                 "(12, 'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.', null, 'B', "
+                                 "'[{\"key\": \"ValueOne\", \"actions\": []}, {\"key\": \"ValueTwo\", \"actions\": []}]', '9:1:00'),"
+                                 "(13, 'Special Characters: [\"\\,''!@£$%^&*()]\\\\', null, 'B', null, '12:00:00'),"
+                                 "(14, '	', 20, 'B', null, '15:36:10')")
+
         #  INCREMENTAL
         self.run_query_tap_mysql('INSERT INTO address(isactive, street_number, date_created, date_updated,'
                                  ' supplier_supplier_id, zip_code_zip_code_id)'

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -75,13 +75,14 @@ class TestTargetSnowflake:
         # 2. Make changes in MariaDB source database
         #  LOG_BASED
         self.run_query_tap_mysql('UPDATE weight_unit SET isactive = 0 WHERE weight_unit_id IN (2, 3, 4)')
-        self.run_query_tap_mysql("INSERT INTO edgydata VALUES"
-                                 "(10, 'Lorem ipsum dolor sit amet', 10, 'A', '[]', '00:00:00'),"
-                                 "(11, 'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช', 20, 'A', '{}', '12:00:59'),"
-                                 "(12, 'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.', null, 'B', "
-                                 "'[{\"key\": \"ValueOne\", \"actions\": []}, {\"key\": \"ValueTwo\", \"actions\": []}]', '9:1:00'),"
-                                 "(13, 'Special Characters: [\"\\,''!@£$%^&*()]\\\\', null, 'B', null, '12:00:00'),"
-                                 "(14, '	', 20, 'B', null, '15:36:10')")
+        self.run_query_tap_mysql('INSERT INTO edgydata VALUES'
+                                 '(10, \'Lorem ipsum dolor sit amet\', 10, \'A\', \'[]\', \'00:00:00\'),'
+                                 '(11, \'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช\', 20, \'A\', \'{}\', \'12:00:59\'),'
+                                 '(12, \'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.\', null,\'B\', '
+                                 '\'[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]\','
+                                 ' \'9:1:00\'),'
+                                 '(13, \'Special Characters: [\"\\,''!@£$%^&*()]\\\\\', null, \'B\', null, \'12:00:00\'),'
+                                 '(14, \'	\', 20, \'B\', null, \'15:36:10\')')
 
         #  INCREMENTAL
         self.run_query_tap_mysql('INSERT INTO address(isactive, street_number, date_created, date_updated,'

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -75,7 +75,7 @@ class TestTargetSnowflake:
         # 2. Make changes in MariaDB source database
         #  LOG_BASED
         self.run_query_tap_mysql('UPDATE weight_unit SET isactive = 0 WHERE weight_unit_id IN (2, 3, 4)')
-        self.run_query_tap_mysql('INSERT INTO edgydata edgydata (c_varchar, `group`, `case`, cjson, c_time) VALUES'
+        self.run_query_tap_mysql('INSERT INTO edgydata (c_varchar, `group`, `case`, cjson, c_time) VALUES'
                                  '(\'Lorem ipsum dolor sit amet\', 10, \'A\', \'[]\', \'00:00:00\'),'
                                  '(\'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช\', 20, \'A\', \'{}\', \'12:00:59\'),'
                                  '(\'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.\', null,\'B\', '

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -75,6 +75,14 @@ class TestTargetSnowflake:
         # 2. Make changes in MariaDB source database
         #  LOG_BASED
         self.run_query_tap_mysql('UPDATE weight_unit SET isactive = 0 WHERE weight_unit_id IN (2, 3, 4)')
+        self.run_query_tap_mysql("INSERT INTO edgydata VALUES"
+                                 "(10, 'Lorem ipsum dolor sit amet', 10, 'A', '[]', '00:00:00'),"
+                                 "(11, 'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช', 20, 'A', '{}', '12:00:59'),"
+                                 "(12, 'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.', null, 'B', "
+                                 "'[{\"key\": \"ValueOne\", \"actions\": []}, {\"key\": \"ValueTwo\", \"actions\": []}]', '9:1:00'),"
+                                 "(13, 'Special Characters: [\"\\,''!@£$%^&*()]\\\\', null, 'B', null, '12:00:00'),"
+                                 "(14, '	', 20, 'B', null, '15:36:10')")
+
         #  INCREMENTAL
         self.run_query_tap_mysql('INSERT INTO address(isactive, street_number, date_created, date_updated,'
                                  ' supplier_supplier_id, zip_code_zip_code_id)'

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -81,7 +81,8 @@ class TestTargetSnowflake:
                                  '(12, \'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.\', null,\'B\', '
                                  '\'[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]\','
                                  ' \'9:1:00\'),'
-                                 '(13, \'Special Characters: [\"\\,''!@£$%^&*()]\\\\\', null, \'B\', null, \'12:00:00\'),'
+                                 '(13, \'Special Characters: [\"\\,''!@£$%^&*()]\\\\\', null, \'B\', '
+                                 'null, \'12:00:00\'),'
                                  '(14, \'	\', 20, \'B\', null, \'15:36:10\')')
 
         #  INCREMENTAL

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -75,15 +75,15 @@ class TestTargetSnowflake:
         # 2. Make changes in MariaDB source database
         #  LOG_BASED
         self.run_query_tap_mysql('UPDATE weight_unit SET isactive = 0 WHERE weight_unit_id IN (2, 3, 4)')
-        self.run_query_tap_mysql('INSERT INTO edgydata VALUES'
-                                 '(10, \'Lorem ipsum dolor sit amet\', 10, \'A\', \'[]\', \'00:00:00\'),'
-                                 '(11, \'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช\', 20, \'A\', \'{}\', \'12:00:59\'),'
-                                 '(12, \'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.\', null,\'B\', '
+        self.run_query_tap_mysql('INSERT INTO edgydata edgydata (c_varchar, `group`, `case`, cjson, c_time) VALUES'
+                                 '(\'Lorem ipsum dolor sit amet\', 10, \'A\', \'[]\', \'00:00:00\'),'
+                                 '(\'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช\', 20, \'A\', \'{}\', \'12:00:59\'),'
+                                 '(\'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.\', null,\'B\', '
                                  '\'[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]\','
                                  ' \'9:1:00\'),'
-                                 '(13, \'Special Characters: [\"\\,''!@£$%^&*()]\\\\\', null, \'B\', '
+                                 '(\'Special Characters: [\"\\,''!@£$%^&*()]\\\\\', null, \'B\', '
                                  'null, \'12:00:00\'),'
-                                 '(14, \'	\', 20, \'B\', null, \'15:36:10\')')
+                                 '(\'	\', 20, \'B\', null, \'15:36:10\')')
 
         #  INCREMENTAL
         self.run_query_tap_mysql('INSERT INTO address(isactive, street_number, date_created, date_updated,'


### PR DESCRIPTION
## Problem

Currently, pipelinewise FastSync and singer replication are not aligned on how to handle `Time` column in Mysql:
* FastSync lacks mapping so Time is by default mapped to Varchar
* Singer replication on the other hand interprets `time` as a datetime.

## Proposed changes

* FastSync: map `time` to the right equivalent in targets.
* Singer replication: use https://github.com/transferwise/pipelinewise/pull/514 


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
