### PR TITLE
[AP-862] Publish releases to dockerhub

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,41 @@
+name: Docker Image to DockerHub
+
+on:
+  release:
+    types:
+      - [published]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Generate tag
+      uses: frabert/replace-string-action@master
+      id: genTag
+      with:
+        pattern: '.*(\d+\.\d+\.\d+).*'
+        string: "${{ github.event.release.tag_name }}"
+        replace-with: '$1'
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        file: ./Dockerfile
+        push: true
+        tags: transferwiseworkspace/pipelinewise:${{ steps.genTag.outputs.replaced }}
+
+    - name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}
+


### PR DESCRIPTION
## Problem

PPW releases not published to dockerhub automatically at https://hub.docker.com/r/transferwiseworkspace/pipelinewise

## Proposed changes

Build and push every published releases to dockerhub. 

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
