### PR TITLE
[AP-902][AP-905] Drop pg replication slot in case of full re-sync of a tap.

### DIFF
--- a/docs/connectors/taps/postgres.rst
+++ b/docs/connectors/taps/postgres.rst
@@ -86,34 +86,18 @@ This should be sufficient unless you have a large number of read replicas connec
 
 Restart your PostgreSQL service to ensure the changes take effect.
 
-**Step 3.4: Create a replication slot**
+**Step 3.4: Replication slot**
 
-Next, you’ll create a dedicated logical replication slot for Stitch. In PostgreSQL, a logical replication
-slot represents a stream of database changes that can then be replayed to a client in the order they were
-made on the original server. Each slot streams a sequence of changes from a single database.
+In PostgreSQL, a logical replication slot represents a stream of database changes that can then be replayed to a
+client in the order they were made on the original server. Each slot streams a sequence of changes from a single
+database.
 
-**Note**: Replication slots are specific to a given database in a cluster. If you want to connect
-multiple databases - whether in one integration or several - you’ll need to create a replication slot
-for each database.
+Pipelinewise automatically creates a dedicated logical replication slot for each database and tap.
 
-1. Log into the master database as a superuser.
 
-2. Using the ``wal2json`` plugin, create a logical replication slot:
+.. note:: ``wal2json`` is required to use :ref:`log_based` in Pipelinewise for PostgreSQL-backed databases.
 
-.. code-block:: bash
-
-    SELECT *
-    FROM pg_create_logical_replication_slot('pipelinewise_<database_name>', 'wal2json');
-
-3. Log in as the PipelineWise user and verify you can read from the replication slot,
-replacing ``pipelinewise_<database_name>`` with the name of the replication slot:
-
-.. code-block:: bash
-
-    SELECT COUNT(*)
-    FROM pg_logical_slot_peek_changes('pipelinewise_<database_name>', null, null);
-
-**Note**: ``wal2json`` is required to use :ref:`log_based` in Stitch for PostgreSQL-backed databases.
+.. note:: In case of full resync of a whole tap, Pipelinewise will attempt to drop the slot.
 
 
 Configuring what to replicate

--- a/pipelinewise/cli/commands.py
+++ b/pipelinewise/cli/commands.py
@@ -248,13 +248,15 @@ def build_fastsync_command(tap: TapParams,
                            temp_dir: str,
                            tables: str = None,
                            profiling_mode: bool = False,
-                           profiling_dir: str = None
+                           profiling_dir: str = None,
+                           drop_pg_slot: bool = False
                            ) -> str:
     """
     Builds a command that starts fastsync from a given tap to a
     given target with optional transformations.
 
     Args:
+        drop_pg_slot: flag for fastsync to indicate whether to drop or not PG replication slot
         profiling_dir: directory where profiling output should be dumped
         profiling_mode: Flag to indicate whether build the command with profiling
         tap: NamedTuple with tap properties
@@ -278,7 +280,9 @@ def build_fastsync_command(tap: TapParams,
         f'--target {target.config}',
         f'--temp_dir {temp_dir}',
         f'--transform {transform.config}' if transform.config and os.path.isfile(transform.config) else '',
-        f'--tables {tables}' if tables else ''])))
+        f'--tables {tables}' if tables else '',
+        '--drop_pg_slot' if drop_pg_slot else '',
+    ])))
 
     command = f'{fastsync_bin} {command_args}'
 

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1140,7 +1140,7 @@ class PipelineWise:
 
         # Set drop_pg_slot to True if we want to sync the whole tap
         # This flag will be used by FastSync PG to (PG/SF/Redshift)
-        self.drop_pg_slot = True if not self.args.tables else False
+        self.drop_pg_slot = bool(not self.args.tables)
 
         # Some target attributes can be passed and override by tap (aka. inheritable config)
         # We merge the two configs and use that with the target

--- a/pipelinewise/fastsync/postgres_to_postgres.py
+++ b/pipelinewise/fastsync/postgres_to_postgres.py
@@ -2,11 +2,11 @@
 import os
 import sys
 import time
+import multiprocessing
+
 from functools import partial
 from argparse import Namespace
-import multiprocessing
 from typing import Union
-
 from datetime import datetime
 
 from ..logger import Logger
@@ -149,6 +149,10 @@ def main_impl():
             CPU cores                      : %s
         -------------------------------------------------------
         """, args.tables, len(args.tables), cpu_cores)
