### PR TITLE
[CI] Fix upload docker image step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,7 @@ jobs:
             DEPLOY_SLACK_CHANNEL: "#analytics-platform-builds"
             DEPLOY_IMAGE_NAME: "pipelinewise"
             DEPLOY_DOCKERFILE: "./Dockerfile"
+            DEPLOY_REGISTRY_URL: $DEPLOY_REGISTRY_URL
 
   promote_docker_image:
     <<: *docker_k8s_deployer
@@ -187,6 +188,7 @@ jobs:
           environment:
             DEPLOY_IMAGE_NAME: "pipelinewise"
             DEPLOY_SLACK_CHANNEL: "#analytics-platform-builds"
+            DEPLOY_REGISTRY_URL: $DEPLOY_REGISTRY_URL
 
 
 workflows:


### PR DESCRIPTION
## Problem

Upload step fails with missing url option

## Proposed changes

Set the environment variable: DEPLOY_REGISTRY_URL in the config.
It has also been added to CircleCI UI

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
