### PR TITLE
Add docker build-arg to control which connectors are being added to t…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,19 @@ RUN apt-get -qq update && apt-get -qqy install \
         libaio1 \
         mongo-tools \
         mbuffer \
+        wget \
     && pip install --upgrade pip
 
-# Oracle Instant Clinet for tap-oracle
-ADD https://download.oracle.com/otn_software/linux/instantclient/193000/oracle-instantclient19.3-basiclite-19.3.0.0.0-1.x86_64.rpm /app/oracle-instantclient.rpm
-RUN alien -i /app/oracle-instantclient.rpm --scripts && rm -rf /app/oracle-instantclient.rpm
+ARG connectors=all
+
+# Install Oracle Instant Client for tap-oracle if its in the connectors list
+RUN bash -c "if grep -q \"tap-oracle\" <<< \"$connectors\"; then wget https://download.oracle.com/otn_software/linux/instantclient/193000/oracle-instantclient19.3-basiclite-19.3.0.0.0-1.x86_64.rpm -O /app/oracle-instantclient.rpm && alien -i /app/oracle-instantclient.rpm --scripts && rm -rf /app/oracle-instantclient.rpm ; fi"
+
 
 COPY . /app
 
 RUN cd /app \
-    && ./install.sh --connectors=all --acceptlicenses --nousage --notestextras \
+    && ./install.sh --connectors=$connectors --acceptlicenses --nousage --notestextras \
     && ln -s /root/.pipelinewise /app/.pipelinewise
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ consumes data from taps and do something with it, like load it into a file, API 
 
 If you have [Docker](https://www.docker.com/) installed then using docker is the recommended and easiest method to start using PipelineWise.
 
-1. Build an executable docker image that has every required dependency and is isolated from your host system:
+1. Build an executable docker image that has every required dependency and is isolated from your host system. 
+
+By default, the image will build with *all* connectors. In order to keep image size small, we strongly recommend you change it to just the connectors you need by supplying the `--build-arg` command:
 
     ```sh
-    $ docker build -t pipelinewise:latest .
+    $ docker build --build-arg connectors=tap-mysql,target-snowflake -t pipelinewise:latest .
     ```
 
 2. Once the image is ready, create an alias to the docker wrapper script:


### PR DESCRIPTION
…he image

+ README.md update

## Problem

Dockerfile is fixed to install all connectors when that's usually not necessary

## Proposed changes

As discussed, in here https://github.com/transferwise/pipelinewise/issues/528. Added the ability to supply a docker --build-arg to control which connectors are being installed. Still defaults to "all"


## Types of changes
- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation Update (if none of the other choices apply)


## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [X] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [X] CI checks pass with my changes
- [X] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions
