### PR TITLE
[DOC] Document postgres SSL mode

### DIFF
--- a/docs/connectors/taps/postgres.rst
+++ b/docs/connectors/taps/postgres.rst
@@ -154,6 +154,9 @@ Example YAML for ``tap-postgres``:
       #break_at_end_lsn:                   # Optional: Stop running the tap if the newly received lsn
                                            #           is after the max lsn that was detected when the tap started
                                            #           Default: true
+      #ssl: "true"                         # Optional: Using SSL via postgres sslmode 'require' option.
+                                           #           If the server does not accept SSL connections or the client
+                                           #           certificate is not recognized the connection will fail
 
 
     # ------------------------------------------------------------------------------

--- a/docs/connectors/targets/postgres.rst
+++ b/docs/connectors/targets/postgres.rst
@@ -42,4 +42,7 @@ Example YAML for ``target-postgres``:
       user: "<USER>"                       # PostgreSQL user
       password: "<PASSWORD>"               # Plain string or vault encrypted
       dbname: "<DB_NAME>"                  # PostgreSQL database name
+      #ssl: "true"                         # Optional: Using SSL via postgres sslmode 'require' option.
+                                           #           If the server does not accept SSL connections or the client
+                                           #           certificate is not recognized the connection will fail
 

--- a/pipelinewise/cli/samples/tap_postgres.yml.sample
+++ b/pipelinewise/cli/samples/tap_postgres.yml.sample
@@ -31,6 +31,9 @@ db_conn:
   #break_at_end_lsn:                   # Optional: Stop running the tap if the newly received lsn
                                        #           is after the max lsn that was detected when the tap started
                                        #           Default: true
+  #ssl: "true"                         # Optional: Using SSL via postgres sslmode 'require' option.
+                                       #           If the server does not accept SSL connections or the client
+                                       #           certificate is not recognized the connection will fail
 
 
 # ------------------------------------------------------------------------------

--- a/pipelinewise/cli/samples/target_postgres.yml.sample
+++ b/pipelinewise/cli/samples/target_postgres.yml.sample
@@ -17,4 +17,7 @@ db_conn:
   user: "<USER>"                          # Postgres user
   password: "<PASSWORD>"                  # Plain string or vault encrypted
   dbname: "<DB_NAME>"                     # Postgres database name
+  #ssl: "true"                         # Optional: Using SSL via postgres sslmode 'require' option.
+                                       #           If the server does not accept SSL connections or the client
+                                       #           certificate is not recognized the connection will fail
 


### PR DESCRIPTION
## Problem

PR https://github.com/transferwise/pipelinewise/pull/531 added SSL support to tap-postgres and target-postgres, but documentation not updated. 

## Proposed changes

Update documentation how to enable SSL in tap-postgres and target-postgres.


## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
