### PR TITLE
[AP-975] Use unique file names in fastsync to avoid file name collision

### DIFF
--- a/pipelinewise/fastsync/commons/target_redshift.py
+++ b/pipelinewise/fastsync/commons/target_redshift.py
@@ -77,11 +77,11 @@ class FastSyncTargetRedshift:
 
                 return []
 
-    def upload_to_s3(self, file, table):
+    def upload_to_s3(self, file):
         bucket = self.connection_config['s3_bucket']
         s3_acl = self.connection_config.get('s3_acl')
         s3_key_prefix = self.connection_config.get('s3_key_prefix', '')
-        s3_key = '{}pipelinewise_{}_{}.csv.gz'.format(s3_key_prefix, table, time.strftime('%Y%m%d-%H%M%S'))
+        s3_key = '{}{}'.format(s3_key_prefix, os.path.basename(file))
 
         extra_args = {'ACL': s3_acl} if s3_acl else None
 

--- a/pipelinewise/fastsync/commons/target_redshift.py
+++ b/pipelinewise/fastsync/commons/target_redshift.py
@@ -1,7 +1,6 @@
 import os
 import logging
 import json
-import time
 import boto3
 import psycopg2
 import psycopg2.extras

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import json
-import time
 from typing import List
 
 import boto3

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -89,11 +89,11 @@ class FastSyncTargetSnowflake:
 
                 return []
 
-    def upload_to_s3(self, file, table, tmp_dir=None):
+    def upload_to_s3(self, file, tmp_dir=None):
         bucket = self.connection_config['s3_bucket']
         s3_acl = self.connection_config.get('s3_acl')
         s3_key_prefix = self.connection_config.get('s3_key_prefix', '')
-        s3_key = '{}pipelinewise_{}_{}.csv.gz'.format(s3_key_prefix, table, time.strftime('%Y%m%d-%H%M%S'))
+        s3_key = '{}{}'.format(s3_key_prefix, os.path.basename(file))
 
         LOGGER.info('Uploading to S3 bucket: %s, local file: %s, S3 key: %s', bucket, file, s3_key)
 

--- a/pipelinewise/fastsync/commons/utils.py
+++ b/pipelinewise/fastsync/commons/utils.py
@@ -3,6 +3,9 @@ import json
 import multiprocessing
 import os
 import logging
+import datetime
+import random
+import string
 
 from typing import Dict
 
@@ -373,3 +376,40 @@ def get_pool_size(tap: Dict) -> int:
         return cpu_cores
 
     return min(fastsync_parallelism, cpu_cores)
+
+
+def gen_export_filename(tap_id: str,
+                        table: str,
+                        suffix: str = None,
+                        postfix: str = None,
+                        ext: str = None) -> str:
+    """
+    Generates a unique filename used for exported fastsync data that avoids file name collision
+
+    Default pattern:
+        pipelinewise_<tap_id>_<table>_<timestamp_with_ms>_fastsync_<random_string>.csv.gz
+
+    Args:
+        tap_id: Unique tap id
+        table: Name of the table to export
+        suffix: Generated filename suffix. Defaults to current timestamp in milliseconds
+        postfix: Generated filename postfix. Defaults to a random 8 character length string
+        ext: Filename extension. Defaults to .csv.gz
+
+    Returns:
+        Unique filename as a string
+    """
+    if not suffix:
+        suffix = datetime.datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+
+    if not postfix:
+        postfix = ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
+
+    if not ext:
+        ext = 'csv.gz'
+
+    return 'pipelinewise_{}_{}_{}_fastsync_{}.{}'.format(tap_id,
+                                                         table,
+                                                         suffix,
+                                                         postfix,
+                                                         ext)

--- a/pipelinewise/fastsync/commons/utils.py
+++ b/pipelinewise/fastsync/commons/utils.py
@@ -4,10 +4,9 @@ import multiprocessing
 import os
 import logging
 import datetime
-import random
-import string
 
 from typing import Dict
+from pipelinewise.cli.utils import generate_random_string
 
 LOGGER = logging.getLogger(__name__)
 
