### PR TITLE
Copy existing metadata when archiving load files

### DIFF
--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -140,13 +140,6 @@ class FastSyncTargetSnowflake:
         archive_table = table_dict.get('table_name')
         archive_schema = table_dict.get('schema_name', '')
 
-        archive_metadata = {
-            'tap': tap_id,
-            'schema': archive_schema,
-            'table': archive_table,
-            'archived-by': 'pipelinewise_fastsync_postgres_to_snowflake'
-        }
-
         # Retain same filename
         archive_file_basename = os.path.basename(source_s3_key)
 
@@ -154,6 +147,15 @@ class FastSyncTargetSnowflake:
         archive_s3_prefix = self.connection_config.get('archive_load_files_s3_prefix', 'archive')
 
         source_s3_bucket = self.connection_config.get('s3_bucket')
+
+        # Combine existing metadata with archive related headers
+        metadata = self.s3.head_object(Bucket=source_s3_bucket, Key=source_s3_key)['Metadata']
+        metadata.update({
+            'tap': tap_id,
+            'schema': archive_schema,
+            'table': archive_table,
+            'archived-by': 'pipelinewise_fastsync_postgres_to_snowflake'
+        })
 
         # Get archive s3 bucket from config, defaulting to same bucket used for Snowflake imports if not specified
         archive_s3_bucket = self.connection_config.get('archive_load_files_s3_bucket', source_s3_bucket)
@@ -163,7 +165,7 @@ class FastSyncTargetSnowflake:
         LOGGER.info('Archiving %s to %s', copy_source, archive_key)
 
         self.s3.copy_object(CopySource=copy_source, Bucket=archive_s3_bucket, Key=archive_key,
-                            Metadata=archive_metadata, MetadataDirective='REPLACE')
+                            Metadata=metadata, MetadataDirective='REPLACE')
 
     def create_schema(self, schema):
         sql = 'CREATE SCHEMA IF NOT EXISTS {}'.format(schema)


### PR DESCRIPTION
## Problem

If client side encrypted is enabled, archived files cannot be decrypted unless x-amz-key and x-amz-iv metadata is carried over to the archived file.

## Proposed changes

Copy metadata from load file into the archive file, and append archive related metadata on top of it.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
