### PR TITLE
AP1011 archive_load_files in fastsync

### DIFF
--- a/pipelinewise/cli/config.py
+++ b/pipelinewise/cli/config.py
@@ -360,7 +360,9 @@ class Config:
             'split_large_files': tap.get('split_large_files', False),
             'split_file_chunk_size_mb': tap.get('split_file_chunk_size_mb', 1000),
             'split_file_max_chunks': tap.get('split_file_max_chunks', 20),
-            'archive_load_files': tap.get('archive_load_files', False)
+            'archive_load_files': tap.get('archive_load_files', False),
+            'archive_load_files_s3_bucket': tap.get('archive_load_files_s3_bucket', None),
+            'archive_load_files_s3_prefix': tap.get('archive_load_files_s3_prefix', None)
         })
 
         # Save the generated JSON files

--- a/pipelinewise/cli/config.py
+++ b/pipelinewise/cli/config.py
@@ -359,7 +359,8 @@ class Config:
             'add_metadata_columns': tap.get('add_metadata_columns', False),
             'split_large_files': tap.get('split_large_files', False),
             'split_file_chunk_size_mb': tap.get('split_file_chunk_size_mb', 1000),
-            'split_file_max_chunks': tap.get('split_file_max_chunks', 20)
+            'split_file_max_chunks': tap.get('split_file_max_chunks', 20),
+            'archive_load_files': tap.get('archive_load_files', False)
         })
 
         # Save the generated JSON files

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -134,6 +134,29 @@ class FastSyncTargetSnowflake:
 
         return s3_key
 
+    def copy_to_archive(self, source_s3_key, tap_id, table):
+        """Copy load file to archive folder with metadata added"""
+        table_dict = utils.tablename_to_dict(table)
+        archive_table = table_dict.get('table_name')
+        archive_schema = table_dict.get('schema_name', '')
+
+        archive_metadata = {
+            'tap': tap_id,
+            'schema': archive_schema,
+            'table': archive_table,
+            'archived-by': 'pipelinewise_fastsync_postgres_to_snowflake'
+        }
+
+        archive_file = source_s3_key.split('/')[-1]
+        archive_folder = 'archive/{}/{}'.format(tap_id, archive_table)
+        archive_key = '{}/{}'.format(archive_folder, archive_file)
+
+        LOGGER.info('Archiving %s to %s', source_s3_key, archive_key)
+        bucket = self.connection_config['s3_bucket']
+        copy_source = '{}/{}'.format(bucket, source_s3_key)
+        self.s3.copy_object(CopySource=copy_source, Bucket=bucket, Key=archive_key, Metadata=archive_metadata,
+                            MetadataDirective='REPLACE')
+
     def create_schema(self, schema):
         sql = 'CREATE SCHEMA IF NOT EXISTS {}'.format(schema)
         self.query(sql, query_tag_props={'schema': schema})

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -83,10 +83,12 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     """Sync one table"""
     postgres = FastSyncTapPostgres(args.tap, tap_type_to_target_type)
     snowflake = FastSyncTargetSnowflake(args.target, args.transform)
+    tap_id = args.target.get('tap_id')
+    archive_load_files = args.target.get('archive_load_files', False)
 
     try:
         dbname = args.tap.get('dbname')
-        filename = utils.gen_export_filename(tap_id=args.target.get('tap_id'), table=table)
+        filename = utils.gen_export_filename(tap_id=tap_id, table=table)
         filepath = os.path.join(args.temp_dir, filename)
         target_schema = utils.get_target_schema(args.target, table)
 
@@ -97,7 +99,6 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         bookmark = utils.get_bookmark_for_table(table, args.properties, postgres, dbname=dbname)
 
         # Exporting table data, get table definitions and close connection to avoid timeouts
-        postgres.copy_table(table, filepath)
         postgres.copy_table(table,
                             filepath,
                             split_large_files=args.target.get('split_large_files'),
@@ -126,8 +127,12 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         # Load into Snowflake table
         snowflake.copy_to_table(s3_key_pattern, target_schema, table, size_bytes, is_temporary=True)
 
-        # Delete all file parts from s3
         for s3_key in s3_keys:
+            if archive_load_files:
+                # Copy load file to archive
+                snowflake.copy_to_archive(s3_key, tap_id, table)
+
+            # Delete all file parts from s3
             snowflake.s3.delete_object(Bucket=args.target.get('s3_bucket'), Key=s3_key)
 
         # Obfuscate columns

--- a/tests/end_to_end/helpers/env.py
+++ b/tests/end_to_end/helpers/env.py
@@ -187,6 +187,23 @@ class E2EEnv:
         """Get the value of a specific variable in the self.env dict"""
         return self.env[connector]['vars'][key]['value']
 
+    def get_aws_session(self):
+        """Get AWS session with using access from TARGET_SNOWFLAKE_ env vars"""
+        if not self.env['TARGET_SNOWFLAKE']['is_configured']:
+            raise Exception('TARGET_SNOWFLAKE is not configured')
+
+        aws_access_key_id = os.environ.get('TARGET_SNOWFLAKE_AWS_ACCESS_KEY')
+        aws_secret_access_key = os.environ.get('TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY')
+        if aws_access_key_id is None or aws_secret_access_key is None:
+            raise Exception(
+                'Env vars TARGET_SNOWFLAKE_AWS_ACCESS_KEY and TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY are required')
+
+        return boto3.session.Session(
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key
+        )
+
+
     def _is_env_connector_configured(self, env_connector):
         """Detect if certain component(s) of env vars group is configured properly"""
         env_conns = []

--- a/tests/end_to_end/test-project/tap_postgres_to_sf_archive_load_files.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf_archive_load_files.yml.template
@@ -1,0 +1,61 @@
+---
+
+# ------------------------------------------------------------------------------
+# General Properties
+# ------------------------------------------------------------------------------
+id: "postgres_to_sf_archive_load_files"
+name: "PostgreSQL source test database"
+type: "tap-postgres"
+owner: "test-runner"
+
+
+# ------------------------------------------------------------------------------
+# Source (Tap) - PostgreSQL connection details
+# ------------------------------------------------------------------------------
+db_conn:
+  host: "${TAP_POSTGRES_HOST}"          # PostgreSQL host
+  logical_poll_total_seconds: 3         # Time out if no LOG_BASED changes received for 3 seconds
+  port: ${TAP_POSTGRES_PORT}            # PostgreSQL port
+  user: "${TAP_POSTGRES_USER}"          # PostgreSQL user
+  password: "${TAP_POSTGRES_PASSWORD}"  # Plain string or vault encrypted
+  dbname: "${TAP_POSTGRES_DB}"          # PostgreSQL database name
+
+
+# ------------------------------------------------------------------------------
+# Destination (Target) - Target properties
+# Connection details should be in the relevant target YAML file
+# ------------------------------------------------------------------------------
+target: "snowflake"                    # ID of the target connector where the data will be loaded
+batch_size_rows: 1000                  # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                  # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
+archive_load_files: True               # Archive the load files in dedicated S3 folder
+
+
+# ------------------------------------------------------------------------------
+# Source to target Schema mapping
+# ------------------------------------------------------------------------------
+schemas:
+
+  ### SOURCE SCHEMA 1: public
+  - source_schema: "public"
+    target_schema: "ppw_e2e_tap_postgres"
+
+    tables:
+
+      ### Table with INCREMENTAL replication
+      - table_name: "city"
+        replication_method: "INCREMENTAL"
+        replication_key: "id"
+
+      ### Table with FULL_TABLE replication
+      - table_name: "country"
+        replication_method: "FULL_TABLE"
+
+  ### SOURCE SCHEMA 2: public2
+  - source_schema: "public2"
+    target_schema: "ppw_e2e_tap_postgres_public2"
+
+    tables:
+      ### Table with FULL_TABLE replication
+      - table_name: "wearehere"
+        replication_method: "FULL_TABLE"

--- a/tests/end_to_end/test-project/tap_postgres_to_sf_archive_load_files.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf_archive_load_files.yml.template
@@ -25,10 +25,11 @@ db_conn:
 # Destination (Target) - Target properties
 # Connection details should be in the relevant target YAML file
 # ------------------------------------------------------------------------------
-target: "snowflake"                    # ID of the target connector where the data will be loaded
-batch_size_rows: 1000                  # Batch size for the stream to optimise load performance
-stream_buffer_size: 0                  # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
-archive_load_files: True               # Archive the load files in dedicated S3 folder
+target: "snowflake"                           # ID of the target connector where the data will be loaded
+batch_size_rows: 1000                         # Batch size for the stream to optimise load performance
+stream_buffer_size: 0                         # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
+archive_load_files: True                      # Archive the load files in dedicated S3 folder
+archive_load_files_s3_prefix: archive_folder  # Archive folder
 
 
 # ------------------------------------------------------------------------------

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -240,7 +240,7 @@ class TestTargetSnowflake:
         if not self.e2e.env['TARGET_SNOWFLAKE']['is_configured']:
             pytest.skip('Target Snowflake environment variables are not provided')
 
-        archive_s3_prefix = 'archive'  # Custom s3 prefix defined in TAP_POSTGRES_ARCHIVE_LOAD_FILES_ID
+        archive_s3_prefix = 'archive_folder'  # Custom s3 prefix defined in TAP_POSTGRES_ARCHIVE_LOAD_FILES_ID
 
         s3_bucket = os.environ.get('TARGET_SNOWFLAKE_S3_BUCKET')
         s3_client = self.e2e.get_aws_session().client('s3')

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -233,7 +233,7 @@ class TestTargetSnowflake:
 
         assert result == datetime(9999, 12, 31, 23, 59, 59, 998993)
 
-    # pylint: disable=invalid-name
+    # pylint: disable=invalid-name,too-many-locals
     @pytest.mark.dependency(depends=['import_config'])
     def test_replicate_pg_to_sf_with_archive_load_files(self):
         """Fastsync tables from Postgres to Snowflake with archive load files enabled"""

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -240,12 +240,15 @@ class TestTargetSnowflake:
         if not self.e2e.env['TARGET_SNOWFLAKE']['is_configured']:
             pytest.skip('Target Snowflake environment variables are not provided')
 
+        archive_s3_prefix = 'archive'  # Custom s3 prefix defined in TAP_POSTGRES_ARCHIVE_LOAD_FILES_ID
+
         s3_bucket = os.environ.get('TARGET_SNOWFLAKE_S3_BUCKET')
         s3_client = self.e2e.get_aws_session().client('s3')
 
         # Delete any dangling files from archive
         files_in_s3_archive = s3_client.list_objects(
-            Bucket=s3_bucket, Prefix='archive/postgres_to_sf_archive_load_files/').get('Contents', [])
+            Bucket=s3_bucket,
+            Prefix='{}/postgres_to_sf_archive_load_files/'.format(archive_s3_prefix)).get('Contents', [])
         for file_in_archive in files_in_s3_archive:
             s3_client.delete_object(Bucket=s3_bucket, Key=(file_in_archive['Key']))
 
