### PR TITLE
[AP-XXXX] Exit as failure when tap is running or not enabled

### DIFF
--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -898,14 +898,14 @@ class PipelineWise:
 
         # Run only if tap enabled
         if not self.tap.get('enabled', False):
-            self.logger.info('Tap %s is not enabled. Do nothing and exit normally.', self.tap['name'])
-            sys.exit(0)
+            self.logger.info('Tap %s is not enabled.', self.tap['name'])
+            sys.exit(1)
 
         # Run only if not running
         tap_status = self.detect_tap_status(target_id, tap_id)
         if tap_status['currentStatus'] == 'running':
-            self.logger.info('Tap %s is currently running. Do nothing and exit normally.', self.tap['name'])
-            sys.exit(0)
+            self.logger.info('Tap %s is currently running.', self.tap['name'])
+            sys.exit(1)
 
         # Generate and run the command to run the tap directly
         tap_config = self.tap['files']['config']
@@ -1051,8 +1051,8 @@ class PipelineWise:
 
         # Run only if tap enabled
         if not self.tap.get('enabled', False):
-            self.logger.info('Tap %s is not enabled. Do nothing and exit normally.', self.tap['name'])
-            sys.exit(0)
+            self.logger.info('Tap %s is not enabled.', self.tap['name'])
+            sys.exit(1)
 
         # Run only if tap not running
         tap_status = self.detect_tap_status(target_id, tap_id)


### PR DESCRIPTION
## Problem

`run_tap` and `sync_tables` commands returns exit code 0 (success), even if the tap cannot start because another tap is running or the tap cannot start because it's not enabled.

## Proposed changes

Change exit code from 0 to 1 if `run_tap` of `sync_tables` commands cannot start because another instance of the tap is already or the tap is not enabled.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
