### PR TITLE
[DOC] Document optional parameters of tap-postgres

### DIFF
--- a/docs/connectors/taps/postgres.rst
+++ b/docs/connectors/taps/postgres.rst
@@ -152,7 +152,7 @@ Example YAML for ``tap-postgres``:
                                            #           received from wal after certain number of seconds
                                            #           Default: 10800
       #break_at_end_lsn:                   # Optional: Stop running the tap if the newly received lsn
-                                           #           is after the max lsn that was detected when the tap startup
+                                           #           is after the max lsn that was detected when the tap started
                                            #           Default: true
 
 

--- a/docs/connectors/taps/postgres.rst
+++ b/docs/connectors/taps/postgres.rst
@@ -152,7 +152,7 @@ Example YAML for ``tap-postgres``:
                                            #           received from wal after certain number of seconds
                                            #           Default: 10800
       #break_at_end_lsn:                   # Optional: Stop running the tap if the newly received lsn
-                                           #           is after the max lsn that was detected at tap startup
+                                           #           is after the max lsn that was detected when the tap startup
                                            #           Default: true
 
 

--- a/docs/connectors/taps/postgres.rst
+++ b/docs/connectors/taps/postgres.rst
@@ -145,6 +145,15 @@ Example YAML for ``tap-postgres``:
       #filter_schemas: "schema1,schema2"   # Optional: Scan only the required schemas
                                            #           to improve the performance of
                                            #           data extraction
+      #max_run_seconds                     # Optional: Stop running the tap after certain
+                                           #           number of seconds
+                                           #           Default: 43200
+      #logical_poll_total_seconds:         # Optional: Stop running the tap when no data
+                                           #           received from wal after certain number of seconds
+                                           #           Default: 10800
+      #break_at_end_lsn:                   # Optional: Stop running the tap if the newly received lsn
+                                           #           is after the max lsn that was detected at tap startup
+                                           #           Default: true
 
 
     # ------------------------------------------------------------------------------

--- a/pipelinewise/cli/samples/tap_postgres.yml.sample
+++ b/pipelinewise/cli/samples/tap_postgres.yml.sample
@@ -22,6 +22,15 @@ db_conn:
   #filter_schemas: "schema1,schema2"   # Optional: Scan only the required schemas
                                        #           to improve the performance of
                                        #           data extraction
+  #max_run_seconds                     # Optional: Stop running the tap after certain
+                                       #           number of seconds
+                                       #           Default: 43200
+  #logical_poll_total_seconds:         # Optional: Stop running the tap when no data
+                                       #           received from wal after certain number of seconds
+                                       #           Default: 10800
+  #break_at_end_lsn:                   # Optional: Stop running the tap if the newly received lsn
+                                       #           is after the max lsn that was detected when the tap started
+                                       #           Default: true
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A few optional parameters of tap-postgres are not documented.

## Proposed changes

Document the missing `max_run_seconds`, `logical_poll_total_seconds`, and `break_at_end_lsn` options of tap-postgres.


## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
