### PR TITLE
[AP-755] PG timestamp with TZ to target's timestamp without TZ

### DIFF
--- a/pipelinewise/fastsync/postgres_to_postgres.py
+++ b/pipelinewise/fastsync/postgres_to_postgres.py
@@ -61,7 +61,7 @@ def tap_type_to_target_type(pg_type):
         'date': 'TIMESTAMP WITHOUT TIME ZONE',
         'timestamp': 'TIMESTAMP WITHOUT TIME ZONE',
         'timestamp without time zone': 'TIMESTAMP WITHOUT TIME ZONE',
-        'timestamp with time zone': 'TIMESTAMP WITH TIME ZONE',
+        'timestamp with time zone': 'TIMESTAMP WITHOUT TIME ZONE',
         'time': 'TIME WITHOUT TIME ZONE',
         'time without time zone': 'TIME WITHOUT TIME ZONE',
         'time with time zone': 'TIME WITH TIME ZONE',

--- a/pipelinewise/fastsync/postgres_to_redshift.py
+++ b/pipelinewise/fastsync/postgres_to_redshift.py
@@ -65,7 +65,7 @@ def tap_type_to_target_type(pg_type):
         'date': 'TIMESTAMP WITHOUT TIME ZONE',
         'timestamp': 'TIMESTAMP WITHOUT TIME ZONE',
         'timestamp without time zone': 'TIMESTAMP WITHOUT TIME ZONE',
-        'timestamp with time zone': 'TIMESTAMP WITH TIME ZONE',
+        'timestamp with time zone': 'TIMESTAMP WITHOUT TIME ZONE',
         'time': 'CHARACTER VARYING({})'.format(SHORT_VARCHAR_LENGTH),
         'time without time zone': 'CHARACTER VARYING({})'.format(SHORT_VARCHAR_LENGTH),
         'time with time zone': 'CHARACTER VARYING({})'.format(SHORT_VARCHAR_LENGTH),

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -65,7 +65,7 @@ def tap_type_to_target_type(pg_type):
         'date': 'TIMESTAMP_NTZ',
         'timestamp': 'TIMESTAMP_NTZ',
         'timestamp without time zone': 'TIMESTAMP_NTZ',
-        'timestamp with time zone': 'TIMESTAMP_TZ',
+        'timestamp with time zone': 'TIMESTAMP_NTZ',
         'time': 'TIME',
         'time without time zone': 'TIME',
         'time with time zone': 'TIME',

--- a/tests/db/tap_postgres_data.sql
+++ b/tests/db/tap_postgres_data.sql
@@ -4512,8 +4512,16 @@ CREATE TABLE "table_with_space and UPPERCase"
 (
     id serial primary key,
     cvarchar varchar,
-    created_at timestamp default current_timestamp
+    created_at timestamp default current_timestamp,
+    updated_at timestamp with time zone
 );
 
 
-insert into "table_with_space and UPPERCase" (cvarchar) values ('A'), ('B'), ('C'), ('D'), ('E'), ('F'), ('G');
+insert into "table_with_space and UPPERCase" (cvarchar, updated_at)
+values ('A', '2020-01-01 08:53:56.112248-07'),
+       ('B', '2020-08-31 08:53:56.2248+11:30'),
+       ('C', '2020-08-27 00:00:00.11+00:30'),
+       ('D', '2020-02-27 12:00:00.1148-12'),
+       ('E', '2020-12-31 12:59:00.148+00'),
+       ('F', null),
+       ('G', '2020-03-03 12:30:00');

--- a/tests/end_to_end/helpers/assertions.py
+++ b/tests/end_to_end/helpers/assertions.py
@@ -255,3 +255,18 @@ def assert_all_columns_exist(tap_query_runner_fn: callable,
                                          f'Expected: {exp_col_type} '
                                          f'Actual: {act_col_type}')
                     raise
+
+def assert_date_column_naive_in_target(target_query_runner_fn, column_name, full_table_name):
+    """
+    Checks if all dates in the given column are naive,i.e no timezone
+    Args:
+        target_query_runner_fn: target query runner callable
+        column_name: column of timestamp type
+        full_table_name: fully qualified table name
+    """
+    dates = target_query_runner_fn(
+        f'SELECT {column_name} FROM {full_table_name};')
+
+    for date in dates:
+        if date[0] is not None:
+            assert date[0].tzinfo is None

