### PR TITLE
fix s3 date type mapping in bigquery fastsync

### DIFF
--- a/pipelinewise/fastsync/s3_csv_to_bigquery.py
+++ b/pipelinewise/fastsync/s3_csv_to_bigquery.py
@@ -37,7 +37,7 @@ def tap_type_to_target_type(csv_type):
         'number': 'NUMERIC',
         'string': 'STRING',
         'boolean': 'STRING',  # The guess sometimes can be wrong, we'll use string for now.
-        'date': 'TIMESTAMP',
+        'date': 'STRING',  # The guess sometimes can be wrong, we'll use string for now.
 
         'date_override': 'TIMESTAMP'  # Column type to use when date_override defined in YAML
     }.get(csv_type, 'STRING')


### PR DESCRIPTION
## Problem

s3 date type is detected as a string by the incremental load. Fastsync should do the same

## Proposed changes

Change the mapping of date s3 csv type to STRING


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