+
+    # if internal arg drop_pg_slot is set to True, then we drop the slot before starting resync
+    if args.drop_pg_slot:
+        FastSyncTapPostgres.drop_slot(args.tap)
 
     # Create target schemas sequentially, Postgres doesn't like it running in parallel
     postgres_target = FastSyncTargetPostgres(args.target, args.transform)

--- a/pipelinewise/fastsync/postgres_to_redshift.py
+++ b/pipelinewise/fastsync/postgres_to_redshift.py
@@ -2,12 +2,13 @@
 import os
 import sys
 import time
-from functools import partial
-from argparse import Namespace
 import multiprocessing
-from typing import Union
 
+from argparse import Namespace
+from typing import Union
+from functools import partial
 from datetime import datetime
+
 from ..logger import Logger
 from .commons import utils
 from .commons.tap_postgres import FastSyncTapPostgres
@@ -156,6 +157,10 @@ def main_impl():
             CPU cores                      : %s
         -------------------------------------------------------
         """, args.tables, len(args.tables), cpu_cores)
+
+    # if internal arg drop_pg_slot is set to True, then we drop the slot before starting resync
+    if args.drop_pg_slot:
+        FastSyncTapPostgres.drop_slot(args.tap)
 
     # Create target schemas sequentially, Redshift doesn't like it running in parallel
     redshift = FastSyncTargetRedshift(args.target, args.transform)

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -2,12 +2,13 @@
 import os
 import sys
 import time
-from functools import partial
-from argparse import Namespace
 import multiprocessing
-from typing import Union
 
+from argparse import Namespace
+from typing import Union
+from functools import partial
 from datetime import datetime
+
 from ..logger import Logger
 from .commons import utils
 from .commons.tap_postgres import FastSyncTapPostgres
@@ -157,6 +158,10 @@ def main_impl():
             CPU cores                      : %s
         -------------------------------------------------------
         """, args.tables, len(args.tables), cpu_cores)
+
+    # if internal arg drop_pg_slot is set to True, then we drop the slot before starting resync
+    if args.drop_pg_slot:
+        FastSyncTapPostgres.drop_slot(args.tap)
 
     # Start loading tables in parallel in spawning processes by
     # utilising all available CPU cores

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -1,38 +1,28 @@
 from unittest import TestCase
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
+
 from pipelinewise.fastsync.commons.tap_postgres import FastSyncTapPostgres
 
 
-class FastSyncTapPostgresMock(FastSyncTapPostgres):
-    """
-    Mocked FastSyncTapPostgres class
-    """
-    def __init__(self, connection_config, transformation_config=None):
-        super().__init__(connection_config, transformation_config)
-
-        self.executed_queries_primary_host = []
-        self.executed_queries = []
-
-    def primary_host_query(self, query, params=None):
-        self.executed_queries_primary_host.append(query)
-        return []
-
-    def query(self, query, params=None):
-        self.executed_queries.append(query)
-        return []
-
-
-# pylint: disable=invalid-name,no-self-use
 class TestFastSyncTapPostgres(TestCase):
     """
     Unit tests for fastsync tap postgres
     """
+
     def setUp(self) -> None:
         """Initialise test FastSyncTapPostgres object"""
-        self.postgres = FastSyncTapPostgresMock(connection_config={'dbname': 'test_database',
-                                                                   'tap_id': 'test_tap'},
-                                                transformation_config={})
+        self.postgres = FastSyncTapPostgres(connection_config={'dbname': 'test_database',
+                                                               'tap_id': 'test_tap'},
+                                            tap_type_to_target_type={})
+        self.postgres.executed_queries_primary_host = []
+        self.postgres.executed_queries = []
 
-    def test_generate_replication_slot_name(self):
+        def primary_host_query_mock(query, _=None):
+            self.postgres.executed_queries_primary_host.append(query)
+
+        self.postgres.primary_host_query = primary_host_query_mock
+
+    def test_generate_repl_slot_name(self):
         """Validate if the replication slot name generated correctly"""
         # Provide only database name
         assert self.postgres.generate_replication_slot_name('some_db') == 'pipelinewise_some_db'
@@ -57,10 +47,225 @@ class TestFastSyncTapPostgres(TestCase):
         assert self.postgres.generate_replication_slot_name('some.db',
                                                             'some.tap') == 'pipelinewise_some_db_some_tap'
 
