### PR TITLE
[AP-345] Do not denest tap-mixpanel stream properties

### DIFF
--- a/docs/connectors/taps/mixpanel.rst
+++ b/docs/connectors/taps/mixpanel.rst
@@ -63,6 +63,10 @@ Example YAML for ``tap-mixpanel``:
       project_timezone: "Europe/London"         # Time zone in which integer date times are stored. The project timezone
                                                 # may be found in the project settings in the Mixpanel console.
       user_agent: "tap-mixpanel <api@foo.com>"  # Optional: Process and email for API logging purposes.
+      #denest_properties: "false"               # Optional: Do not denest JSON responses in `export` and `engage` streams
+                                                # to avoid very wide tables. If denesting is disabled then responses are
+                                                # loaded into one JSON column in the target.
+                                                # Default denest_properties is false.
 
       #export_events:                           # Optional: List of event names to export
       #  - event_one

--- a/pipelinewise/cli/samples/tap_mixpanel.yml.sample
+++ b/pipelinewise/cli/samples/tap_mixpanel.yml.sample
@@ -25,6 +25,10 @@ db_conn:
   project_timezone: "Europe/London"         # Time zone in which integer date times are stored. The project timezone
                                             # may be found in the project settings in the Mixpanel console.
   user_agent: "tap-mixpanel <api@foo.com>"  # Optional: Process and email for API logging purposes.
+  #denest_properties: "false"               # Optional: Do not denest JSON responses in `export` and `engage` streams
+                                            # to avoid very wide tables. If denesting is disabled then responses are
+                                            # loaded into one JSON column in the target.
+                                            # Default denest_properties is false.
 
   #export_events:                           # Optional: List of event names to export
   #  - event_one

--- a/pipelinewise/cli/tap_properties.py
+++ b/pipelinewise/cli/tap_properties.py
@@ -255,7 +255,11 @@ def get_tap_properties(tap=None, temp_dir=None):
             'default_data_flattening_max_level': 0
         },
         'tap-mixpanel': {
-            'tap_config_extras': {},
+            'tap_config_extras': {
+                'user_agent': 'PipelineWise - Tap Mixpanel',
+                # Do not denest properties by default
+                'denest_properties': tap.get('db_conn', {}).get('denest_properties', 'false') if tap else None
+            },
             'tap_stream_id_pattern': '{{table_name}}',
             'tap_stream_name_pattern': '{{table_name}}',
             'tap_catalog_argument': '--catalog',

--- a/singer-connectors/tap-mixpanel/requirements.txt
+++ b/singer-connectors/tap-mixpanel/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mixpanel==1.0.1
+pipelinewise-tap-mixpanel==1.2.0


### PR DESCRIPTION
## Problem

Tap mixpanel is de-nesting event JSONs received from the `export` and `engage` endpoints. This is cool but it's producing very wide tables and can be hard to work with it. Some database also have efficient column types to store JSONs and de-nesting is not always the preferred option.

## Proposed changes

Bump `pipelinewise-tap-mixpanel` to 1.2.0 that introduce `denest_properties` optional parameter:
* If it's `true` then JSON properties are de-nested producing wide columns in the `export` and `engage` streams.
* If it's `false` then JSON properties received from Mixpanel are kept as-is, and let the target decide how to store it: Postgres will load into `JSONB` columns, Snowflake will load into `VARIANT` column type, etc.

**The default value is `false`, so JSON properties are loaded as-is and not de-nested.**


## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
