### PR TITLE
[DOC] Document KMS encryption option in target-s3-csv

### DIFF
--- a/docs/connectors/targets/s3_csv.rst
+++ b/docs/connectors/targets/s3_csv.rst
@@ -63,3 +63,8 @@ Example YAML for ``target-s3-csv``:
       quotechar: "\""                                # Default: '\"') A one-character string used to quote fields containing
                                                        special characters, such as the delimiter or quotechar, or which contain
                                                        new-line characters.
+
+      #encryption_type: "KMS"                        # (Default: None) The type of encryption to use. Current supported options are: 'none' and 'KMS'.
+      #encryption_key: "<ENCRYPTIION_KEY_ID>"        # A reference to the encryption key to use for data encryption.
+                                                     # For KMS encryption, this should be the name of the KMS encryption key ID (e.g. '1234abcd-1234-1234-1234-1234abcd1234').
+                                                     # This field is ignored if 'encryption_type' is none or blank.

--- a/pipelinewise/cli/samples/target_s3_csv.yml.sample
+++ b/pipelinewise/cli/samples/target_s3_csv.yml.sample
@@ -28,3 +28,8 @@ db_conn:
   #quotechar: "\""                               # (Default: '\"') A one-character string used to quote fields containing
                                                    special characters, such as the delimiter or quotechar, or which contain
                                                    new-line characters.
+
+  #encryption_type: "KMS"                        # (Default: None) The type of encryption to use. Current supported options are: 'none' and 'KMS'.
+  #encryption_key: "<ENCRYPTIION_KEY_ID>"        # A reference to the encryption key to use for data encryption.
+                                                 # For KMS encryption, this should be the name of the KMS encryption key ID (e.g. '1234abcd-1234-1234-1234-1234abcd1234').
+                                                 # This field is ignored if 'encryption_type' is none or blank.


### PR DESCRIPTION
## Problem

KMS encryption option in target-s3-csv is not documented.

## Proposed changes

Document KMS encryption option in target-s3-csv.


## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