-    def test_create_replication_slot(self):
-        """Validate if replication slot creation SQL commands generated correctly"""
+    def test_create_replication_slot_1(self):
+        """
+        Validate if replication slot creation SQL commands generated correctly in case no v15 slots exists
+        """
+
+        def execute_mock(query):
+            print('Mocked execute called')
+            self.postgres.executed_queries_primary_host.append(query)
+
+        # mock cursor with execute method
+        cursor_mock = MagicMock().return_value
+        cursor_mock.__enter__.return_value.execute.side_effect = execute_mock
+        type(cursor_mock.__enter__.return_value).rowcount = PropertyMock(return_value=0)
+
+        # mock PG connection instance with ability to open cursor
+        pg_con = Mock()
+        pg_con.cursor.return_value = cursor_mock
+
+        self.postgres.primary_host_conn = pg_con
+
         self.postgres.create_replication_slot()
         assert self.postgres.executed_queries_primary_host == [
-            "SELECT * FROM pg_replication_slots WHERE slot_name = 'pipelinewise_test_database'",
+            "SELECT * FROM pg_replication_slots WHERE slot_name = 'pipelinewise_test_database';",
             "SELECT * FROM pg_create_logical_replication_slot('pipelinewise_test_database_test_tap', 'wal2json')"
+        ]
+
+    def test_create_replication_slot_2(self):
+        """
+        Validate if replication slot creation SQL commands generated correctly in case a v15 slots exists
+        """
+
+        def execute_mock(query):
+            print('Mocked execute called')
+            self.postgres.executed_queries_primary_host.append(query)
+
+        # mock cursor with execute method
+        cursor_mock = MagicMock().return_value
+        cursor_mock.__enter__.return_value.execute.side_effect = execute_mock
+        type(cursor_mock.__enter__.return_value).rowcount = PropertyMock(return_value=1)
+
+        # mock PG connection instance with ability to open cursor
+        pg_con = Mock()
+        pg_con.cursor.return_value = cursor_mock
+
+        self.postgres.primary_host_conn = pg_con
+
+        self.postgres.create_replication_slot()
+        assert self.postgres.executed_queries_primary_host == [
+            "SELECT * FROM pg_replication_slots WHERE slot_name = 'pipelinewise_test_database';",
+            "SELECT * FROM pg_create_logical_replication_slot('pipelinewise_test_database', 'wal2json')"
+        ]
+
+    @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
+    def test_get_connection_to_primary(self, connect_mock):
+        """
+        Check that get connection uses the right credentials to connect to primary
+        """
+        creds = {
+            'host': 'my_primary_host',
+            'user': 'my_primary_user',
+            'password': 'my_primary_user',
+            'dbname': 'my_db',
+            'port': 'my_primary_port',
+        }
+
+        self.assertEqual(FastSyncTapPostgres.get_connection(creds, prioritize_primary=True),
+                         connect_mock.return_value)
+
+        connect_mock.assert_called_once_with(
+            f"host='{creds['host']}' port='{creds['port']}' user='{creds['user']}' password='{creds['password']}' "
+            f"dbname='{creds['dbname']}'")
+
+        self.assertTrue(connect_mock.autocommit)
+
+    @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
+    def test_get_connection_to_sec(self, connect_mock):
+        """
+        Check that get connection uses the right credentials to connect to secondary if present
+        """
+        creds = {
+            'host': 'my_primary_host',
+            'replica_host': 'my_replica_host',
+            'user': 'my_primary_user',
+            'replica_user': 'my_replica_user',
+            'password': 'my_primary_user',
+            'replica_password': 'my_replica_user',
+            'dbname': 'my_db',
+            'port': 'my_primary_port',
+            'replica_port': 'my_replica_port',
+        }
+
+        self.assertEqual(FastSyncTapPostgres.get_connection(creds, prioritize_primary=False),
+                         connect_mock.return_value)
+
+        connect_mock.assert_called_once_with(
+            f"host='{creds['replica_host']}' port='{creds['replica_port']}' user='{creds['replica_user']}' password"
+            f"='{creds['replica_password']}' "
+            f"dbname='{creds['dbname']}'")
+
+        self.assertTrue(connect_mock.autocommit)
+
+    @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
+    def test_get_connection_fallback(self, connect_mock):
+        """
+        Check that get connection uses the primary server credentials as a fallback
+        """
+        creds = {
+            'host': 'my_primary_host',
+            'replica_host': 'my_replica_host',
+            'user': 'my_primary_user',
+            'password': 'my_primary_user',
+            'dbname': 'my_db',
+            'port': 'my_primary_port',
+        }
+
+        self.assertEqual(FastSyncTapPostgres.get_connection(creds, prioritize_primary=False),
+                         connect_mock.return_value)
+
+        connect_mock.assert_called_once_with(
+            f"host='{creds['replica_host']}' port='{creds['port']}' user='{creds['user']}' password"
+            f"='{creds['password']}' dbname='{creds['dbname']}'")
+
+        self.assertTrue(connect_mock.autocommit)
+
+    @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
+    def test_get_connection_ssl(self, connect_mock):
+        """
+        Check that get connection uses ssl when present
+        """
+        creds = {
+            'host': 'my_primary_host',
+            'user': 'my_primary_user',
+            'password': 'my_primary_user',
+            'dbname': 'my_db',
+            'port': 'my_primary_port',
+            'ssl': 'true'
+        }
+
+        self.assertEqual(FastSyncTapPostgres.get_connection(creds, prioritize_primary=False),
+                         connect_mock.return_value)
+
+        connect_mock.assert_called_once_with(
+            f"host='{creds['host']}' port='{creds['port']}' user='{creds['user']}' password"
+            f"='{creds['password']}' dbname='{creds['dbname']}' sslmode='require'")
+
+        self.assertTrue(connect_mock.autocommit)
+
+    @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
+    def test_drop_slot_v15(self, connect_mock):
+        """
+        Check that dropping slots works fine for v15 slots
+        """
+        def execute_mock(query):
+            print('Mocked execute called')
+            self.postgres.executed_queries_primary_host.append(query)
+
+        creds = {
+            'host': 'my_primary_host',
+            'user': 'my_primary_user',
+            'password': 'my_primary_user',
+            'dbname': 'my_db',
+            'port': 'my_primary_port',
+            'ssl': 'true',
+            'tap_id': 'tap_test'
+        }
+
+        # mock cursor with execute method
+        cursor_mock = MagicMock().return_value
+        cursor_mock.__enter__.return_value.execute.side_effect = execute_mock
+        type(cursor_mock.__enter__.return_value).rowcount = PropertyMock(side_effect=[1, 2])
+
+        # mock PG connection instance with ability to open cursor
+        pg_con = Mock()
+        pg_con.cursor.return_value = cursor_mock
+
+        connect_mock.return_value = pg_con
+
+        self.postgres.drop_slot(creds)
+
+        assert self.postgres.executed_queries_primary_host == [
+            "SELECT * FROM pg_replication_slots WHERE slot_name = 'pipelinewise_my_db';",
+            "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE "
+            "slot_name = 'pipelinewise_my_db';",
+        ]
+
+    @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
+    def test_drop_slot_v16(self, connect_mock):
+        """
+        Check that dropping slots works fine for v16 slots
+        """
+        def execute_mock(query):
+            print('Mocked execute called')
+            self.postgres.executed_queries_primary_host.append(query)
+
+        creds = {
+            'host': 'my_primary_host',
+            'user': 'my_primary_user',
+            'password': 'my_primary_user',
+            'dbname': 'my_db',
+            'port': 'my_primary_port',
+            'ssl': 'true',
+            'tap_id': 'tap_test'
+        }
+
+        # mock cursor with execute method
+        cursor_mock = MagicMock().return_value
+        cursor_mock.__enter__.return_value.execute.side_effect = execute_mock
+        type(cursor_mock.__enter__.return_value).rowcount = PropertyMock(side_effect=[0, 1])
+
+        # mock PG connection instance with ability to open cursor
+        pg_con = Mock()
+        pg_con.cursor.return_value = cursor_mock
+
+        connect_mock.return_value = pg_con
+
+        self.postgres.drop_slot(creds)
+
+        assert self.postgres.executed_queries_primary_host == [
+            "SELECT * FROM pg_replication_slots WHERE slot_name = 'pipelinewise_my_db';",
+            "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE "
+            "slot_name = 'pipelinewise_my_db_tap_test';",
         ]

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -228,7 +228,7 @@ class TestFastSyncTapPostgres(TestCase):
 
         assert self.postgres.executed_queries_primary_host == [
             "SELECT * FROM pg_replication_slots WHERE slot_name = 'pipelinewise_my_db';",
-            "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE "
+            'SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE '
             "slot_name = 'pipelinewise_my_db';",
         ]
 
