### PR TITLE
[AP-495] Add --profiler optional parameter to pipelinewise commands

### DIFF
--- a/pipelinewise/cli/__init__.py
+++ b/pipelinewise/cli/__init__.py
@@ -65,11 +65,12 @@ def __init_profiler(profiler_arg: bool, logger: logging.Logger) -> Tuple[Optiona
     """
     Initialise profiling environment by creating a cprofile.Profiler instance, a folder where pstats can be dumped
     Args:
-        profiler_arg:
-        logger:
+        profiler_arg: the value of profiler argument passed when running the command
+        logger: a logger instance
 
     Returns:
-
+        If profiling enabled, a tuple of profiler instance and profiling directory where the stats files
+        would be dumped, otherwise, a tuple of nulls
     """
     if profiler_arg:
         logger.info('Profiling mode enabled')

--- a/pipelinewise/cli/__init__.py
+++ b/pipelinewise/cli/__init__.py
@@ -2,19 +2,25 @@
 PipelineWise CLI
 """
 import argparse
+import errno
 import os
 import sys
 import copy
 import logging
 
+from cProfile import Profile
+from datetime import datetime
+from typing import Optional, Tuple
 from pkg_resources import get_distribution
-from ..logger import Logger
 
+from .utils import generate_random_string
 from .pipelinewise import PipelineWise
+from ..logger import Logger
 
 __version__ = get_distribution('pipelinewise').version
 USER_HOME = os.path.expanduser('~')
 CONFIG_DIR = os.path.join(USER_HOME, '.pipelinewise')
+PROFILING_DIR = os.path.join(CONFIG_DIR, 'profiling')
 PIPELINEWISE_DEFAULT_HOME = os.path.join(USER_HOME, 'pipelinewise')
 PIPELINEWISE_HOME = os.path.abspath(os.environ.setdefault('PIPELINEWISE_HOME', PIPELINEWISE_DEFAULT_HOME))
 VENV_DIR = os.path.join(PIPELINEWISE_HOME, '.virtualenvs')
@@ -31,6 +37,7 @@ COMMANDS = [
     'validate',
     'encrypt_string',
 ]
+
 
 def __init_logger(log_file=None, debug=False):
     """
@@ -51,6 +58,80 @@ def __init_logger(log_file=None, debug=False):
 
         logger.addHandler(file_handler)
 
+    return logger
+
+
+def __init_profiler(profiler_arg: bool, logger: logging.Logger) -> Tuple[Optional[Profile], Optional[str]]:
+    """
+    Initialise profiling environment by creating a cprofile.Profiler instance, a folder where pstats can be dumped
+    Args:
+        profiler_arg:
+        logger:
+
+    Returns:
+
+    """
+    if profiler_arg:
+        logger.info('Profiling mode enabled')
+
+        logger.debug('Creating & enabling profiler ...')
+
+        profiler = Profile()
+        profiler.enable()
+
+        logger.debug('Profiler created.')
+
+        profiling_dir = os.path.join(PROFILING_DIR,
+                                     f'{datetime.utcnow().strftime("%Y%m%d_%H%M%S_%f")}_{generate_random_string(10)}'
+                                     )
+
+        try:
+            os.makedirs(profiling_dir)
+            logger.debug('Profiling directory "%s" created', profiling_dir)
+
+        except OSError as ex:
+            if ex.errno != errno.EEXIST:
+                raise
+
+            logger.debug('Profiling directory "%s" already exists', profiling_dir)
+
+        return profiler, profiling_dir
+
+    logger.info('Profiling mode not enabled')
+
+    return None, None
+
+
+def __disable_profiler(profiler: Optional[Profile],
+                       profiling_dir: Optional[str],
+                       pstat_filename: Optional[str],
+                       logger: logging.Logger):
+    """
+    Disable given profiler and dump pipelinewise stats into a pStat file
+    Args:
+        profiler: optional instance of cprofile.Profiler to disable
+        profiling_dir: profiling dir where pstat file will be created
+        pstat_filename: custom pstats file name, the extension .pstat will be appended to the name
+        logger: Logger instance to do some info and debug logging
+    """
+    if profiler is not None:
+        logger.debug('disabling profiler and dumping stats...')
+
+        profiler.disable()
+
+        if not pstat_filename.endswith('.pstat'):
+            pstat_filename = f'{pstat_filename}.pstat'
+
+        dump_file = os.path.join(profiling_dir, pstat_filename)
+
+        logger.debug('Attempting to dump profiling stats in file "%s" ...', dump_file)
+        profiler.dump_stats(dump_file)
+        logger.debug('Profiling stats dump successful')
+
+        logger.info('Profiling stats files are in folder "%s"', profiling_dir)
+
+        profiler.clear()
+
 
 # pylint: disable=too-many-branches,too-many-statements
 def main():
@@ -67,12 +148,10 @@ def main():
     parser.add_argument('--name', type=str, default='*', help='Name of the project')
     parser.add_argument('--secret', type=str, help='Path to vault password file')
     parser.add_argument('--string', type=str)
-    parser.add_argument(
-        '--version',
-        action='version',
-        help='Displays the installed versions',
-        version='PipelineWise {} - Command Line Interface'.format(__version__),
-    )
+    parser.add_argument('--version',
+                        action='version',
+                        help='Displays the installed versions',
+                        version='PipelineWise {} - Command Line Interface'.format(__version__))
     parser.add_argument('--log', type=str, default='*', help='File to log into')
     parser.add_argument('--extra_log',
                         default=False,
@@ -84,14 +163,20 @@ def main():
                         required=False,
                         help='Forces the debug mode with logging on stdout and log level debug',
                         action='store_true')
+    parser.add_argument('--profiler', '-p',
+                        default=False,
+                        required=False,
+                        help='Enables code profiling mode using Python builtin profiler cProfile. '
+                             'The stats will be dumped into a folder in .pipelinewise/profiling',
+                        action='store_true'
+                        )
 
     args = parser.parse_args()
 
     # Command specific argument validations
-    if args.command == 'init':
-        if args.name == '*':
-            print('You must specify a project name using the argument --name')
-            sys.exit(1)
+    if args.command == 'init' and args.name == '*':
+        print('You must specify a project name using the argument --name')
+        sys.exit(1)
 
     if args.command in ['discover_tap', 'test_tap_connection', 'run_tap', 'stop_tap']:
         if args.tap == '*':
@@ -122,10 +207,9 @@ def main():
         # python keyword and can't be used as function name
         args.command = 'import_project'
 
-    if args.command == 'validate':
-        if args.dir == '*':
-            print('You must specify a directory path with config YAML files using the argument --dir')
-            sys.exit(1)
+    if args.command == 'validate' and args.dir == '*':
+        print('You must specify a directory path with config YAML files using the argument --dir')
+        sys.exit(1)
 
     if args.command == 'encrypt_string':
         if not args.secret:
@@ -135,11 +219,16 @@ def main():
             print('You must specify a string to encrypt using the argument --string')
             sys.exit(1)
 
-    # Init logger
-    __init_logger(args.log, args.debug)
+    logger = __init_logger(args.log, args.debug)
 
-    ppw_instance = PipelineWise(args, CONFIG_DIR, VENV_DIR)
-    getattr(ppw_instance, args.command)()
+    profiler, profiling_dir = __init_profiler(args.profiler, logger)
+
+    ppw_instance = PipelineWise(args, CONFIG_DIR, VENV_DIR, profiling_dir)
+
+    try:
+        getattr(ppw_instance, args.command)()
+    finally:
+        __disable_profiler(profiler, profiling_dir, f'pipelinewise_{args.command}', logger)
 
 
 if __name__ == '__main__':

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -34,8 +34,12 @@ class PipelineWise:
     FULL_TABLE = 'FULL_TABLE'
     STATUS_SUCCESS = 'SUCCESS'
     STATUS_FAILED = 'FAILED'
+    TRANSFORM_FIELD_CONNECTOR_NAME = 'transform-field'
 
-    def __init__(self, args, config_dir, venv_dir):
+    def __init__(self, args, config_dir, venv_dir, profiling_dir=None):
+
+        self.profiling_mode = args.profiler
+        self.profiling_dir = profiling_dir
         self.args = args
         self.logger = logging.getLogger(__name__)
         self.config_dir = config_dir
@@ -49,12 +53,15 @@ class PipelineWise:
         if args.tap != '*':
             self.tap = self.get_tap(args.target, args.tap)
             self.tap_bin = self.get_connector_bin(self.tap['type'])
+            self.tap_python_bin = self.get_connector_python_bin(self.tap['type'])
 
         if args.target != '*':
             self.target = self.get_target(args.target)
             self.target_bin = self.get_connector_bin(self.target['type'])
+            self.target_python_bin = self.get_connector_python_bin(self.target['type'])
 
-        self.transform_field_bin = self.get_connector_bin('transform-field')
+        self.transform_field_bin = self.get_connector_bin(self.TRANSFORM_FIELD_CONNECTOR_NAME)
+        self.transform_field_python_bin = self.get_connector_python_bin(self.TRANSFORM_FIELD_CONNECTOR_NAME)
         self.tap_run_log_file = None
 
         # Catch SIGINT and SIGTERM to exit gracefully
@@ -304,6 +311,12 @@ class PipelineWise:
         """
         return os.path.join(self.venv_dir, connector_type, 'bin', connector_type)
 
+    def get_connector_python_bin(self, connector_type):
+        """
+        Get absolute path of a connector python command
+        """
+        return os.path.join(self.venv_dir, connector_type, 'bin', 'python')
+
     @classmethod
     def get_connector_files(cls, connector_dir):
         """
@@ -332,7 +345,7 @@ class PipelineWise:
 
         return targets
 
-    def get_target(self, target_id):
+    def get_target(self, target_id: str) -> Dict:
         """
         Get target by id
         """
@@ -613,6 +626,11 @@ class PipelineWise:
         # We will use the discover option to test connection
         tap_config = self.tap['files']['config']
         command = f'{self.tap_bin} --config {tap_config} --discover'
+
+        if self.profiling_mode:
+            dump_file = os.path.join(self.profiling_dir, f'tap_{tap_id}.pstat')
+            command = f'{self.tap_python_bin} -m cProfile -o {dump_file} {command}'
+
         result = commands.run_command(command)
 
         # Get output and errors from tap
@@ -648,6 +666,7 @@ class PipelineWise:
         tap_properties_file = tap.get('files', {}).get('properties')
         tap_selection_file = tap.get('files', {}).get('selection')
         tap_bin = self.get_connector_bin(tap_type)
+        tap_python_bin = self.get_connector_python_bin(tap_type)
 
         # Define target props
         target_id = target.get('id')
@@ -657,6 +676,13 @@ class PipelineWise:
 
         # Generate and run the command to run the tap directly
         command = f'{tap_bin} --config {tap_config_file} --discover'
+
+        if self.profiling_mode:
+            dump_file = os.path.join(self.profiling_dir, f'tap_{tap_id}.pstat')
+            command = f'{tap_python_bin} -m cProfile -o {dump_file} {command}'
+
+        self.logger.debug('Discovery command: %s', command)
+
         result = commands.run_command(command)
 
         # Get output and errors from tap
@@ -670,6 +696,7 @@ class PipelineWise:
         try:
             new_schema = json.loads(new_schema)
         except Exception as exc:
+            self.logger.exception(exc)
             return f'Schema discovered by {tap_id} ({tap_type}) is not a valid JSON.'
 
         # Merge the old and new schemas and diff changes
@@ -778,7 +805,10 @@ class PipelineWise:
         print(tabulate(tab_body, headers=tab_headers, tablefmt='simple'))
         print(f'{pipelines} pipeline(s)')
 
-    def run_tap_singer(self, tap: TapParams, target: TargetParams, transform: TransformParams,
+    def run_tap_singer(self,
+                       tap: TapParams,
+                       target: TargetParams,
+                       transform: TransformParams,
                        stream_buffer_size: int = 0) -> str:
         """
         Generate and run piped shell command to sync tables using singer taps and targets
@@ -788,7 +818,9 @@ class PipelineWise:
                                                 target=target,
                                                 transform=transform,
                                                 stream_buffer_size=stream_buffer_size,
-                                                stream_buffer_log_file=self.tap_run_log_file)
+                                                stream_buffer_log_file=self.tap_run_log_file,
+                                                profiling_mode=self.profiling_mode,
+                                                profiling_dir=self.profiling_dir)
 
         # Do not run if another instance is already running
         log_dir = os.path.dirname(self.tap_run_log_file)
@@ -850,7 +882,9 @@ class PipelineWise:
                                                   transform=transform,
                                                   venv_dir=self.venv_dir,
                                                   temp_dir=self.get_temp_dir(),
-                                                  tables=self.args.tables)
+                                                  tables=self.args.tables,
+                                                  profiling_mode=self.profiling_mode,
+                                                  profiling_dir=self.profiling_dir)
 
         # Do not run if another instance is already running
         log_dir = os.path.dirname(self.tap_run_log_file)
@@ -951,14 +985,29 @@ class PipelineWise:
         start_time = datetime.now()
         try:
             with pidfile.PIDFile(self.tap['files']['pidfile']):
-                target_params = TargetParams(target_type, self.target_bin, cons_target_config)
-                transform_params = TransformParams(self.transform_field_bin, tap_transformation)
+                target_params = TargetParams(id=target_id,
+                                             type=target_type,
+                                             bin=self.target_bin,
+                                             python_bin=self.target_python_bin,
+                                             config=cons_target_config)
+
+                transform_params = TransformParams(bin=self.transform_field_bin,
+                                                   python_bin=self.transform_field_python_bin,
+                                                   config=tap_transformation,
+                                                   tap_id=tap_id,
+                                                   target_id=target_id)
 
                 # Run fastsync for FULL_TABLE replication method
                 if len(fastsync_stream_ids) > 0:
                     self.logger.info('Table(s) selected to sync by fastsync: %s', fastsync_stream_ids)
                     self.tap_run_log_file = os.path.join(log_dir, f'{target_id}-{tap_id}-{current_time}.fastsync.log')
-                    tap_params = TapParams(tap_type, self.tap_bin, tap_config, tap_properties_fastsync, tap_state)
+                    tap_params = TapParams(id=tap_id,
+                                           type=tap_type,
+                                           bin=self.tap_bin,
+                                           python_bin=self.tap_python_bin,
+                                           config=tap_config,
+                                           properties=tap_properties_fastsync,
+                                           state=tap_state)
 
                     self.run_tap_fastsync(tap=tap_params,
                                           target=target_params,
@@ -970,7 +1019,13 @@ class PipelineWise:
                 if len(singer_stream_ids) > 0:
                     self.logger.info('Table(s) selected to sync by singer: %s', singer_stream_ids)
                     self.tap_run_log_file = os.path.join(log_dir, f'{target_id}-{tap_id}-{current_time}.singer.log')
-                    tap_params = TapParams(tap_type, self.tap_bin, tap_config, tap_properties_singer, tap_state)
+                    tap_params = TapParams(id=tap_id,
+                                           type=tap_type,
+                                           bin=self.tap_bin,
+                                           python_bin=self.tap_python_bin,
+                                           config=tap_config,
+                                           properties=tap_properties_singer,
+                                           state=tap_state)
 
                     self.run_tap_singer(tap=tap_params,
                                         target=target_params,
@@ -1095,9 +1150,31 @@ class PipelineWise:
                 self.tap_run_log_file = os.path.join(log_dir, f'{target_id}-{tap_id}-{current_time}.fastsync.log')
 
                 # Create parameters as NamedTuples
-                tap_params = TapParams(tap_type, self.tap_bin, tap_config, tap_properties, tap_state)
-                target_params = TargetParams(target_type, self.target_bin, cons_target_config)
-                transform_params = TransformParams(self.transform_field_bin, tap_transformation)
+                tap_params = TapParams(
+                    id=tap_id,
+                    type=tap_type,
+                    bin=self.tap_bin,
+                    python_bin=self.tap_python_bin,
+                    config=tap_config,
+                    properties=tap_properties,
+                    state=tap_state)
+
+                target_params = TargetParams(
+                    id=target_id,
+                    type=target_type,
+                    bin=self.target_bin,
+                    python_bin=self.target_python_bin,
+                    config=cons_target_config
+                )
+
+                transform_params = TransformParams(
+                    bin=self.transform_field_bin,
+                    config=tap_transformation,
+                    python_bin=self.transform_field_python_bin,
+                    tap_id=tap_id,
+                    target_id=target_id
+                )
+
                 self.run_tap_fastsync(tap=tap_params,
                                       target=target_params,
                                       transform=transform_params)
@@ -1269,7 +1346,6 @@ class PipelineWise:
                     'lsn' not in stream_bookmark and
                     'log_pos' not in stream_bookmark and
                     'token' not in stream_bookmark)
-
 
     # pylint: disable=unused-argument
     def _exit_gracefully(self, sig, frame, exit_code=1):

--- a/pipelinewise/cli/schemas/target.json
+++ b/pipelinewise/cli/schemas/target.json
@@ -179,7 +179,8 @@
       "type": "string",
       "not": {
         "enum": [
-          "tmp"
+          "tmp",
+          "profiling"
         ]
       }
     },

--- a/pipelinewise/cli/utils.py
+++ b/pipelinewise/cli/utils.py
@@ -7,8 +7,12 @@ import json
 import logging
 import os
 import re
+import secrets
+import string
 import sys
 import tempfile
+import warnings
+
 import jsonschema
 import yaml
 
@@ -51,12 +55,12 @@ class AnsibleJSONEncoder(json.JSONEncoder):
         return value
 
 
-def is_json(string):
+def is_json(stringss):
     """
     Detects if a string is a valid json or not
     """
     try:
-        json.loads(string)
+        json.loads(stringss)
     except Exception:
         return False
     return True
@@ -78,7 +82,7 @@ def is_json_file(path):
 
 def load_json(path):
     """
-    Deserialise JSON file to python object
+    Deserialize JSON file to python object
     """
     try:
         LOGGER.debug('Parsing file at %s', path)
@@ -94,7 +98,7 @@ def load_json(path):
 
 def is_state_message(line: str) -> bool:
     """
-    Detects if a string is a validstate message
+    Detects if a string is a valid state message
     """
     try:
         json_object = json.loads(line)
@@ -115,12 +119,12 @@ def save_json(data, path):
         raise Exception(f'Cannot save JSON {path} {exc}')
 
 
-def is_yaml(string):
+def is_yaml(strings):
     """
     Detects if a string is a valid yaml or not
     """
     try:
-        yaml.safe_load(string)
+        yaml.safe_load(strings)
     except Exception:
         return False
     return True
@@ -438,6 +442,17 @@ def get_fastsync_bin(venv_dir, tap_type, target_type):
     return os.path.join(venv_dir, 'pipelinewise', 'bin', fastsync_name)
 
 
+def get_pipelinewise_python_bin(venv_dir: str) -> str:
+    """
+    Get the absolute path of a PPW python executable
+    Args:
+        venv_dir: path to the ppw virtual env
+
+    Returns: path to python executable
+    """
+    return os.path.join(venv_dir, 'pipelinewise', 'bin', 'python')
+
+
 # pylint: disable=redefined-builtin
 def create_temp_file(suffix=None, prefix=None, dir=None, text=None):
     """
@@ -491,3 +506,22 @@ def find_errors_in_log_file(file, max_errors=10, error_pattern=None):
                         file_object.seek(0, 2)
 
     return errors
+
+
+def generate_random_string(length: int = 8) -> str:
+    """
+    Generate cryptographically secure random strings
+    Uses best practice from Python doc https://docs.python.org/3/library/secrets.html#recipes-and-best-practices
+    Args:
+        length: length of the string to generate
+    Returns: random string
+    """
+
+    if length < 1:
+        raise Exception('Length must be at least 1!')
+
+    if 0 < length < 8:
+        warnings.warn('Length is too small! consider 8 or more characters')
+
+    return ''.join(secrets.choice(string.ascii_uppercase + string.digits)
+                   for _ in range(length))

--- a/pylintrc
+++ b/pylintrc
@@ -496,7 +496,7 @@ int-import-graph=
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=5
+max-args=7
 
 # Argument names that match this expression will be ignored. Default to name
 # with leading underscore

--- a/tests/end_to_end/helpers/tasks.py
+++ b/tests/end_to_end/helpers/tasks.py
@@ -28,3 +28,16 @@ def find_run_tap_log_file(stdout, sync_engine=None):
         pattern = re.compile(r'Writing output into (.+\.log)')
 
     return pattern.search(stdout).group(1)
+
+
+def find_profiling_folder(stdout):
+    """
+    Pipelinewise profiling mode creates a folder where all the stats files are dumped
+    This function tries to find that folder from the given stdout output
+    Args:
+        stdout: output of PPW
+    Returns: profiling folder as string
+    """
+    pattern = re.compile(r'Profiling stats files are in folder "(.+)"')
+
+    return pattern.search(stdout).group(1)

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -104,7 +104,7 @@ class TestTargetSnowflake:
     @pytest.mark.dependency(depends=['import_config'])
     def test_resync_mariadb_to_sf(self, tap_mariadb_id=TAP_MARIADB_ID):
         """Resync tables from MariaDB to Snowflake"""
-        assertions.assert_resync_tables_success(tap_mariadb_id, TARGET_ID)
+        assertions.assert_resync_tables_success(tap_mariadb_id, TARGET_ID, profiling=True)
         assertions.assert_row_counts_equal(self.run_query_tap_mysql, self.run_query_target_snowflake)
         assertions.assert_all_columns_exist(self.run_query_tap_mysql, self.run_query_target_snowflake,
                                             mysql_to_snowflake.tap_type_to_target_type)
@@ -161,7 +161,7 @@ class TestTargetSnowflake:
         self.run_query_tap_postgres("DELETE FROM public.country WHERE code = 'UMI'")
 
         # 3. Run tap second time - both fastsync and a singer should be triggered, there are some FULL_TABLE
-        assertions.assert_run_tap_success(TAP_POSTGRES_ID, TARGET_ID, ['fastsync', 'singer'])
+        assertions.assert_run_tap_success(TAP_POSTGRES_ID, TARGET_ID, ['fastsync', 'singer'], profiling=True)
         assertions.assert_row_counts_equal(self.run_query_tap_postgres, self.run_query_target_snowflake)
         assertions.assert_all_columns_exist(self.run_query_tap_postgres, self.run_query_target_snowflake)
         assertions.assert_date_column_naive_in_target(self.run_query_target_snowflake,

--- a/tests/units/cli/cli_args.py
+++ b/tests/units/cli/cli_args.py
@@ -17,7 +17,9 @@ class CliArgs:
                  string=None,
                  log='*',
                  extra_log=False,
-                 debug=False):
+                 debug=False,
+                 profiler=False
+                 ):
         self.target = target
         self.tap = tap
         self.tables = tables
@@ -28,6 +30,7 @@ class CliArgs:
         self.log = log
         self.extra_log = extra_log
         self.debug = debug
+        self.profiler = profiler
 
     # "log" Getters and setters
     @property

--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -18,6 +18,7 @@ CONFIG_DIR = '{}/sample_json_config'.format(RESOURCES_DIR)
 VIRTUALENVS_DIR = './virtualenvs-dummy'
 TEST_PROJECT_NAME = 'test-project'
 TEST_PROJECT_DIR = '{}/{}'.format(os.getcwd(), TEST_PROJECT_NAME)
+PROFILING_DIR = './profiling'
 
 
 # pylint: disable=no-self-use,too-many-public-methods,attribute-defined-outside-init,fixme
@@ -29,7 +30,7 @@ class TestCli:
     def setup_method(self):
         """Create CLI arguments"""
         self.args = CliArgs(log='coverage.log')
-        self.pipelinewise = PipelineWise(self.args, CONFIG_DIR, VIRTUALENVS_DIR)
+        self.pipelinewise = PipelineWise(self.args, CONFIG_DIR, VIRTUALENVS_DIR, PROFILING_DIR)
 
     def teardown_method(self):
         """Delete test directories"""

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -7,12 +7,11 @@ import pytest
 VIRTUALENVS_DIR = './virtualenvs-dummy'
 
 
-# pylint: disable=no-self-use,fixme
+# pylint: disable=no-self-use,too-many-public-methods,fixme
 class TestUtils:
     """
     Unit Tests for PipelineWise CLI utility functions
     """
-
     def assert_json_is_invalid(self, schema, invalid_target):
         """Simple assertion to check if validate function exits with error"""
         with pytest.raises(SystemExit) as pytest_wrapped_e:
@@ -249,10 +248,7 @@ class TestUtils:
             'foo2': None,
             'foo3': None,
             'foo4': 'bar4'
-        }) == {
-            'foo': 'bar',
-            'foo4': 'bar4'
-        }
+        }) == {'foo': 'bar', 'foo4': 'bar4'}
 
         # Delete single key by name
         assert cli.utils.delete_keys_from_dict({'foo': 'bar', 'foo2': 'bar2'}, ['foo2']) == {'foo': 'bar'}
