### PR TITLE
Run snowflake e2e test only when it's enabled

### DIFF
--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -147,6 +147,7 @@ class TestTargetSnowflake:
                                             mysql_to_snowflake.tap_type_to_target_type)
 
     # pylint: disable=invalid-name
+    @pytest.mark.dependency(depends=['import_config'])
     def test_resync_pg_to_sf_with_split_large_files(self, tap_postgres_id=TAP_POSTGRES_SPLIT_LARGE_FILES_ID):
         """Resync tables from Postgres to Snowflake using splitting large files option"""
         assertions.assert_resync_tables_success(tap_postgres_id, TARGET_ID, profiling=True)


### PR DESCRIPTION
## Problem

[test_resync_pg_to_sf_with_split_large_files](test_resync_pg_to_sf_with_split_large_files) end-to-end test is always running regardless if snowflake connection is enabled or not.

## Proposed changes

Run this test only if snowflake is configured by using the same annotation that we use in other tests.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Testing
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
