### PR TITLE
[FIX] - Ensure generated Postgres replication slot name is valid

### DIFF
--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -2,6 +2,7 @@ import datetime
 import decimal
 import gzip
 import logging
+import re
 import psycopg2
 import psycopg2.extras
 
@@ -40,7 +41,11 @@ class FastSyncTapPostgres:
         # Convert None to empty string
         else:
             tap_id = ''
-        return f'{prefix}_{dbname}{tap_id}'.lower()
+
+        slot_name = f'{prefix}_{dbname}{tap_id}'.lower()
+
+        # Replace invalid characters and truncate to a maximum of 64 characters; required by Postgres
+        return re.sub('[^a-z0-9_]', '_', slot_name)[:64]
 
     def open_connection(self):
         """

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -44,8 +44,8 @@ class FastSyncTapPostgres:
 
         slot_name = f'{prefix}_{dbname}{tap_id}'.lower()
 
-        # Replace invalid characters and truncate to a maximum of 64 characters; required by Postgres
-        return re.sub('[^a-z0-9_]', '_', slot_name)[:64]
+        # Replace invalid characters to ensure replication slot name is in accordance with Postgres spec
+        return re.sub('[^a-z0-9_]', '_', slot_name)
 
     def open_connection(self):
         """

--- a/singer-connectors/tap-postgres/requirements.txt
+++ b/singer-connectors/tap-postgres/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-postgres==1.6.3
+pipelinewise-tap-postgres==1.6.4

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -6,6 +6,7 @@ class FastSyncTapPostgresMock(FastSyncTapPostgres):
     """
     Mocked FastSyncTapPostgres class
     """
+
     def __init__(self, connection_config, transformation_config=None):
         super().__init__(connection_config, transformation_config)
 
@@ -26,6 +27,7 @@ class TestFastSyncTapPostgres(TestCase):
     """
     Unit tests for fastsync tap postgres
     """
+
     def setUp(self) -> None:
         """Initialise test FastSyncTapPostgres object"""
         self.postgres = FastSyncTapPostgresMock(connection_config={'dbname': 'test_database',
@@ -35,7 +37,8 @@ class TestFastSyncTapPostgres(TestCase):
     def test_generate_replication_slot_name(self):
         """Validate if the replication slot name generated correctly"""
         # Provide only database name
-        assert self.postgres.generate_replication_slot_name('some_db') == 'pipelinewise_some_db'
+        assert self.postgres.generate_replication_slot_name(
+            'some_db') == 'pipelinewise_some_db'
 
         # Provide database name and tap_id
         assert self.postgres.generate_replication_slot_name('some_db',
@@ -49,6 +52,19 @@ class TestFastSyncTapPostgres(TestCase):
         # Replication slot name should be lowercase
         assert self.postgres.generate_replication_slot_name('SoMe_DB',
                                                             'SoMe_TaP') == 'pipelinewise_some_db_some_tap'
+
+        # Invalid characters should be replaced by underscores
+        assert self.postgres.generate_replication_slot_name('some-db',
+                                                            'some-tap') == 'pipelinewise_some_db_some_tap'
+
+        assert self.postgres.generate_replication_slot_name('some.db',
+                                                            'some.tap') == 'pipelinewise_some_db_some_tap'
+
+        # Replication slots name should be truncated to 64 characters
+        assert self.postgres.generate_replication_slot_name(
+            'some_db_with_an_extremely_long_name',
+            'some_tap_with_an_extremely_long_name'
+        ) == 'pipelinewise_some_db_with_an_extremely_long_name_some_tap_with_a'
 
     def test_create_replication_slot(self):
         """Validate if replication slot creation SQL commands generated correctly"""

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -60,7 +60,7 @@ class TestFastSyncTapPostgres(TestCase):
         assert self.postgres.generate_replication_slot_name('some.db',
                                                             'some.tap') == 'pipelinewise_some_db_some_tap'
 
-        # Replication slots name should be truncated to 64 characters
+        # Replication slot name should be truncated to 64 characters
         assert self.postgres.generate_replication_slot_name(
             'some_db_with_an_extremely_long_name',
             'some_tap_with_an_extremely_long_name'

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -57,12 +57,6 @@ class TestFastSyncTapPostgres(TestCase):
         assert self.postgres.generate_replication_slot_name('some.db',
                                                             'some.tap') == 'pipelinewise_some_db_some_tap'
 
-        # Replication slot name should be truncated to 64 characters
-        assert self.postgres.generate_replication_slot_name(
-            'some_db_with_an_extremely_long_name',
-            'some_tap_with_an_extremely_long_name'
-        ) == 'pipelinewise_some_db_with_an_extremely_long_name_some_tap_with_a'
-
     def test_create_replication_slot(self):
         """Validate if replication slot creation SQL commands generated correctly"""
         self.postgres.create_replication_slot()

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -6,7 +6,6 @@ class FastSyncTapPostgresMock(FastSyncTapPostgres):
     """
     Mocked FastSyncTapPostgres class
     """
-
     def __init__(self, connection_config, transformation_config=None):
         super().__init__(connection_config, transformation_config)
 
@@ -27,7 +26,6 @@ class TestFastSyncTapPostgres(TestCase):
     """
     Unit tests for fastsync tap postgres
     """
-
     def setUp(self) -> None:
         """Initialise test FastSyncTapPostgres object"""
         self.postgres = FastSyncTapPostgresMock(connection_config={'dbname': 'test_database',
@@ -37,8 +35,7 @@ class TestFastSyncTapPostgres(TestCase):
     def test_generate_replication_slot_name(self):
         """Validate if the replication slot name generated correctly"""
         # Provide only database name
-        assert self.postgres.generate_replication_slot_name(
-            'some_db') == 'pipelinewise_some_db'
+        assert self.postgres.generate_replication_slot_name('some_db') == 'pipelinewise_some_db'
 
         # Provide database name and tap_id
         assert self.postgres.generate_replication_slot_name('some_db',


### PR DESCRIPTION
## Problem

When using logical replication from a Postgres tap, Pipelinewise generates the name of the Postgres replication slot used from a combination of prefix, database name, and tap name. This does not work if any of the constituent parts contain characters that are not valid in Postgres replication slot names, or if the full generated name is more than 64 characters long.

## Proposed changes

Replace invalid characters with an underscore and truncate the generated name at 64 characters. See https://github.com/transferwise/pipelinewise/issues/529. A similar PR is open on the tap-postgres repository: https://github.com/transferwise/pipelinewise-tap-postgres/pull/63.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [X] Description above provides context of the change
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
