### PR TITLE
AP-965 add support for auth to s3 source via aws profile to FastSync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,6 @@ jobs:
             . .virtualenvs/pipelinewise/bin/activate
             export PIPELINEWISE_HOME=$PWD
             pytest tests/end_to_end -v
-          no_output_timeout: 15m
 
       - store_test_results:
           path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,7 @@ jobs:
             . .virtualenvs/pipelinewise/bin/activate
             export PIPELINEWISE_HOME=$PWD
             pytest tests/end_to_end -v
+          no_output_timeout: 30m
 
       - store_test_results:
           path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
             export PIPELINEWISE_HOME=$PWD
             mkdir test-reports
             coverage run -m pytest tests/units -v --junitxml=test-reports/junit.xml
-            coverage report
+            coverage report --fail-under=69 || { echo 'Coverage threshold of 69% not met!' ; exit 1; }
             coverage html -d coverage_html
 
       - run:

--- a/docs/connectors/taps/s3_csv.rst
+++ b/docs/connectors/taps/s3_csv.rst
@@ -15,13 +15,19 @@ S3 objects to incrementally download only the new or updated files.
   **Authentication Methods**
 
    * **Profile based authentication**: This is the default authentication method. Credentials taken from
-     the ``default`` AWS profile, that's available on the host where PipelineWise is running.
-     To use anoter profile set the ``aws_profile`` parameter.
-   * **Non-profile based authentication**: To provide fixed credentials set ``aws_access_key_id``,
+     the ``AWS_PROFILE`` environment variable or the ``default`` AWS profile, that's available on the host where
+     PipelineWise is running.
+     To use another profile set the ``aws_profile`` parameter.
+     This method requires the presence of ``~/.aws/credentials`` file on the host.
+
+   * **Credentials based authentication**: To provide fixed credentials set ``aws_access_key_id``,
      ``aws_secret_access_key`` and optionally the ``aws_session_token`` parameters.
 
      Optionally the credentials can be vault-encrypted in the YAML. Please check :ref:`encrypting_passwords`
      for further details.
+
+   * **IAM role based authentication**: When no credentials and no AWS profile is given nor found on the host,
+     PipelineWise will resort to use the IAM role attached to the host.
 
 Configuring what to replicate
 '''''''''''''''''''''''''''''
@@ -50,10 +56,13 @@ Example YAML for ``tap-s3-csv``:
     # Source (Tap) - S3 connection details
     # ------------------------------------------------------------------------------
     db_conn:
-      # Profile based authentication
-      aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment variable or the 'default' profile will be used
 
-      # Non-profile based authentication
+      # Profile based authentication
+      aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment
+                                                    # variable or the 'default' profile will be used, if not
+                                                    # available, then IAM role attached to the host will be used.
+
+      # Credentials based authentication
       #aws_access_key_id: "<ACCESS_KEY>"            # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_ACCESS_KEY_ID environment variable will be used.
       #aws_secret_access_key: "<SECRET_ACCESS_KEY"  # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_SECRET_ACCESS_KEY environment variable will be used.
       #aws_session_token: "<AWS_SESSION_TOKEN>"     # Optional: Plain string or vault encrypted. If not provided, AWS_SESSION_TOKEN environment variable will be used.

--- a/docs/connectors/targets/redshift.rst
+++ b/docs/connectors/targets/redshift.rst
@@ -43,9 +43,11 @@ Example YAML for target-redshift:
 
       # We use an intermediate S3 to load data into Redshift
       # S3 Profile based authentication
-      aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment variable or the 'default' profile will be used
+      aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment
+                                                    # variable or the 'default' profile will be used, if not
+                                                    # available, then IAM role attached to the host will be used.
 
-      # S3 Non-profile based authentication
+      # S3 Credentials based authentication
       #aws_access_key_id: "<ACCESS_KEY>"            # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_ACCESS_KEY_ID environment variable will be used.
       #aws_secret_access_key: "<SECRET_ACCESS_KEY"  # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_SECRET_ACCESS_KEY environment variable will be used.
       #aws_session_token: "<AWS_SESSION_TOKEN>"     # Optional: Plain string or vault encrypted. If not provided, AWS_SESSION_TOKEN environment variable will be used.

--- a/docs/connectors/targets/s3_csv.rst
+++ b/docs/connectors/targets/s3_csv.rst
@@ -15,13 +15,19 @@ supported :ref:`taps_list`.
   **Authentication Methods**
 
    * **Profile based authentication**: This is the default authentication method. Credentials taken from
-     the ``default`` AWS profile, that's available on the host where PipelineWise is running.
-     To use anoter profile set the ``aws_profile`` parameter.
-   * **Non-profile based authentication**: To provide fixed credentials set ``aws_access_key_id``,
+     the ``AWS_PROFILE`` environment variable or the ``default`` AWS profile, that's available on the host where
+     PipelineWise is running.
+     To use another profile set the ``aws_profile`` parameter.
+     This method requires the presence of ``~/.aws/credentials`` file on the host.
+
+   * **Credentials based authentication**: To provide fixed credentials set ``aws_access_key_id``,
      ``aws_secret_access_key`` and optionally the ``aws_session_token`` parameters.
 
      Optionally the credentials can be vault-encrypted in the YAML. Please check :ref:`encrypting_passwords`
      for further details.
+
+   * **IAM role based authentication**: When no credentials and no AWS profile is given nor found on the host,
+     PipelineWise will resort to use the IAM role attached to the host.
 
 Configuring where to replicate data
 '''''''''''''''''''''''''''''''''''
