### PR TITLE
AP-NNN Bump tap-s3-csv to 1.2.1

### DIFF
--- a/singer-connectors/tap-s3-csv/requirements.txt
+++ b/singer-connectors/tap-s3-csv/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-s3-csv==1.2.0
+pipelinewise-tap-s3-csv==1.2.1


### PR DESCRIPTION
## Problem

Current tap-s3-csv uses old dependencies 

## Proposed changes
Uses latest version with bumped dependencies


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