@@ -266,6 +266,6 @@ class TestFastSyncTapPostgres(TestCase):
 
         assert self.postgres.executed_queries_primary_host == [
             "SELECT * FROM pg_replication_slots WHERE slot_name = 'pipelinewise_my_db';",
-            "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE "
+            'SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE '
             "slot_name = 'pipelinewise_my_db_tap_test';",
         ]

--- a/tests/units/fastsync/commons/test_fastsync_utils.py
+++ b/tests/units/fastsync/commons/test_fastsync_utils.py
@@ -395,8 +395,7 @@ class TestFastSyncUtils(TestCase):
     def test_parse_args_without_tables(self, mock_args, load_json_mock, check_config_mock, get_tables_prop_mock):
         """
         test args parsing:
-            not tables are specified, this should return a tables equal to the list of selected tables and a
-            drop_pg_slot = True
+            not tables are specified, this should return a tables equal to the list of selected tables
         """
         mock_args.return_value = argparse.Namespace(**{
             'tap': './tap.yml',
@@ -420,7 +419,6 @@ class TestFastSyncUtils(TestCase):
         self.assertDictEqual(
             vars(args), {
                 'tables': {'schema.table_1', 'schema.table_2'},
-                'drop_pg_slot': True,
                 'tap': {},
                 'target': {},
                 'transform': {},
@@ -436,12 +434,13 @@ class TestFastSyncUtils(TestCase):
     def test_parse_args_with_all_tables(self, mock_args, load_json_mock, check_config_mock, get_tables_prop_mock):
         """
         test args parsing:
-            all selected tables are specified, this should return a drop_pg_slot = True
+            all selected tables are specified
         """
         mock_args.return_value = argparse.Namespace(**{
             'tap': './tap.yml',
             'properties': './prop.json',
             'transform': None,
+            'drop_pg_slot': True,
             'target': './target.yml',
             'tables': 'schema.table_1,schema.table_2',
             'temp_dir': './'
@@ -500,7 +499,6 @@ class TestFastSyncUtils(TestCase):
         self.assertDictEqual(
             vars(args), {
                 'tables': {'schema.table_2'},
-                'drop_pg_slot': False,
                 'tap': {},
                 'target': {},
                 'transform': {},

--- a/tests/units/fastsync/commons/test_fastsync_utils.py
+++ b/tests/units/fastsync/commons/test_fastsync_utils.py
@@ -1,7 +1,11 @@
+import argparse
 import os
 import pytest
-from unittest import TestCase
+
+from unittest import TestCase, mock
+
 from pipelinewise.fastsync.commons import utils
+from pipelinewise.fastsync.commons.utils import NotSelectedTableException
 
 RESOURCES_DIR = '{}/resources'.format(os.path.dirname(__file__))
 
@@ -19,7 +23,7 @@ class MySqlMock:
             'version': 1
         }
 
-    #pylint: disable=unused-argument
+    # pylint: disable=unused-argument
     def fetch_current_incremental_key_pos(self, table, replication_key):
         return {
             'replication_key': replication_key,
@@ -39,7 +43,7 @@ class PostgresMock:
             'version': 1
         }
 
-    #pylint: disable=unused-argument
+    # pylint: disable=unused-argument
     def fetch_current_incremental_key_pos(self, table, replication_key):
         return {
             'replication_key': replication_key,
@@ -53,7 +57,7 @@ class S3CsvMock:
     S3 CSV mock
     """
 
-    #pylint: disable=unused-argument
+    # pylint: disable=unused-argument
     def fetch_current_incremental_key_pos(self, table, replication_key):
         return {
             'modified_since': '2019-11-15T07:39:44.171098'
@@ -128,17 +132,17 @@ class TestFastSyncUtils(TestCase):
 
         # MySQL schema
         assert mysql_tables == \
-               [
+               {
                    'mysql_source_db.address',
                    'mysql_source_db.order',
                    'mysql_source_db.weight_unit'
-               ]
+               }
 
         assert postgres_tables == \
-               [
+               {
                    'public.city',
                    'public.country'
-               ]
+               }
 
     def test_get_tables_from_properties_for_s3_csv(self):
         properties = utils.load_json('{}/properties_s3_csv.json'.format(RESOURCES_DIR))
@@ -147,11 +151,11 @@ class TestFastSyncUtils(TestCase):
 
         # MySQL schema
         assert s3_csv_tables == \
-               [
+               {
                    'applications',
                    'candidate_survey_questions',
                    'interviews',
-               ]
+               }
 
     def test_get_bookmark_for_table_mysql(self):
         """Test bookmark extractors for MySQL taps"""
@@ -383,3 +387,154 @@ class TestFastSyncUtils(TestCase):
 
         with pytest.raises(Exception):
             utils.check_config(config, required_keys)
+
+    @mock.patch('pipelinewise.fastsync.commons.utils.get_tables_from_properties')
+    @mock.patch('pipelinewise.fastsync.commons.utils.check_config')
+    @mock.patch('pipelinewise.fastsync.commons.utils.load_json')
+    @mock.patch('argparse.ArgumentParser.parse_args')
+    def test_parse_args_without_tables(self, mock_args, load_json_mock, check_config_mock, get_tables_prop_mock):
+        """
+        test args parsing:
+            not tables are specified, this should return a tables equal to the list of selected tables and a
+            drop_pg_slot = True
+        """
+        mock_args.return_value = argparse.Namespace(**{
+            'tap': './tap.yml',
+            'properties': './prop.json',
+            'transform': None,
+            'target': './target.yml',
+            'tables': None,
+            'temp_dir': './'
+        })
+
+        load_json_mock.return_value = {}
+        check_config_mock.return_value = None
+        get_tables_prop_mock.return_value = {'schema.table_1', 'schema.table_2'}
+
+        args = utils.parse_args({'tap': [], 'target': []})
+
+        get_tables_prop_mock.assert_called_once()
+        self.assertEqual(load_json_mock.call_count, 3)
+        self.assertEqual(check_config_mock.call_count, 2)
+
+        self.assertDictEqual(
+            vars(args), {
+                'tables': {'schema.table_1', 'schema.table_2'},
+                'drop_pg_slot': True,
+                'tap': {},
+                'target': {},
+                'transform': {},
+                'properties': {},
+                'temp_dir': './'
+            }
+        )
+
+    @mock.patch('pipelinewise.fastsync.commons.utils.get_tables_from_properties')
+    @mock.patch('pipelinewise.fastsync.commons.utils.check_config')
+    @mock.patch('pipelinewise.fastsync.commons.utils.load_json')
+    @mock.patch('argparse.ArgumentParser.parse_args')
+    def test_parse_args_with_all_tables(self, mock_args, load_json_mock, check_config_mock, get_tables_prop_mock):
+        """
+        test args parsing:
+            all selected tables are specified, this should return a drop_pg_slot = True
+        """
+        mock_args.return_value = argparse.Namespace(**{
+            'tap': './tap.yml',
+            'properties': './prop.json',
+            'transform': None,
+            'target': './target.yml',
+            'tables': 'schema.table_1,schema.table_2',
+            'temp_dir': './'
+        })
+
+        load_json_mock.return_value = {}
+        check_config_mock.return_value = None
+        get_tables_prop_mock.return_value = {'schema.table_1', 'schema.table_2'}
+
+        args = utils.parse_args({'tap': [], 'target': []})
+
+        get_tables_prop_mock.assert_called_once()
+        self.assertEqual(load_json_mock.call_count, 3)
+        self.assertEqual(check_config_mock.call_count, 2)
+
+        self.assertDictEqual(
+            vars(args), {
+                'tables': {'schema.table_1', 'schema.table_2'},
+                'drop_pg_slot': True,
+                'tap': {},
+                'target': {},
+                'transform': {},
+                'properties': {},
+                'temp_dir': './'
+            }
+        )
+
+    @mock.patch('pipelinewise.fastsync.commons.utils.get_tables_from_properties')
+    @mock.patch('pipelinewise.fastsync.commons.utils.check_config')
+    @mock.patch('pipelinewise.fastsync.commons.utils.load_json')
+    @mock.patch('argparse.ArgumentParser.parse_args')
+    def test_parse_args_with_table_found(self, mock_args, load_json_mock, check_config_mock, get_tables_prop_mock):
+        """
+        test args parsing:
+            one table is specified out of 2, this should return a drop_pg_slot = False
+        """
+        mock_args.return_value = argparse.Namespace(**{
+            'tap': './tap.yml',
+            'properties': './prop.json',
+            'transform': None,
+            'target': './target.yml',
+            'tables': 'schema.table_2',
+            'temp_dir': './'
+        })
+
+        load_json_mock.return_value = {}
+        check_config_mock.return_value = None
+        get_tables_prop_mock.return_value = {'schema.table_1', 'schema.table_2'}
+
+        args = utils.parse_args({'tap': [], 'target': []})
+
+        get_tables_prop_mock.assert_called_once()
+        self.assertEqual(load_json_mock.call_count, 3)
+        self.assertEqual(check_config_mock.call_count, 2)
+
+        self.assertDictEqual(
+            vars(args), {
+                'tables': {'schema.table_2'},
+                'drop_pg_slot': False,
+                'tap': {},
+                'target': {},
+                'transform': {},
+                'properties': {},
+                'temp_dir': './'
+            }
+        )
+
+    @mock.patch('pipelinewise.fastsync.commons.utils.get_tables_from_properties')
+    @mock.patch('pipelinewise.fastsync.commons.utils.check_config')
+    @mock.patch('pipelinewise.fastsync.commons.utils.load_json')
+    @mock.patch('argparse.ArgumentParser.parse_args')
+    def test_parse_args_with_table_not_selected(self, mock_args, load_json_mock, check_config_mock,
+                                                get_tables_prop_mock):
+        """
+        test args parsing:
+            one table not found in selected tables, this should throw a  NotSelectedTableException exception
+        """
+        mock_args.return_value = argparse.Namespace(**{
+            'tap': './tap.yml',
+            'properties': './prop.json',
+            'transform': None,
+            'target': './target.yml',
+            'tables': 'schema.table_not_selected',
+            'temp_dir': './'
+        })
+
+        load_json_mock.return_value = {}
+        check_config_mock.return_value = None
+        get_tables_prop_mock.return_value = {'schema.table_1', 'schema.table_2'}
+
+        with pytest.raises(NotSelectedTableException):
+            utils.parse_args({'tap': [], 'target': []})
+
+        get_tables_prop_mock.assert_called_once()
+        check_config_mock.assert_not_called()
+        self.assertEqual(load_json_mock.call_count, 3)

--- a/tests/units/fastsync/test_postgres_to_postgres.py
+++ b/tests/units/fastsync/test_postgres_to_postgres.py
@@ -9,7 +9,7 @@ TARGET = 'FastSyncTargetPostgres'
 
 
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
-class S3CsvToPostgres(unittest.TestCase):
+class PostgresToPostgres(unittest.TestCase):
     """
     Unit tests for postgres postgres to postgres
     """

--- a/tests/units/fastsync/test_postgres_to_redshift.py
+++ b/tests/units/fastsync/test_postgres_to_redshift.py
@@ -9,7 +9,7 @@ TARGET = 'FastSyncTargetRedshift'
 
 
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
-class S3CsvToPostgres(unittest.TestCase):
+class PostgresToRedshift(unittest.TestCase):
     """
     Unit tests for postgres postgres to redshift
     """

--- a/tests/units/fastsync/test_postgres_to_snowflake.py
+++ b/tests/units/fastsync/test_postgres_to_snowflake.py
@@ -9,7 +9,7 @@ TARGET = 'FastSyncTargetSnowflake'
 
 
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
-class S3CsvToPostgres(unittest.TestCase):
+class PostgresToSnowflake(unittest.TestCase):
     """
     Unit tests for fastsync postgres to snowflake
     """


### PR DESCRIPTION
## Problem

**AP-905** 
This is a bug in FastSync that allows running Fastsync with tables that aren't configured in the tap with the help of the arg `--tables`.

**AP-902**
When a full resync of the whole tap is triggered, PipelineWise creates a slot if it doesn’t exist.
while the full resync is taking place, if a slot already exists and occupies a lot of disk space, it will grow in size as it’s not consumed from, this can create disk space problems for small but active dbs. 

## Proposed changes

**AP-905** 
Check the list of tables provided via `tables` arg against the set of selected tables in the properties file of the tap. 
Change is in commit

**AP-902** 
Since Full resync is not making use of the slot anyway, and the latter might grow too much, add ability to drop the slot.
That is done automatically by checking the value of arg `tables`, if none is provided then enable the dropping slot by calling a class method `FastSyncTapPostgres.drop_slot`.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
