### PR TITLE
Fix install script issue due to conflict

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ make_virtualenv() {
     python3 -m pip install --upgrade pip setuptools
 
     if [ -f "requirements.txt" ]; then
-        python3 -m pip install --upgrade -r requirements.txt
+        python3 -m pip install --upgrade -r requirements.txt --use-feature=2020-resolver
     fi
     if [ -f "setup.py" ]; then
         PIP_ARGS=


### PR DESCRIPTION
## Problem

Docker build is failing due to conflict #575 

## Proposed changes

When build failing, it displays a suggestion as follows:

```shell
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.
```

And so this changes to implement that suggestion to the install script. I've done it on local and it the build back to normal. Should fix #575 I guess.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
