### PR TITLE
add location config to bigquery fastsync

### DIFF
--- a/pipelinewise/fastsync/commons/target_bigquery.py
+++ b/pipelinewise/fastsync/commons/target_bigquery.py
@@ -39,7 +39,8 @@ class FastSyncTargetBigquery:
 
     def open_connection(self):
         project_id = self.connection_config['project_id']
-        return bigquery.Client(project=project_id)
+        location = self.connection_config.get('location', None)
+        return bigquery.Client(project=project_id, location=location)
 
     def query(self, query, params=None):
         def to_query_parameter(value):


### PR DESCRIPTION
## Problem

BigQuery in fastsync mode is ignoring the location project config and writing to the default location

## Proposed changes

Change the open connection function call to use the location added in the target yml file


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
