### PR TITLE
[DOC] Use dynamic current year in copyright strings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
           name: 'Build source databases for integration tests'
           command: |
             sudo apt-get update
-            sudo apt install mariadb-client postgresql-client mongo-tools mbuffer
+            sudo apt install mariadb-client postgresql-client mongo-tools mbuffer gettext-base
             wget https://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.2/multiverse/binary-amd64/mongodb-org-shell_4.2.7_amd64.deb
             sudo dpkg -i ./mongodb-org-shell_4.2.7_amd64.deb && rm mongodb-org-shell_4.2.7_amd64.deb
             ./dev-project/mongo/init_rs.sh

--- a/dev-project/entrypoint.sh
+++ b/dev-project/entrypoint.sh
@@ -36,10 +36,9 @@ if [[ $? != 0 ]]; then
 fi
 
 # Activate CLI virtual environment at every login
-DO_AT_LOGIN="cd $PIPELINEWISE_HOME && source $PIPELINEWISE_HOME/.virtualenvs/pipelinewise/bin/activate && cat $PIPELINEWISE_HOME/../motd"
-if [[ `tail -n1 ~/.bashrc` != "$DO_AT_LOGIN" ]]; then
-    echo $DO_AT_LOGIN >> ~/.bashrc
-fi
+sed -i '/motd/d' ~/.bashrc  # Delete any existing old DO_AT_LOGIN line from bashrc
+DO_AT_LOGIN="cd $PIPELINEWISE_HOME && source $PIPELINEWISE_HOME/.virtualenvs/pipelinewise/bin/activate && CURRENT_YEAR=\$(date +'%Y') envsubst < $PIPELINEWISE_HOME/../motd"
+echo $DO_AT_LOGIN >> ~/.bashrc
 
 echo
 echo "=========================================================================="

--- a/dev-project/entrypoint.sh
+++ b/dev-project/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Install OS dependencies
 apt-get update
-apt-get install -y mariadb-client postgresql-client alien libaio1 mongo-tools mbuffer
+apt-get install -y mariadb-client postgresql-client alien libaio1 mongo-tools mbuffer gettext-base
 
 wget https://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.2/multiverse/binary-amd64/mongodb-org-shell_4.2.7_amd64.deb
 dpkg -i ./mongodb-org-shell_4.2.7_amd64.deb && rm mongodb-org-shell_4.2.7_amd64.deb

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,8 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+import datetime
+
 
 def setup(app):
     app.add_css_file('css/custom.css')
@@ -21,7 +23,7 @@ def setup(app):
 # -- Project information -----------------------------------------------------
 
 project = 'PipelineWise'
-copyright = '2020, TransferWise Ltd.'
+copyright = f'{datetime.datetime.now().year}, TransferWise Ltd.'
 author = 'TransferWise'
 version = '0.26.0'
 

--- a/install.sh
+++ b/install.sh
@@ -155,6 +155,11 @@ for arg in "$@"; do
 done
 
 # Welcome message
+if ! ENVSUBST_LOC="$(type -p "envsubst")" || [[ -z ENVSUBST_LOC ]]; then
+  echo "envsubst not found which is required to run this script. Try to install gettext or gettext-base package"
+  exit 1
+fi
+
 CURRENT_YEAR=$(date +"%Y") envsubst < $SRC_DIR/motd
 
 # Install PipelineWise core components

--- a/install.sh
+++ b/install.sh
@@ -156,7 +156,7 @@ done
 
 # Welcome message
 if ! ENVSUBST_LOC="$(type -p "envsubst")" || [[ -z ENVSUBST_LOC ]]; then
-  echo "envsubst not found which is required to run this script. Try to install gettext or gettext-base package"
+  echo "envsubst not found but it's required to run this script. Try to install gettext or gettext-base package"
   exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -155,7 +155,7 @@ for arg in "$@"; do
 done
 
 # Welcome message
-cat $SRC_DIR/motd
+CURRENT_YEAR=$(date +"%Y") envsubst < $SRC_DIR/motd
 
 # Install PipelineWise core components
 cd $SRC_DIR

--- a/motd
+++ b/motd
@@ -3,7 +3,7 @@
       `.`-.        /  ',-""""'
         `. ``~-._.'_."/                 PipelineWise
           `~-._ .` `~;
-               ;.    /             (C) TransferWise - 2020
+               ;.    /             (C) TransferWise - $CURRENT_YEAR
               /     /
      jgs ,_.-';_,.'`
           `"-;`/


### PR DESCRIPTION
## Problem

Years in copyright messages are hard coded to 2020.

## Proposed changes

This PR makes the current year to be dynamic in [motd](https://github.com/transferwise/pipelinewise/blob/83434f36c2f82fe177cb2718c9e144ecba4f6e1b/motd) and in the footer of the [documentation](https://transferwise.github.io/pipelinewise/).

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
