### PR TITLE
Remove pip 2020-resolver feature

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ make_virtualenv() {
             PIP_ARGS=$PIP_ARGS"[test]"
         fi
 
-        python3 -m pip install --upgrade -e .$PIP_ARGS --use-feature=2020-resolver
+        python3 -m pip install --upgrade -e .$PIP_ARGS
     fi
 
     echo ""


### PR DESCRIPTION
## Problem

PPW install script shows warning:
```
WARNING: --use-feature=2020-resolver no longer has any effect, since it is now the default dependency resolver in pip. This will become an error in pip 21.0.
```

This warning started happen since the very recently released `pip 20.3`, which comes with the new dependency resolver by default. 


## Proposed changes

Remove `--use-feature=2020-resolver` option. PPW install scripts are using the latest available pip and the install script will not fail once `pip 21.0` is available.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
