### PR TITLE
[AP-786] Bump tap-kafka connector

### DIFF
--- a/docs/connectors/taps/kafka.rst
+++ b/docs/connectors/taps/kafka.rst
@@ -55,20 +55,25 @@ Example YAML for ``tap-kafka``:
       # --------------------------------------------------------------------------
       # Optionally you can define primary key(s) from the kafka JSON messages.
       # If primary keys defined then extra column(s) will be added to the output
-      # singer stream with the extracted values by JSONPath selectors.
+      # singer stream with the extracted values by /slashed/paths ala XPath selectors.
       # --------------------------------------------------------------------------
       primary_keys:
-         transfer_id: "$.transferMetadata.transferId"
+         transfer_id: "/transferMetadata/transferId"
 
       # --------------------------------------------------------------------------
       # Kafka Consumer optional parameters
       # --------------------------------------------------------------------------
       #max_runtime_ms: 300000                   # The maximum time for the tap to collect new messages from Kafka topic.
-      #consumer_timeout_ms: 10000               # Number of milliseconds to block during message iteration before raising StopIteration
-      #session_timeout_ms: 30000                # The timeout used to detect failures when using Kafka’s group management facilities.
-      #heartbeat_interval_ms: 10000             # The expected time in milliseconds between heartbeats to the consumer coordinator when using Kafka’s group management facilities.
-      #max_poll_interval_ms: 300000             # The maximum delay between invocations of poll() when using consumer group management.
+      #consumer_timeout_ms: 10000               # KafkaConsumer setting. Number of milliseconds to block during message iteration before raising StopIteration
+      #session_timeout_ms: 30000                # KafkaConsumer setting. The timeout used to detect failures when using Kafka’s group management facilities.
+      #heartbeat_interval_ms: 10000             # KafkaConsumer setting. The expected time in milliseconds between heartbeats to the consumer coordinator when using Kafka’s group management facilities.
+      #max_poll_interval_ms: 300000             # KafkaConsumer setting. The maximum delay between invocations of poll() when using consumer group management.
+      #max_poll_records: 500                    # KafkaConsumer setting. The maximum number of records returned in a single call to poll().
+
+      #commit_interval_ms: 5000                 # Number of milliseconds between two commits. This is different than the kafka auto commit feature. Tap-kafka sends commit messages automatically but only when the data consumed successfully and persisted to local store.
       #local_store_dir: ./tap-kafka-local-store # Path to the local store with consumed kafka messages
+      #local_store_batch_size_rows: 1000        # Number of messages to write to disk in one go. This can avoid high I/O issues when messages written to local store disk too frequently.
+
 
     # ------------------------------------------------------------------------------
     # Destination (Target) - Target properties

--- a/pipelinewise/cli/samples/tap_kafka.yml.sample
+++ b/pipelinewise/cli/samples/tap_kafka.yml.sample
@@ -22,20 +22,24 @@ db_conn:
   # --------------------------------------------------------------------------
   # Optionally you can define primary key(s) from the kafka JSON messages.
   # If primary keys defined then extra column(s) will be added to the output
-  # singer stream with the extracted values by JSONPath selectors.
+  # singer stream with the extracted values by /slashed/paths ala XPath selectors.
   # --------------------------------------------------------------------------
   primary_keys:
-     transfer_id: "$.transferMetadata.transferId"
+     transfer_id: "/transferMetadata/transferId"
 
   # --------------------------------------------------------------------------
   # Kafka Consumer optional parameters
   # --------------------------------------------------------------------------
   #max_runtime_ms: 300000                   # The maximum time for the tap to collect new messages from Kafka topic.
-  #consumer_timeout_ms: 10000               # Number of milliseconds to block during message iteration before raising StopIteration
-  #session_timeout_ms: 30000                # The timeout used to detect failures when using Kafka’s group management facilities.
-  #heartbeat_interval_ms: 10000             # The expected time in milliseconds between heartbeats to the consumer coordinator when using Kafka’s group management facilities.
-  #max_poll_interval_ms: 300000             # The maximum delay between invocations of poll() when using consumer group management.
+  #consumer_timeout_ms: 10000               # KafkaConsumer setting. Number of milliseconds to block during message iteration before raising StopIteration
+  #session_timeout_ms: 30000                # KafkaConsumer setting. The timeout used to detect failures when using Kafka’s group management facilities.
+  #heartbeat_interval_ms: 10000             # KafkaConsumer setting. The expected time in milliseconds between heartbeats to the consumer coordinator when using Kafka’s group management facilities.
+  #max_poll_interval_ms: 300000             # KafkaConsumer setting. The maximum delay between invocations of poll() when using consumer group management.
+  #max_poll_records: 500                    # KafkaConsumer setting. The maximum number of records returned in a single call to poll().
+
+  #commit_interval_ms: 5000                 # Number of milliseconds between two commits. This is different than the kafka auto commit feature. Tap-kafka sends commit messages automatically but only when the data consumed successfully and persisted to local store.
   #local_store_dir: ./tap-kafka-local-store # Path to the local store with consumed kafka messages
+  #local_store_batch_size_rows: 1000        # Number of messages to write to disk in one go. This can avoid high I/O issues when messages written to local store disk too frequently.
 
 # ------------------------------------------------------------------------------
 # Destination (Target) - Target properties

--- a/singer-connectors/tap-kafka/requirements.txt
+++ b/singer-connectors/tap-kafka/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-kafka==3.0.0
+pipelinewise-tap-kafka==4.0.0


### PR DESCRIPTION
## Problem

The current version of pipelinewise-tap-kafka 3.0.0 having some performance and functional issues.

## Proposed changes

Bump pipelinewise-tap-kafka to 4.0.0 that contains the performance improvements and fixes.
Changelog is at https://github.com/transferwise/pipelinewise-tap-kafka/blob/master/CHANGELOG.md

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

This is a breaking change and every kafka tap that's having the `primary_keys` option should be re-configured:

From:
```
  primary_keys:
    id: "$.payload.id"
    type: "$.payload.type"
```

To:
```
  primary_keys:
    id: "/payload/id"
    type: "/payload/type"
```
## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