--- a/tests/end_to_end/test-project/tap_postgres_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_pg.yml.template
@@ -68,7 +68,7 @@ schemas:
 
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_space and UPPERCase"
-        replication_method: "FULL_TABLE"
+        replication_method: "LOG_BASED"
 
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_reserved_words"

--- a/tests/end_to_end/test-project/tap_postgres_to_rs.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_rs.yml.template
@@ -67,7 +67,7 @@ schemas:
 
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_space and UPPERCase"
-        replication_method: "FULL_TABLE"
+        replication_method: "LOG_BASED"
 
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_reserved_words"

--- a/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
@@ -66,7 +66,7 @@ schemas:
 
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_space and UPPERCase"
-        replication_method: "FULL_TABLE"
+        replication_method: "LOG_BASED"
 
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_reserved_words"

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -169,6 +169,11 @@ class TestTargetPostgres:
                                                       'updated_at',
                                                       'ppw_e2e_tap_postgres."table_with_space and uppercase"')
 
+        result = self.run_query_target_postgres(
+            'SELECT updated_at FROM ppw_e2e_tap_postgres."table_with_space and uppercase" where cvarchar=\'M\';')[0][0]
+
+        assert result == datetime(2019, 12, 31, 22, 53, 56, 800000)
+
     @pytest.mark.dependency(depends=['import_config'])
     def test_replicate_s3_to_pg(self):
         """Replicate csv files from s3 to Postgres"""

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -125,6 +125,7 @@ class TestTargetPostgres:
         Same tests cases as test_replicate_mariadb_to_pg but using another tap with custom stream buffer size"""
         self.test_resync_mariadb_to_pg(tap_mariadb_id=TAP_MARIADB_BUFFERED_STREAM_ID)
 
+
     @pytest.mark.dependency(depends=['import_config'])
     def test_replicate_pg_to_pg(self):
         """Replicate data from Postgres to Postgres DWH"""
@@ -132,9 +133,18 @@ class TestTargetPostgres:
         assertions.assert_run_tap_success(TAP_POSTGRES_ID, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_postgres, self.run_query_target_postgres)
         assertions.assert_all_columns_exist(self.run_query_tap_postgres, self.run_query_target_postgres)
+        assertions.assert_date_column_naive_in_target(self.run_query_target_postgres,
+                                                      'updated_at',
+                                                      'ppw_e2e_tap_postgres."table_with_space and uppercase"')
 
         # 2. Make changes in pg source database
-        #  LOG_BASED - Missing due to some changes that's required in tap-postgres to test it automatically
+        #  LOG_BASED
+        self.run_query_tap_postgres('insert into public."table_with_space and UPPERCase" (cvarchar, updated_at) values '
+                                    "('M', '2020-01-01 08:53:56.8+10'),"
+                                    "('N', '2020-12-31 12:59:00.148+00'),"
+                                    "('O', null),"
+                                    "('P', '2020-03-03 12:30:00');")
+
         #  INCREMENTAL
         self.run_query_tap_postgres('INSERT INTO public.city (id, name, countrycode, district, population) '
                                     "VALUES (4080, 'Bath', 'GBR', 'England', 88859)")
@@ -155,6 +165,9 @@ class TestTargetPostgres:
         assertions.assert_run_tap_success(TAP_POSTGRES_ID, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_postgres, self.run_query_target_postgres)
         assertions.assert_all_columns_exist(self.run_query_tap_postgres, self.run_query_target_postgres)
+        assertions.assert_date_column_naive_in_target(self.run_query_target_postgres,
+                                                      'updated_at',
+                                                      'ppw_e2e_tap_postgres."table_with_space and uppercase"')
 
     @pytest.mark.dependency(depends=['import_config'])
     def test_replicate_s3_to_pg(self):

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -151,6 +151,12 @@ class TestTargetSnowflake:
                                                       'updated_at',
                                                       'ppw_e2e_tap_postgres."TABLE_WITH_SPACE AND UPPERCASE"')
 
+
+        result = self.run_query_target_snowflake(
+            'SELECT updated_at FROM ppw_e2e_tap_postgres."TABLE_WITH_SPACE AND UPPERCASE" where cvarchar=\'X\';')[0][0]
+
+        assert result == datetime(2019, 12, 31, 22, 53, 56, 800000)
+
     @pytest.mark.dependency(depends=['import_config'])
     def test_replicate_s3_to_sf(self):
         """Replicate csv files from s3 to Snowflake, check if return code is zero and success log file created"""

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -121,10 +121,18 @@ class TestTargetSnowflake:
         # Run tap first time - both fastsync and a singer should be triggered
         assertions.assert_run_tap_success(TAP_POSTGRES_ID, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_postgres, self.run_query_target_snowflake)
-        assertions.assert_all_columns_exist(self.run_query_tap_postgres, self.e2e.run_query_target_snowflake)
+        assertions.assert_all_columns_exist(self.run_query_tap_postgres, self.run_query_target_snowflake)
+        assertions.assert_date_column_naive_in_target(self.run_query_target_snowflake,
+                                                      'updated_at',
+                                                      'ppw_e2e_tap_postgres."TABLE_WITH_SPACE AND UPPERCASE"')
 
-        # 2. Make changes in MariaDB source database
-        #  LOG_BASED - Missing due to some changes that's required in tap-postgres to test it automatically
+        # 2. Make changes in PG source database
+        #  LOG_BASED
+        self.run_query_tap_postgres('insert into public."table_with_space and UPPERCase" (cvarchar, updated_at) values '
+                                    "('X', '2020-01-01 08:53:56.8+10'),"
+                                    "('Y', '2020-12-31 12:59:00.148+00'),"
+                                    "('Z', null),"
+                                    "('W', '2020-03-03 12:30:00');")
         #  INCREMENTAL
         self.run_query_tap_postgres('INSERT INTO public.city (id, name, countrycode, district, population) '
                                     "VALUES (4080, 'Bath', 'GBR', 'England', 88859)")
@@ -138,7 +146,10 @@ class TestTargetSnowflake:
         # 3. Run tap second time - both fastsync and a singer should be triggered, there are some FULL_TABLE
         assertions.assert_run_tap_success(TAP_POSTGRES_ID, TARGET_ID, ['fastsync', 'singer'])
         assertions.assert_row_counts_equal(self.run_query_tap_postgres, self.run_query_target_snowflake)
-        assertions.assert_all_columns_exist(self.run_query_tap_postgres, self.e2e.run_query_target_snowflake)
+        assertions.assert_all_columns_exist(self.run_query_tap_postgres, self.run_query_target_snowflake)
+        assertions.assert_date_column_naive_in_target(self.run_query_target_snowflake,
+                                                      'updated_at',
+                                                      'ppw_e2e_tap_postgres."TABLE_WITH_SPACE AND UPPERCASE"')
 
     @pytest.mark.dependency(depends=['import_config'])
     def test_replicate_s3_to_sf(self):


### PR DESCRIPTION
## Problem

FastSync PG -> SF and PG -> PG map `timestamp with time zone` type columns to timestamp with timzone:
https://github.com/transferwise/pipelinewise/blob/240a9ff088871cd1f5ade2199be06d765f7cfebf/pipelinewise/fastsync/postgres_to_snowflake.py#L68

https://github.com/transferwise/pipelinewise/blob/240a9ff088871cd1f5ade2199be06d765f7cfebf/pipelinewise/fastsync/postgres_to_postgres.py#L64

The dates sent to targets are in UTC though.

There is no such issue with Singer replication. 
**Example in tap**
```
CREATE TABLE "order"
(
    id serial primary key,
    cvarchar varchar,
    created_at timestamp default current_timestamp,
    updated_at timestamp with time zone
);


insert into "order" (cvarchar, updated_at)
values ('A', '2020-01-01 08:53:56.112248-07'),
       ('B', '2020-08-31 08:53:56.112248+11:30'),
       ('C', '2020-08-27 00:00:00.112248+00:30'),
       ('D', '2020-02-27 12:00:00.112248-12'),
       ('E', '2020-12-31 12:59:00.112248+00'),
       ('F', null),
       ('G', null);
```

Running the tap for the above table yields the following streams:
```
{"type": "SCHEMA", "stream": "public-order", "schema": {"type": "object", "properties": {"id": {"type": ["integer"], "minimum": -2147483648, "maximum": 2147483647}, "cvarchar": {"type": ["null", "string"]}, "created_at": {"type": ["null", "string"], "format": "date-time"}, "updated_at": {"type": ["null", "string"], "format": "date-time"}}, "definitions": {"sdc_recursive_integer_array": {"type": ["null", "integer", "array"], "items": {"$ref": "#/definitions/sdc_recursive_integer_array"}}, "sdc_recursive_number_array": {"type": ["null", "number", "array"], "items": {"$ref": "#/definitions/sdc_recursive_number_array"}}, "sdc_recursive_string_array": {"type": ["null", "string", "array"], "items": {"$ref": "#/definitions/sdc_recursive_string_array"}}, "sdc_recursive_boolean_array": {"type": ["null", "boolean", "array"], "items": {"$ref": "#/definitions/sdc_recursive_boolean_array"}}, "sdc_recursive_timestamp_array": {"type": ["null", "string", "array"], "format": "date-time", "items": {"$ref": "#/definitions/sdc_recursive_timestamp_array"}}, "sdc_recursive_object_array": {"type": ["null", "object", "array"], "items": {"$ref": "#/definitions/sdc_recursive_object_array"}}}}, "key_properties": ["id"], "bookmark_properties": []}
{"type": "STATE", "value": {"bookmarks": {"public-order": {"last_replication_method": "LOG_BASED", "lsn": 25157384, "version": 1598610014806}}, "currently_syncing": "public-order"}}
{"type": "ACTIVATE_VERSION", "stream": "public-order", "version": 1598610014806}
{"type": "RECORD", "stream": "public-order", "record": {"created_at": "2020-08-28T10:19:43.134595+00:00", "cvarchar": "A", "id": 1, "updated_at": "2020-01-01T15:53:56.112248+00:00"}, "version": 1598610014806, "time_extracted": "2020-08-28T10:20:14.806296Z"}
{"type": "RECORD", "stream": "public-order", "record": {"created_at": "2020-08-28T10:19:43.134595+00:00", "cvarchar": "B", "id": 2, "updated_at": "2020-08-30T21:23:56.112248+00:00"}, "version": 1598610014806, "time_extracted": "2020-08-28T10:20:14.806296Z"}
{"type": "RECORD", "stream": "public-order", "record": {"created_at": "2020-08-28T10:19:43.134595+00:00", "cvarchar": "C", "id": 3, "updated_at": "2020-08-26T23:30:00.112248+00:00"}, "version": 1598610014806, "time_extracted": "2020-08-28T10:20:14.806296Z"}
{"type": "RECORD", "stream": "public-order", "record": {"created_at": "2020-08-28T10:19:43.134595+00:00", "cvarchar": "D", "id": 4, "updated_at": "2020-02-28T00:00:00.112248+00:00"}, "version": 1598610014806, "time_extracted": "2020-08-28T10:20:14.806296Z"}
{"type": "RECORD", "stream": "public-order", "record": {"created_at": "2020-08-28T10:19:43.134595+00:00", "cvarchar": "E", "id": 5, "updated_at": "2020-12-31T12:59:00.112248+00:00"}, "version": 1598610014806, "time_extracted": "2020-08-28T10:20:14.806296Z"}
{"type": "RECORD", "stream": "public-order", "record": {"created_at": "2020-08-28T10:19:43.134595+00:00", "cvarchar": "F", "id": 6, "updated_at": null}, "version": 1598610014806, "time_extracted": "2020-08-28T10:20:14.806296Z"}
{"type": "RECORD", "stream": "public-order", "record": {"created_at": "2020-08-28T10:19:43.134595+00:00", "cvarchar": "G", "id": 7, "updated_at": null}, "version": 1598610014806, "time_extracted": "2020-08-28T10:20:14.806296Z"}
{"type": "ACTIVATE_VERSION", "stream": "public-order", "version": 1598610014806}
{"type": "STATE", "value": {"bookmarks": {"public-order": {"last_replication_method": "LOG_BASED", "lsn": 25157384, "version": 1598610014806, "xmin": null}}, "currently_syncing": null}}
```

Notice the field `updated_at`, all the dates in it are in UTC tz. 

## Proposed changes

All that is needed is to correct the mapping to a naive timestamp

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