@@ -263,17 +259,14 @@ class TestUtils:
             'foo2': 'bar2',
             'foo3': None,
             'foo4': 'bar4'
-        }, ['foo2', 'foo4']) == {
-            'foo': 'bar',
-            'foo3': None
-        }
+        }, ['foo2', 'foo4']) == {'foo': 'bar', 'foo3': None}
 
         # Delete multiple keys from list of nested dictionaries
         assert cli.utils.delete_keys_from_dict(
             [{'foo': 'bar', 'foo2': 'bar2'},
              {'foo3': {'nested_foo': 'nested_bar', 'nested_foo2': 'nested_bar2'}}], ['foo2', 'nested_foo']) == \
-             [{'foo': 'bar'},
-              {'foo3': {'nested_foo2': 'nested_bar2'}}]
+               [{'foo': 'bar'},
+                {'foo3': {'nested_foo2': 'nested_bar2'}}]
 
     def test_silentremove(self):
         """Test removing functions"""
@@ -375,24 +368,40 @@ class TestUtils:
         # Should return the default max number of errors
         log_file = '{}/resources/sample_log_files/tap-run-lot-of-errors.log'.format(os.path.dirname(__file__))
         assert cli.utils.find_errors_in_log_file(log_file) == \
-            ['time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 1\n',
-             'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 2\n',
-             'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 3\n',
-             'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 4\n',
-             'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 5\n',
-             'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 6\n',
-             'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 7\n',
-             'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 8\n',
-             'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 9\n',
-             'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 10\n']
+               ['time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 1\n',
+                'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 2\n',
+                'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 3\n',
+                'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 4\n',
+                'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 5\n',
+                'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 6\n',
+                'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 7\n',
+                'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 8\n',
+                'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 9\n',
+                'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 10\n']
 
         # Should return the custom max number of errors
         log_file = '{}/resources/sample_log_files/tap-run-lot-of-errors.log'.format(os.path.dirname(__file__))
         assert cli.utils.find_errors_in_log_file(log_file, max_errors=2) == \