@@ -49,9 +55,11 @@ Example YAML for ``target-s3-csv``:
     # ------------------------------------------------------------------------------
     db_conn:
       # Profile based authentication
-      aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment variable or the 'default' profile will be used
+      aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment
+                                                    # variable or the 'default' profile will be used, if not
+                                                    # available, then IAM role attached to the host will be used.
 
-      # Non-profile based authentication
+      # Credentials based authentication
       #aws_access_key_id: "<ACCESS_KEY>"            # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_ACCESS_KEY_ID environment variable will be used.
       #aws_secret_access_key: "<SECRET_ACCESS_KEY"  # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_SECRET_ACCESS_KEY environment variable will be used.
       #aws_session_token: "<AWS_SESSION_TOKEN>"     # Optional: Plain string or vault encrypted. If not provided, AWS_SESSION_TOKEN environment variable will be used.
@@ -65,6 +73,6 @@ Example YAML for ``target-s3-csv``:
                                                        new-line characters.
 
       #encryption_type: "KMS"                        # (Default: None) The type of encryption to use. Current supported options are: 'none' and 'KMS'.
-      #encryption_key: "<ENCRYPTIION_KEY_ID>"        # A reference to the encryption key to use for data encryption.
+      #encryption_key: "<ENCRYPTION_KEY_ID>"        # A reference to the encryption key to use for data encryption.
                                                      # For KMS encryption, this should be the name of the KMS encryption key ID (e.g. '1234abcd-1234-1234-1234-1234abcd1234').
                                                      # This field is ignored if 'encryption_type' is none or blank.

--- a/docs/connectors/targets/snowflake.rst
+++ b/docs/connectors/targets/snowflake.rst
@@ -102,9 +102,11 @@ Example YAML for target-snowflake:
 
       # We use an external stage on S3 to load data into Snowflake
       # S3 Profile based authentication
-      aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment variable or the 'default' profile will be used
+      aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment
+                                                    # variable or the 'default' profile will be used, if not
+                                                    # available, then IAM role attached to the host will be used.
 
-      # S3 Non-profile based authentication
+      # S3 Credentials based authentication
       #aws_access_key_id: "<ACCESS_KEY>"            # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_ACCESS_KEY_ID environment variable will be used.
       #aws_secret_access_key: "<SECRET_ACCESS_KEY"  # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_SECRET_ACCESS_KEY environment variable will be used.
       #aws_session_token: "<AWS_SESSION_TOKEN>"     # Optional: Plain string or vault encrypted. If not provided, AWS_SESSION_TOKEN environment variable will be used.

