### PR TITLE
[Fix] time bug in tap-mysql 

### DIFF
--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mysql==1.3.6
+pipelinewise-tap-mysql==1.3.7


### PR DESCRIPTION
## Problem

a bug was detected in ppw-tap-mysql where encountering a time type column during prepping of singer record causes the whole record to be overridden.

## Proposed changes

Use latest tap-mysql 1.3.7 with the fix 


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
