### PR TITLE
[AP-840][FIX] Parse data from json(b) column in tap-postgres during log based replication

### DIFF
--- a/singer-connectors/tap-postgres/requirements.txt
+++ b/singer-connectors/tap-postgres/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-postgres==1.7.0
+pipelinewise-tap-postgres==1.7.1


### PR DESCRIPTION
## Problem

Log_Based replication in postgres doesn't properly parse data from json(b) column and the streams end up having stringified json data.
This is not in sync with other replication methods that parse json data.

## Proposed changes

https://github.com/transferwise/pipelinewise-tap-postgres/pull/70

Use ppw-tap-postgres 1.7.1


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
