### PR TITLE
Bump target-snowflake from 1.12.0 to 1.13.0

### DIFF
--- a/singer-connectors/target-snowflake/requirements.txt
+++ b/singer-connectors/target-snowflake/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-snowflake==1.12.0
+pipelinewise-target-snowflake==1.13.0


### PR DESCRIPTION
## Problem

Archiving load files feature for fastsync is already merged to this repo (https://github.com/transferwise/pipelinewise/pull/717). The equivalent feature added to target-snowflake as well but the new version is not included in this repo. (https://github.com/transferwise/pipelinewise-target-snowflake/pull/178)

## Proposed changes

Bump target snowflake to latest to include `archive_load_files` option. 

The PR also fixing e2e tests where multiple archive files expected, one from fastsync and one from target-snowflake

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