@@ -257,7 +260,7 @@ class TestTargetSnowflake:
             schema, table = schema_table.split('.')
             files_in_s3_archive = s3_client.list_objects(
                 Bucket=s3_bucket,
-                Prefix=('archive/postgres_to_sf_archive_load_files/{}'.format(table))).get('Contents')
+                Prefix=('{}/postgres_to_sf_archive_load_files/{}'.format(archive_s3_prefix, table))).get('Contents')
 
             if files_in_s3_archive is None or len(files_in_s3_archive) != 1:
                 raise Exception('files_in_archive for {} is {}'.format(table, files_in_s3_archive))

--- a/tests/units/cli/test_config.py
+++ b/tests/units/cli/test_config.py
@@ -313,7 +313,8 @@ class TestConfig:
             'add_metadata_columns': False,
             'split_large_files': True,
             'split_file_chunk_size_mb': 500,
-            'split_file_max_chunks': 25
+            'split_file_max_chunks': 25,
+            'archive_load_files': False
         }
 
         # Delete the generated JSON config directory

--- a/tests/units/fastsync/commons/test_fastsync_target_snowflake.py
+++ b/tests/units/fastsync/commons/test_fastsync_target_snowflake.py
@@ -537,7 +537,8 @@ class TestFastSyncTargetSnowflake(TestCase):
             ]
         )
 
-    def test_copy_to_archive_default_bucket_and_folder(self):
+    # pylint: disable=invalid-name
+    def test_default_archive_destination(self):
         """
         Validate parameters passed to s3 copy_object method when custom s3 bucket and folder are not defined
         """
@@ -559,7 +560,8 @@ class TestFastSyncTargetSnowflake(TestCase):
             },
             MetadataDirective='REPLACE')
 
-    def test_copy_to_archive_custom_bucket_and_folder(self):
+    # pylint: disable=invalid-name
+    def test_custom_archive_destination(self):
         """
         Validate parameters passed to s3 copy_object method when using custom s3 bucket and folder
         """


### PR DESCRIPTION
## Problem

https://transferwise.atlassian.net/browse/AP-1011

## Proposed changes

When enabled, this feature will result in PipelineWise load files being copied to a separate folder for archival.

See https://github.com/transferwise/pipelinewise-target-snowflake/pull/178 for same feature in target-snowflake.

Original grooming document (slightly outdated now):
https://docs.google.com/document/d/11UTlmWVJS9aGickmyxpXOUhrv4RTPnm8zip_IqeR2J0/edit?ts=609e4106


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