-            ['time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 1\n',
-             'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 2\n']
+               ['time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 1\n',
+                'time=2020-07-15 11:24:43 logger_name=tap_postgres log_level=CRITICAL This is a critical error 2\n']
 
         # Should return the custom max number of errors
         log_file = '{}/resources/sample_log_files/tap-run-errors.log'.format(os.path.dirname(__file__))
         assert cli.utils.find_errors_in_log_file(log_file, error_pattern=re.compile('CUSTOM-ERR-PATTERN')) == \
-            ['CUSTOM-ERR-PATTERN: This is a custom pattern error message\n']
+               ['CUSTOM-ERR-PATTERN: This is a custom pattern error message\n']
+
+    def test_generate_rand_str_exc(self):
+        """generate_random_string given a length lower than 1, expect an exception"""
+        with pytest.raises(Exception):
+            cli.utils.generate_random_string(-1)
+
+    def test_generate_rand_str_warning(self):
+        """generate_random_string given a length between 1 and 8 expect result and warning"""
+        with pytest.warns(Warning):
+            random_str = cli.utils.generate_random_string(5)
+            assert len(random_str) == 5
+
+    def test_generate_rand_str_success(self):
+        """generate_random_string given a length greater than or eq to 8 expect result"""
+        random_str = cli.utils.generate_random_string(10)
+        assert len(random_str) == 10


### PR DESCRIPTION
## Problem

Code profiling ability missing

## Proposed changes

Add a parameter `--profiler` to pipelinewise commands, this enables profiling mode which uses Python built-in profiler cProfile to get stats on where pipelinewise is spending time.

The profiling mode also profiles the connectors and dumps their stats in separate files. 

The `pstat` files are dumped into a dynamically generated folder under `.pipelinewise/profiling`, these files can be viewed with external tools such as Pycharm or from the command line by using the `pStats` python module.

PS: Will work on documentation in a separate PR.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
