### PR TITLE
[GITHUB-578] Exclude MongoDB-Redshift from valid Fastsync pairs.

### DIFF
--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -21,6 +21,8 @@ from . import utils
 from . import commands
 from .commands import TapParams, TargetParams, TransformParams
 from .config import Config
+from .alert_sender import AlertSender
+from .alert_handlers.base_alert_handler import BaseAlertHandler
 
 FASTSYNC_PAIRS = {
     'tap-mysql': {'target-snowflake', 'target-redshift', 'target-postgres'},

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -21,9 +21,13 @@ from . import utils
 from . import commands
 from .commands import TapParams, TargetParams, TransformParams
 from .config import Config
-from .alert_sender import AlertSender
-from .alert_handlers.base_alert_handler import BaseAlertHandler
 
+FASTSYNC_PAIRS = {
+    'tap-mysql': {'target-snowflake', 'target-redshift', 'target-postgres'},
+    'tap-postgres': {'target-snowflake', 'target-redshift', 'target-postgres'},
+    'tap-s3-csv': {'target-snowflake', 'target-redshift', 'target-postgres'},
+    'tap-mongodb': {'target-snowflake', 'target-postgres'}
+}
 
 # pylint: disable=too-many-lines,too-many-instance-attributes,too-many-public-methods
 class PipelineWise:
@@ -132,8 +136,7 @@ class PipelineWise:
         # Get filter conditions with default values from input dictionary
         # Nothing selected by default
         f_selected = filters.get('selected', None)
-        f_target_type = filters.get('target_type', None)
-        f_tap_type = filters.get('tap_type', None)
+        f_tap_target_pairs = filters.get('tap_target_pairs', None)
         f_replication_method = filters.get('replication_method', None)
         f_initial_sync_required = filters.get('initial_sync_required', None)
 
@@ -199,8 +202,7 @@ class PipelineWise:
                 # pylint: disable=too-many-boolean-expressions,bad-continuation
                 if (
                         (f_selected is None or selected == f_selected) and
-                        (f_target_type is None or target_type in f_target_type) and
-                        (f_tap_type is None or tap_type in f_tap_type) and
+                        (f_tap_target_pairs is None or target_type in f_tap_target_pairs.get(tap_type, {})) and
                         (f_replication_method is None or replication_method in f_replication_method) and
                         (f_initial_sync_required is None or initial_sync_required == f_initial_sync_required)
                 ):
@@ -976,8 +978,7 @@ class PipelineWise:
             tap_properties,
             tap_state, {
                 'selected': True,
-                'target_type': ['target-snowflake', 'target-redshift', 'target-postgres'],
-                'tap_type': ['tap-mysql', 'tap-postgres', 'tap-s3-csv', 'tap-mongodb'],
+                'tap_target_pairs': FASTSYNC_PAIRS,
                 'initial_sync_required': True
             },
             create_fallback=True)

--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -184,8 +184,7 @@ class TestCli:
                  os.path.dirname(__file__)),
              filters={
                  'selected': True,
-                 'target_type': ['target-snowflake'],
-                 'tap_type': ['tap-mysql', 'tap-postgres'],
+                 'tap_target_pairs': {'tap-mysql': {'target-snowflake'}, 'tap-postgres': {'target-snowflake'}},
                  'initial_sync_required': True
              },
              create_fallback=True)
@@ -200,6 +199,40 @@ class TestCli:
 
         # Fastsync and singer properties should be created
         assert fastsync_stream_ids == ['db_test_mysql-table_one', 'db_test_mysql-table_two']
+        assert singer_stream_ids == ['db_test_mysql-table_one', 'db_test_mysql-table_two']
+
+    # pylint: disable=bad-continuation
+    def test_create_filtered_tap_props_fallback(self):
+        """Test creating fastsync and singer specific properties file"""
+        (
+            tap_properties_fastsync,
+            fastsync_stream_ids,
+            tap_properties_singer,
+            singer_stream_ids
+        ) = self.pipelinewise.create_filtered_tap_properties(
+             target_type='target-snowflake',
+             tap_type='tap-mysql',
+             tap_properties='{}/resources/sample_json_config/target_one/tap_one/properties.json'.format(
+                 os.path.dirname(__file__)),
+             tap_state='{}/resources/sample_json_config/target_one/tap_one/state.json'.format(
+                 os.path.dirname(__file__)),
+             filters={
+                 'selected': True,
+                 'tap_target_pairs': {'tap-postgres': {'target-snowflake'}},
+                 'initial_sync_required': True
+             },
+             create_fallback=True)
+
+        # Fastsync and singer properties should be created
+        assert os.path.isfile(tap_properties_fastsync)
+        assert os.path.isfile(tap_properties_singer)
+
+        # Delete generated properties file
+        os.remove(tap_properties_fastsync)
+        os.remove(tap_properties_singer)
+
+        # Fastsync and singer properties should be created
+        assert fastsync_stream_ids == []
         assert singer_stream_ids == ['db_test_mysql-table_one', 'db_test_mysql-table_two']
 
     def test_merge_empty_catalog(self):


### PR DESCRIPTION
## Problem

Fix for issue #578. Pipelinewise tries to use fastsync for MongoDB->Redshift, but that combination is not supproted.

## Proposed changes

Adds specific tap-target pairs that have fastsync support. Providing taps and targets separately doesn't work if there are "holes in the cartesian product" like aforementioned MongoDB-Redshift.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
