### PR TITLE
[GITHUB-570] Fix to create docker image with tap oracle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,10 @@ RUN apt-get -qq update && apt-get -qqy install \
     && pip install --upgrade pip
 
 ARG connectors=all
+COPY . /app
 
 # Install Oracle Instant Client for tap-oracle if its in the connectors list
 RUN bash -c "if grep -q \"tap-oracle\" <<< \"$connectors\"; then wget https://download.oracle.com/otn_software/linux/instantclient/193000/oracle-instantclient19.3-basiclite-19.3.0.0.0-1.x86_64.rpm -O /app/oracle-instantclient.rpm && alien -i /app/oracle-instantclient.rpm --scripts && rm -rf /app/oracle-instantclient.rpm ; fi"
-
-
-COPY . /app
 
 RUN cd /app \
     && ./install.sh --connectors=$connectors --acceptlicenses --nousage --notestextras \


### PR DESCRIPTION
## Problem

Cannot build docker image if tap-oracle is selected in the connectors list:
```
docker build --build-arg connectors=tap-oracle,target-snowflake -t pipelinewise:latest .
```

Original problem reported at https://github.com/transferwise/pipelinewise/issues/570

## Proposed changes

Create `/app` before downloading oracle client

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
