### PR TITLE
Fix dependency errors and warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ jobs:
           command: |
             python3 -m venv .venv
             . .venv/bin/activate
+            pip install --upgrade pip
             pip install -Ue .[test]
             find pipelinewise tests -type f -name '*.py' | xargs unify --check-only
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,12 +76,17 @@ jobs:
       - checkout
 
       - run:
-          name: 'Check code formatting'
+          name: 'Install dependencies'
           command: |
             python3 -m venv .venv
             . .venv/bin/activate
-            pip install --upgrade pip
+            pip install --upgrade pip setuptools wheel
             pip install -Ue .[test]
+
+      - run:
+          name: 'Check code formatting'
+          command: |
+            . .venv/bin/activate
             find pipelinewise tests -type f -name '*.py' | xargs unify --check-only
 
       - run:

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ make_virtualenv() {
     echo "Making Virtual Environment for [$1] in $VENV_DIR"
     python3 -m venv $VENV_DIR/$1
     source $VENV_DIR/$1/bin/activate
-    python3 -m pip install --upgrade pip setuptools
+    python3 -m pip install --upgrade pip setuptools wheel
 
     if [ -f "requirements.txt" ]; then
         python3 -m pip install --upgrade -r requirements.txt


### PR DESCRIPTION
## Problem

CI gives error messages when checking code formatting:
```
ERROR: requests 2.23.0 has requirement chardet<4,>=3.0.2, but you'll have chardet 4.0.0 which is incompatible.
ERROR: aiohttp 3.7.3 has requirement chardet<4.0,>=2.0, but you'll have chardet 4.0.0 which is incompatible.
```

And it gives a few warnings of:
```
using legacy 'setup.py install' for {some package} since package 'wheel' is not installed
```

## Proposed changes

The current script is using the original `pip` version 19, that comes with the python 3.7.7 image and `wheel` is not installed into virtual environments.

This PR upgrades `pip` to latest (>=20.3) which has dependency resolver and selects the correct version of packages and doesn't raise the errors and it installs the latest `wheel` to virtual envs.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
