### PR TITLE
[DOC] Add github logo to main page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -173,6 +173,15 @@ PipelineWise can replicate data from the following data sources:
 
         :ref:`tap-mongodb`
 
+    .. container:: tile
+
+        .. container:: img-hover-zoom
+
+          .. image:: img/github-logo.png
+             :target: connectors/taps/github.html
+
+        :ref:`tap-github`
+
 
 Target (Destination Connectors)
 -------------------------------


### PR DESCRIPTION
## Problem

Tap github is missing from tap list on the main page of the documentation.

## Proposed changes

Add tap github to the list of taps on the main page of the documentation.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