--- a/pipelinewise/cli/samples/tap_s3_csv.yml.sample
+++ b/pipelinewise/cli/samples/tap_s3_csv.yml.sample
@@ -4,7 +4,7 @@
 # General Properties
 # ------------------------------------------------------------------------------
 id: "csv_on_s3"                        # Unique identifier of the tap
-name: "Sampe CSV files on S3"          # Name of the tap
+name: "Sample CSV files on S3"          # Name of the tap
 type: "tap-s3-csv"                     # !! THIS SHOULD NOT CHANGE !!
 owner: "somebody@foo.com"              # Data owner to contact
 #send_alert: False                     # Optional: Disable all configured alerts on this tap
@@ -15,9 +15,11 @@ owner: "somebody@foo.com"              # Data owner to contact
 # ------------------------------------------------------------------------------
 db_conn:
   # Profile based authentication
-  aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment variable or the 'default' profile will be used
+  aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment
+                                                # variable or the 'default' profile will be used, if not
+                                                # available, then IAM role attached to the host will be used.
 
-  # Non-profile based authentication
+  # Credentials based authentication
   #aws_access_key_id: "<ACCESS_KEY>"            # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_ACCESS_KEY_ID environment variable will be used.
   #aws_secret_access_key: "<SECRET_ACCESS_KEY"  # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_SECRET_ACCESS_KEY environment variable will be used.
   #aws_session_token: "<AWS_SESSION_TOKEN>"     # Optional: Plain string or vault encrypted. If not provided, AWS_SESSION_TOKEN environment variable will be used.

--- a/pipelinewise/cli/samples/target_redshift.yml.sample
+++ b/pipelinewise/cli/samples/target_redshift.yml.sample
@@ -20,12 +20,15 @@ db_conn:
 
   # We use an intermediate S3 to load data into Redshift
   # S3 Profile based authentication
-  aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment variable or the 'default' profile will be used
+  aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment
+                                                # variable or the 'default' profile will be used, if not
+                                                # available, then IAM role attached to the host will be used.
 
-  # S3 Non-profile based authentication
+  # S3 Credentials based authentication
   #aws_access_key_id: "<ACCESS_KEY>"            # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_ACCESS_KEY_ID environment variable will be used.
   #aws_secret_access_key: "<SECRET_ACCESS_KEY"  # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_SECRET_ACCESS_KEY environment variable will be used.
   #aws_session_token: "<AWS_SESSION_TOKEN>"     # Optional: Plain string or vault encrypted. If not provided, AWS_SESSION_TOKEN environment variable will be used.
+
   #aws_redshift_copy_role_arn: "<ROLE_ARN>"     # Optional: AWS Role ARN to be used for the Redshift COPY operation.
                                                 #           Allow the user to use environment credentials and delegate the COPY command to a role
                                                 #           Used instead of the given AWS keys for the COPY operation if provided

--- a/pipelinewise/cli/samples/target_s3_csv.yml.sample
+++ b/pipelinewise/cli/samples/target_s3_csv.yml.sample
@@ -13,9 +13,11 @@ type: "target-s3-csv"                  # !! THIS SHOULD NOT CHANGE !!
 # ------------------------------------------------------------------------------
 db_conn:
   # Profile based authentication
-  aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment variable or the 'default' profile will be used
+  aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment
+                                                # variable or the 'default' profile will be used, if not
+                                                # available, then IAM role attached to the host will be used.
 
-  # Non-profile based authentication
+  # Credentials based authentication
   #aws_access_key_id: "<ACCESS_KEY>"            # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_ACCESS_KEY_ID environment variable will be used.
   #aws_secret_access_key: "<SECRET_ACCESS_KEY"  # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_SECRET_ACCESS_KEY environment variable will be used.
   #aws_session_token: "<AWS_SESSION_TOKEN>"     # Optional: Plain string or vault encrypted. If not provided, AWS_SESSION_TOKEN environment variable will be used.

--- a/pipelinewise/cli/samples/target_snowflake.yml.sample
+++ b/pipelinewise/cli/samples/target_snowflake.yml.sample
@@ -20,9 +20,11 @@ db_conn:
 
   # We use an external stage on S3 to load data into Snowflake
   # S3 Profile based authentication
