### PR TITLE
[Fix] Patch tap-snowflake to solve issue with LAST_QUERY_ID

### DIFF
--- a/singer-connectors/tap-snowflake/requirements.txt
+++ b/singer-connectors/tap-snowflake/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-snowflake==2.0.2
+pipelinewise-tap-snowflake==2.0.3


### PR DESCRIPTION
## Problem

Solving a problem with usage of `LAST_QUERY_ID()` Snowflake function in ppw-tap-snowflake

## Proposed changes

use ppw-tap-snowflake v2.0.3 


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
