### PR TITLE
Add option to disable fastsync

### DIFF
--- a/docs/user_guide/cli.rst
+++ b/docs/user_guide/cli.rst
@@ -50,6 +50,8 @@ Run a specific pipeline
 
 :--extra_log: Optional: Copy logging into PipelineWise logger to see tap run logs at runtime in STDOUT
 
+:--enable_fastsync: Optional: Use FastSync when possible. Enabled by default.
+
 
 .. _cli_stop_tap:
 
@@ -110,6 +112,8 @@ sync and resets the table bookmarks to their new location.
 :--tap: Tap connector id
 
 :--tables: Optional: Comma separated list of tables to sync from the data source.
+
+:--enable_fastsync: Optional: Use FastSync when possible. Enabled by default.
 
 
 .. _cli_import:

--- a/pipelinewise/cli/__init__.py
+++ b/pipelinewise/cli/__init__.py
@@ -171,6 +171,11 @@ def main():
                              'The stats will be dumped into a folder in .pipelinewise/profiling',
                         action='store_true'
                         )
+    parser.add_argument('--enable_fastsync',
+                        default=True,
+                        required=False,
+                        help='Use fastsync for syncing when possible',
+                        action='store_true')
 
     args = parser.parse_args()
 

--- a/tests/units/cli/cli_args.py
+++ b/tests/units/cli/cli_args.py
@@ -18,7 +18,8 @@ class CliArgs:
                  log='*',
                  extra_log=False,
                  debug=False,
-                 profiler=False
+                 profiler=False,
+                 enable_fastsync=True,
                  ):
         self.target = target
         self.tap = tap
@@ -29,6 +30,7 @@ class CliArgs:
         self.string = string
         self.log = log
         self.extra_log = extra_log
+        self.enable_fastsync = enable_fastsync
         self.debug = debug
         self.profiler = profiler
 


### PR DESCRIPTION
## Problem

We have encountered several times issues with fastsync. It is currently not possible to run without fastsync without editing source code (if you know where to look), and install from a customized source. We'd highly prefer having the easily accessible option to not use fastsync with a certain sync and use the 'normal' singer sync when we need to disable it for a certain table or scenario. While it is definitely faster using fastsync, it sometimes does not work correctly, and in those scenario's we'd like to continue our sync/ELT process without it until e.g. a new release contains a bugfix.

## Proposed changes

Add a cli flag to disable fastsync

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