@@ -403,7 +402,7 @@ def gen_export_filename(tap_id: str,
         suffix = datetime.datetime.now().strftime('%Y%m%d-%H%M%S-%f')
 
     if not postfix:
-        postfix = ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
+        postfix = generate_random_string()
 
     if not ext:
         ext = 'csv.gz'

--- a/pipelinewise/fastsync/commons/utils.py
+++ b/pipelinewise/fastsync/commons/utils.py
@@ -400,7 +400,7 @@ def gen_export_filename(tap_id: str,
         Unique filename as a string
     """
     if not suffix:
-        suffix = datetime.datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+        suffix = datetime.datetime.now().strftime('%Y%m%d-%H%M%S-%f')
 
     if not postfix:
         postfix = ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))

--- a/pipelinewise/fastsync/mongodb_to_postgres.py
+++ b/pipelinewise/fastsync/mongodb_to_postgres.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import sys
-import time
 import multiprocessing
 
 from typing import Union
@@ -55,7 +54,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     postgres = FastSyncTargetPostgres(args.target, args.transform)
 
     try:
-        filename = 'pipelinewise_fastsync_{}_{}.csv.gz'.format(table, time.strftime('%Y%m%d-%H%M%S'))
+        filename = utils.gen_export_filename(tap_id=args.target.get('tap_id'), table=table)
         filepath = os.path.join(args.temp_dir, filename)
         target_schema = utils.get_target_schema(args.target, table)
 

--- a/pipelinewise/fastsync/mongodb_to_snowflake.py
+++ b/pipelinewise/fastsync/mongodb_to_snowflake.py
@@ -78,7 +78,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         mongodb.close_connection()
 
         # Uploading to S3
-        s3_key = snowflake.upload_to_s3(filepath, table, tmp_dir=args.temp_dir)
+        s3_key = snowflake.upload_to_s3(filepath, tmp_dir=args.temp_dir)
         # os.remove(filepath)
 
         # Creating temp table in Snowflake

--- a/pipelinewise/fastsync/mongodb_to_snowflake.py
+++ b/pipelinewise/fastsync/mongodb_to_snowflake.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import sys
-import time
 import multiprocessing
 
 from typing import Union
@@ -60,7 +59,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
 
     try:
         dbname = args.tap.get('dbname')
-        filename = 'pipelinewise_fastsync_{}_{}_{}.csv.gz'.format(dbname, table, time.strftime('%Y%m%d-%H%M%S'))
+        filename = utils.gen_export_filename(tap_id=args.target.get('tap_id'), table=table)
         filepath = os.path.join(args.temp_dir, filename)
         target_schema = utils.get_target_schema(args.target, table)
 

--- a/pipelinewise/fastsync/mysql_to_postgres.py
+++ b/pipelinewise/fastsync/mysql_to_postgres.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import sys
-import time
 from functools import partial
 from argparse import Namespace
 import multiprocessing
@@ -85,7 +84,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     postgres = FastSyncTargetPostgres(args.target, args.transform)
 
     try:
-        filename = 'pipelinewise_fastsync_{}_{}.csv.gz'.format(table, time.strftime('%Y%m%d-%H%M%S'))
+        filename = utils.gen_export_filename(tap_id=args.target.get('tap_id'), table=table)
         filepath = os.path.join(args.temp_dir, filename)
         target_schema = utils.get_target_schema(args.target, table)
 

--- a/pipelinewise/fastsync/mysql_to_redshift.py
+++ b/pipelinewise/fastsync/mysql_to_redshift.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import sys
-import time
 from functools import partial
 from argparse import Namespace
 import multiprocessing
@@ -90,7 +89,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     redshift = FastSyncTargetRedshift(args.target, args.transform)
 
     try:
-        filename = 'pipelinewise_fastsync_{}_{}.csv.gz'.format(table, time.strftime('%Y%m%d-%H%M%S'))
+        filename = utils.gen_export_filename(tap_id=args.target.get('tap_id'), table=table)
         filepath = os.path.join(args.temp_dir, filename)
         target_schema = utils.get_target_schema(args.target, table)
 

--- a/pipelinewise/fastsync/mysql_to_redshift.py
+++ b/pipelinewise/fastsync/mysql_to_redshift.py
@@ -108,7 +108,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         mysql.close_connections()
 
         # Uploading to S3
-        s3_key = redshift.upload_to_s3(filepath, table)
+        s3_key = redshift.upload_to_s3(filepath)
         os.remove(filepath)
 
         # Creating temp table in Redshift

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import sys
-import time
 from functools import partial
 from argparse import Namespace
 import multiprocessing
@@ -86,7 +85,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     snowflake = FastSyncTargetSnowflake(args.target, args.transform)
 
     try:
-        filename = 'pipelinewise_fastsync_{}_{}.csv.gz'.format(table, time.strftime('%Y%m%d-%H%M%S'))
+        filename = utils.gen_export_filename(tap_id=args.target.get('tap_id'), table=table)
         filepath = os.path.join(args.temp_dir, filename)
         target_schema = utils.get_target_schema(args.target, table)
 

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -104,7 +104,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         mysql.close_connections()
 
         # Uploading to S3
-        s3_key = snowflake.upload_to_s3(filepath, table, tmp_dir=args.temp_dir)
+        s3_key = snowflake.upload_to_s3(filepath, tmp_dir=args.temp_dir)
         os.remove(filepath)
 
         # Creating temp table in Snowflake

--- a/pipelinewise/fastsync/postgres_to_postgres.py
+++ b/pipelinewise/fastsync/postgres_to_postgres.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import sys
-import time
 import multiprocessing
 
 from functools import partial
@@ -80,7 +79,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
 
     try:
         dbname = args.tap.get('dbname')
-        filename = 'pipelinewise_fastsync_{}_{}_{}.csv.gz'.format(dbname, table, time.strftime('%Y%m%d-%H%M%S'))
+        filename = utils.gen_export_filename(tap_id=args.target.get('tap_id'), table=table)
         filepath = os.path.join(args.temp_dir, filename)
         target_schema = utils.get_target_schema(args.target, table)
 

--- a/pipelinewise/fastsync/postgres_to_redshift.py
+++ b/pipelinewise/fastsync/postgres_to_redshift.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import sys
-import time
 import multiprocessing
 
 from argparse import Namespace
@@ -85,7 +84,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
 
     try:
         dbname = args.tap.get('dbname')
-        filename = 'pipelinewise_fastsync_{}_{}_{}.csv.gz'.format(dbname, table, time.strftime('%Y%m%d-%H%M%S'))
+        filename = utils.gen_export_filename(tap_id=args.target.get('tap_id'), table=table)
         filepath = os.path.join(args.temp_dir, filename)
         target_schema = utils.get_target_schema(args.target, table)
 

--- a/pipelinewise/fastsync/postgres_to_redshift.py
+++ b/pipelinewise/fastsync/postgres_to_redshift.py
@@ -103,7 +103,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         postgres.close_connection()
 
         # Uploading to S3
-        s3_key = redshift.upload_to_s3(filepath, table)
+        s3_key = redshift.upload_to_s3(filepath)
         os.remove(filepath)
 
         # Creating temp table in Redshift

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -103,7 +103,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         postgres.close_connection()
 
         # Uploading to S3
-        s3_key = snowflake.upload_to_s3(filepath, table, tmp_dir=args.temp_dir)
+        s3_key = snowflake.upload_to_s3(filepath, tmp_dir=args.temp_dir)
         os.remove(filepath)
 
         # Creating temp table in Snowflake

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import sys
-import time
 import multiprocessing
 
 from argparse import Namespace
@@ -85,7 +84,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
 
     try:
         dbname = args.tap.get('dbname')
-        filename = 'pipelinewise_fastsync_{}_{}_{}.csv.gz'.format(dbname, table, time.strftime('%Y%m%d-%H%M%S'))
+        filename = utils.gen_export_filename(tap_id=args.target.get('tap_id'), table=table)
         filepath = os.path.join(args.temp_dir, filename)
         target_schema = utils.get_target_schema(args.target, table)
 

--- a/pipelinewise/fastsync/s3_csv_to_postgres.py
+++ b/pipelinewise/fastsync/s3_csv_to_postgres.py
@@ -2,7 +2,6 @@
 import multiprocessing
 import os
 import sys
-import time
 from argparse import Namespace
 from datetime import datetime
 from functools import partial
@@ -51,8 +50,7 @@ def sync_table(table_name: str, args: Namespace) -> Union[bool, str]:
     postgres = FastSyncTargetPostgres(args.target, args.transform)
 
     try:
-        filename = 'pipelinewise_fastsync_{}_{}_{}.csv.gz'.format(args.tap['bucket'], table_name,
-                                                                  time.strftime('%Y%m%d-%H%M%S'))
+        filename = utils.gen_export_filename(tap_id=args.target.get('tap_id'), table=table_name)
         filepath = os.path.join(args.temp_dir, filename)
 
         target_schema = utils.get_target_schema(args.target, table_name)

--- a/pipelinewise/fastsync/s3_csv_to_redshift.py
+++ b/pipelinewise/fastsync/s3_csv_to_redshift.py
@@ -2,7 +2,6 @@
 import multiprocessing
 import os
 import sys
-import time
 from argparse import Namespace
 from datetime import datetime
 from functools import partial
@@ -53,8 +52,7 @@ def sync_table(table_name: str, args: Namespace) -> Union[bool, str]:
     redshift = FastSyncTargetRedshift(args.target, args.transform)
 
     try:
-        filename = 'pipelinewise_fastsync_{}_{}_{}.csv.gz'.format(args.tap['bucket'], table_name,
-                                                                  time.strftime('%Y%m%d-%H%M%S'))
+        filename = utils.gen_export_filename(tap_id=args.target.get('tap_id'), table=table_name)
         filepath = os.path.join(args.temp_dir, filename)
 
         target_schema = utils.get_target_schema(args.target, table_name)

--- a/pipelinewise/fastsync/s3_csv_to_redshift.py
+++ b/pipelinewise/fastsync/s3_csv_to_redshift.py
@@ -65,7 +65,7 @@ def sync_table(table_name: str, args: Namespace) -> Union[bool, str]:
         primary_key = redshift_types['primary_key']
 
         # Uploading to S3
-        s3_key = redshift.upload_to_s3(filepath, table_name)
+        s3_key = redshift.upload_to_s3(filepath)
         os.remove(filepath)
 
         # Creating temp table in Redshift

--- a/pipelinewise/fastsync/s3_csv_to_snowflake.py
+++ b/pipelinewise/fastsync/s3_csv_to_snowflake.py
@@ -68,7 +68,7 @@ def sync_table(table_name: str, args: Namespace) -> Union[bool, str]:
         primary_key = snowflake_types['primary_key']
 
         # Uploading to S3
-        s3_key = snowflake.upload_to_s3(filepath, table_name, tmp_dir=args.temp_dir)
+        s3_key = snowflake.upload_to_s3(filepath, tmp_dir=args.temp_dir)
         os.remove(filepath)
 
         # Creating temp table in Snowflake

--- a/pipelinewise/fastsync/s3_csv_to_snowflake.py
+++ b/pipelinewise/fastsync/s3_csv_to_snowflake.py
@@ -2,7 +2,6 @@
 import multiprocessing
 import os
 import sys
-import time
 from argparse import Namespace
 from datetime import datetime
 from functools import partial
@@ -56,8 +55,7 @@ def sync_table(table_name: str, args: Namespace) -> Union[bool, str]:
     snowflake = FastSyncTargetSnowflake(args.target, args.transform)
 
     try:
-        filename = 'pipelinewise_fastsync_{}_{}_{}.csv.gz'.format(args.tap['bucket'], table_name,
-                                                                  time.strftime('%Y%m%d-%H%M%S'))
+        filename = utils.gen_export_filename(tap_id=args.target.get('tap_id'), table=table_name)
         filepath = os.path.join(args.temp_dir, filename)
 
         target_schema = utils.get_target_schema(args.target, table_name)

--- a/tests/units/fastsync/assertions.py
+++ b/tests/units/fastsync/assertions.py
@@ -95,6 +95,7 @@ def assert_sync_table_exception_on_failed_copy(sync_table: callable,
             with patch(objects_to_mock.utils_module_nm) as utils_mock:
                 with patch(objects_to_mock.multiproc_module_nm) as multiproc_mock:
                     utils_mock.get_target_schema.return_value = 'my-target-schema'
+                    utils_mock.gen_export_filename.return_value = 'my-export-file'
                     tap_mock.return_value.copy_table.side_effect = Exception('Boooom')
 
                     assert sync_table('table_1', FASTSYNC_NS) == 'table_1: Boooom'

--- a/tests/units/fastsync/commons/test_fastsync_utils.py
+++ b/tests/units/fastsync/commons/test_fastsync_utils.py
@@ -561,3 +561,18 @@ class TestFastSyncUtils(TestCase):
         get_tables_prop_mock.assert_called_once()
         check_config_mock.assert_not_called()
         self.assertEqual(load_json_mock.call_count, 3)
+
+    def test_gen_export_filename(self):
+        """
+        Test unique file name generator function
+        """
+        # Adding tap id and table name should generate uniqe filenames
+        # including timestamps with milliseconds and random generated string
+        #
+        # Example: pipelinewise_tap_table_20210316-111338-878470_fastsync_L5C6VG9W.csv.gz
+        self.assertRegex(utils.gen_export_filename('tap', 'table'),
+                         r'pipelinewise_tap_table_(\d{8})-(\d{6})-(\d{6})_fastsync_(.{8}).csv.gz')
+
+        # Generate filename with custom suffic, postfix and extension
+        self.assertEqual(utils.gen_export_filename('tap', 'table', suffix='suffix', postfix='postfix', ext='ext'),
+                         'pipelinewise_tap_table_suffix_fastsync_postfix.ext')


### PR DESCRIPTION
## Problem

Filenames in fastsync are not unique enough. If two taps with the same table name started at the same time then it's possible that they're using the same export file names, causing file name collisions and failures.

## Proposed changes

Generate more unique file names:
* Pattern: `pipelinewise_<tap_id>_<table>_<timestamp_with_milliseconds>_fastsync_<random_string>.csv.gz`
* Sample generated filename: `pipelinewise_tap_table_20210316-111338-878470_fastsync_L5C6VG9W.csv.gz`

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