-  aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment variable or the 'default' profile will be used
+  aws_profile: "<AWS_PROFILE>"                  # AWS profile name, if not provided, the AWS_PROFILE environment
+                                                # variable or the 'default' profile will be used, if not
+                                                # available, then IAM role attached to the host will be used.
 
-  # S3 Non-profile based authentication
+  # Credentials based authentication
   #aws_access_key_id: "<ACCESS_KEY>"            # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_ACCESS_KEY_ID environment variable will be used.
   #aws_secret_access_key: "<SECRET_ACCESS_KEY"  # Plain string or vault encrypted. Required for non-profile based auth. If not provided, AWS_SECRET_ACCESS_KEY environment variable will be used.
   #aws_session_token: "<AWS_SESSION_TOKEN>"     # Optional: Plain string or vault encrypted. If not provided, AWS_SESSION_TOKEN environment variable will be used.

--- a/pipelinewise/fastsync/commons/tap_s3_csv.py
+++ b/pipelinewise/fastsync/commons/tap_s3_csv.py
@@ -1,6 +1,7 @@
 import csv
 import gzip
 import logging
+import os
 import re
 import sys
 import boto3
@@ -8,7 +9,6 @@ import boto3
 from datetime import datetime
 from time import struct_time
 from typing import Callable, Dict, List, Optional, Set
-from botocore.credentials import DeferredRefreshableCredentials
 from messytables import (CSVTableSet, headers_guess, headers_processor, jts, offset_processor, type_guess)
 from singer.utils import strptime_with_tz
 from singer_encodings import csv as singer_encodings_csv
@@ -243,28 +243,31 @@ class S3Helper:
     SDC_SOURCE_FILE_COLUMN = '_sdc_source_file'
     SDC_SOURCE_LINENO_COLUMN = '_sdc_source_lineno'
 
-    # pylint: disable=too-few-public-methods,missing-class-docstring
-    class AssumeRoleProvider:
-        METHOD = 'assume-role'
-
-        def __init__(self, fetcher):
-            self._fetcher = fetcher
-
-        def load(self):
-            return DeferredRefreshableCredentials(
-                self._fetcher.fetch_credentials,
-                self.METHOD
-            )
-
     @classmethod
     @retry_pattern()
-    def setup_aws_client(cls, config):
-        aws_access_key_id = config['aws_access_key_id']
-        aws_secret_access_key = config['aws_secret_access_key']
-
+    def setup_aws_client(cls, config: Dict) -> None:
+        """
+        Initialize a default AWS session
+        :param config: connection config
+        """
         LOGGER.info('Attempting to create AWS session')
-        boto3.setup_default_session(aws_access_key_id=aws_access_key_id,
-                                    aws_secret_access_key=aws_secret_access_key)
+
+        # Get the required parameters from config file and/or environment variables
+        aws_access_key_id = config.get('aws_access_key_id') or os.environ.get('AWS_ACCESS_KEY_ID')
+        aws_secret_access_key = config.get('aws_secret_access_key') or os.environ.get('AWS_SECRET_ACCESS_KEY')
+        aws_session_token = config.get('aws_session_token') or os.environ.get('AWS_SESSION_TOKEN')
+        aws_profile = config.get('aws_profile') or os.environ.get('AWS_PROFILE')
+
+        # AWS credentials based authentication
+        if aws_access_key_id and aws_secret_access_key:
+            boto3.setup_default_session(
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token
+            )
+        # AWS Profile based authentication, will use IAM role if no profile is found
+        else:
+            boto3.setup_default_session(profile_name=aws_profile)
 
     @classmethod
     def get_input_files_for_table(cls, config: Dict, table_spec: Dict, modified_since: struct_time = None):
@@ -317,10 +320,10 @@ class S3Helper:
 
         if matched_files_count == 0:
             if prefix:
-                raise Exception('No files found in bucket "{}" that matches prefix "{}" and pattern "{}"'.format(
-                    bucket, prefix, pattern))
+                raise Exception(f'No files found in bucket "{bucket}" '
+                                f'that matches prefix "{prefix}" and pattern "{pattern}"')
 
