### PR TITLE
Fix issue replicating text fields with NULL characters in Tap-MySQL

### DIFF
--- a/pipelinewise/fastsync/commons/tap_mysql.py
+++ b/pipelinewise/fastsync/commons/tap_mysql.py
@@ -217,7 +217,7 @@ class FastSyncTapMySql:
                                     THEN concat('CASE WHEN `' , column_name , '` is null THEN null WHEN `' , column_name , '` = 0 THEN 0 ELSE 1 END')
                             WHEN column_name = 'raw_data_hash'
                                     THEN concat('REPLACE(hex(`', column_name, '`)', ", '\n', ' ')")
-                            ELSE concat('REPLACE(cast(`', column_name, '` AS char CHARACTER SET utf8)', ", '\n', ' ')")
+                            ELSE concat('REPLACE(REPLACE(cast(`', column_name, '` AS char CHARACTER SET utf8)', ", '\n', ' '), '\0', '')")
                                 END AS safe_sql_value,
                             ordinal_position
                     FROM information_schema.columns

--- a/tests/db/tap_mysql_data.sql
+++ b/tests/db/tap_mysql_data.sql
@@ -44,7 +44,7 @@ INSERT INTO `edgydata` VALUES
   (2, 'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช', 20, 'A', '{}', '10:00:59'),
   (3, 'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.', null, 'B', '[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]', '15:36:10'),
   (4, 'Special Characters: ["\\,''!@£$%^&*()]\\\\', null, 'B', null, '12:00:00'),
-  (5, '	', 20, 'B', null, '15:36:10'),
+  (5, CONCAT(' <- space ', CHAR(0x0000 using utf16), '<- null char'), 20, 'B', null, '15:36:10'),
   (6,'Enter	The
 Ninja', 10, 'A', null, '15:36:10'),
   (7,'Liewe

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -92,7 +92,8 @@ class TestTargetPostgres:
                                  ' \'9:1:00\'),'
                                  '(\'Special Characters: [\"\\,''!@£$%^&*()]\\\\\', null, \'B\', '
                                  'null, \'12:00:00\'),'
-                                 '(\'	\', 20, \'B\', null, \'15:36:10\')')
+                                 '(\'	\', 20, \'B\', null, \'15:36:10\'),'
+                                 '(CONCAT(CHAR(0x0000 using utf16), \'<- null char\'), 20, \'B\', null, \'15:36:10\')')
 
         #  INCREMENTAL
         self.run_query_tap_mysql('INSERT INTO address(isactive, street_number, date_created, date_updated,'

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -83,7 +83,8 @@ class TestTargetSnowflake:
                                  ' \'9:1:00\'),'
                                  '(\'Special Characters: [\"\\,''!@£$%^&*()]\\\\\', null, \'B\', '
                                  'null, \'12:00:00\'),'
-                                 '(\'	\', 20, \'B\', null, \'15:36:10\')')
+                                 '(\'	\', 20, \'B\', null, \'15:36:10\'),'
+                                 '(CONCAT(CHAR(0x0000 using utf16), \'<- null char\'), 20, \'B\', null, \'15:36:10\')')
 
         #  INCREMENTAL
         self.run_query_tap_mysql('INSERT INTO address(isactive, street_number, date_created, date_updated,'


### PR DESCRIPTION
## Problem

Hi there, I'm running into an issue replicating data from MySQL to PostgreSQL.

```ERROR: invalid byte sequence for encoding "UTF8": 0x00```

The problem is that some text fields in our MySQL database contain the NULL character which Postgres cannot stored according to [this stackoverflow post](https://stackoverflow.com/questions/1347646/postgres-error-on-insert-error-invalid-byte-sequence-for-encoding-utf8-0x0).

Notes: 
- This isn't an issue with [pipelinewise-tap-mysql](https://github.com/transferwise/pipelinewise-tap-mysql) as NULL characters are escaped to `\\u0000` when the data is converted to JSON.

## Proposed changes

This PR removes NULL characters when extracting data out text fields in a MySQL database. 

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
