### PR TITLE
Bump tap-snowflake

### DIFF
--- a/singer-connectors/tap-snowflake/requirements.txt
+++ b/singer-connectors/tap-snowflake/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-snowflake==2.0.1
+pipelinewise-tap-snowflake==2.0.2


### PR DESCRIPTION
## Problem

`snowflake-connector-python` not in sync across the components:
* `ppw-fastsync`: 2.3.6
* ` target-snowflake`: 2.3.6
* `tap-snowflake`: 2.2.9

## Proposed changes

Bump `tap-snowflake` to that comes with 2.3.6

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