-            raise Exception('No files found in bucket "{}" that matches pattern "{}"'.format(bucket, pattern))
+            raise Exception(f'No files found in bucket "{bucket}" that matches pattern "{pattern}"')
 
     @classmethod
     @retry_pattern()

--- a/pipelinewise/fastsync/s3_csv_to_postgres.py
+++ b/pipelinewise/fastsync/s3_csv_to_postgres.py
@@ -17,8 +17,6 @@ LOGGER = Logger().get_logger(__name__)
 
 REQUIRED_CONFIG_KEYS = {
     'tap': [
-        'aws_access_key_id',
-        'aws_secret_access_key',
         'bucket',
         'start_date'
     ],

--- a/pipelinewise/fastsync/s3_csv_to_redshift.py
+++ b/pipelinewise/fastsync/s3_csv_to_redshift.py
@@ -17,8 +17,6 @@ LOGGER = Logger().get_logger(__name__)
 
 REQUIRED_CONFIG_KEYS = {
     'tap': [
-        'aws_access_key_id',
-        'aws_secret_access_key',
         'bucket',
         'start_date'
     ],

--- a/pipelinewise/fastsync/s3_csv_to_snowflake.py
+++ b/pipelinewise/fastsync/s3_csv_to_snowflake.py
@@ -18,8 +18,6 @@ LOGGER = Logger().get_logger(__name__)
 
 REQUIRED_CONFIG_KEYS = {
     'tap': [
-        'aws_access_key_id',
-        'aws_secret_access_key',
         'bucket',
         'start_date'
     ],

--- a/pylintrc
+++ b/pylintrc
@@ -379,7 +379,7 @@ spelling-store-unknown-words=no
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
-notes=FIXME,XXX,TODO
+notes=FIXME,XXX
 
 
 [BASIC]

--- a/tests/units/fastsync/commons/test_fastsync_tap_s3_csv.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_s3_csv.py
@@ -228,7 +228,7 @@ class TestS3Helper(TestCase):
     """
     Unit tests for S3Helper in tap s3 csv
     """
-
+    # pylint: disable=R0201
     def test_setup_aws_client_with_creds(self):
         """
         Test that the aws client is setup when credentials are given
@@ -248,6 +248,7 @@ class TestS3Helper(TestCase):
                 aws_session_token=config['aws_session_token']
             )
 
+    # pylint: disable=R0201
     def test_setup_aws_client_with_env_creds(self):
         """
         Test that the aws client is setup when credentials are in the environment
@@ -276,6 +277,7 @@ class TestS3Helper(TestCase):
         os.environ.pop('AWS_SECRET_ACCESS_KEY')
         os.environ.pop('AWS_SESSION_TOKEN')
 
+    # pylint: disable=R0201
     def test_setup_aws_client_with_profile(self):
         """
         Test that the aws client is setup when profile is given
@@ -292,6 +294,7 @@ class TestS3Helper(TestCase):
                 profile_name=config['aws_profile'],
             )
 
+    # pylint: disable=R0201
     def test_setup_aws_client_with_env_profile(self):
         """
         Test that the aws client is setup when profile is in the environment
@@ -312,6 +315,7 @@ class TestS3Helper(TestCase):
 
         os.environ.pop('AWS_PROFILE')
 
+    # pylint: disable=R0201
     def test_setup_aws_client_with_no_profile_nor_creds(self):
         """
         Test that the aws client is setup when no profile and no creds are given


### PR DESCRIPTION
## Problem

1. 
Singer replication from s3 csv has support for auth via AWS profile or IAM role. FastSync doesn’t which means we cannot have a tap s3 csv unless it has credentials.
The error we get is: 
```
Config is missing required keys: ['aws_access_key_id', 'aws_secret_access_key']
```

2. Documentation around using AWS profile to authenticate to S3 bucket is not super clear.


## Proposed changes

1. Add support for auth via AWS profile to FastSync `tap-s3-csv` so as it is in sync with its Singer counterpart.
2. Update documentation

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
