### PR TITLE
Increase max batch_size_rows and split_file_chunk_size_mb

### DIFF
--- a/pipelinewise/cli/schemas/tap.json
+++ b/pipelinewise/cli/schemas/tap.json
@@ -274,7 +274,7 @@
     "batch_size_rows": {
       "type": "integer",
       "minimum": 1000,
-      "maximum": 1000000
+      "maximum": 5000000
     },
     "stream_buffer_size": {
       "type": "integer",
@@ -287,7 +287,7 @@
     "split_file_chunk_size_mb": {
       "type": "integer",
       "minimum": 1,
-      "maximum": 2500
+      "maximum": 5000
     },
     "split_file_max_chunks": {
       "type": "integer",


### PR DESCRIPTION
## Problem

As we started using the archive_load_files feature to archive historical fin_business_event records to S3, we ran into some limits imposed by PipelineWise, specifically `batch_size_rows` and `split_file_chunk_size_mb`.

Based on discussions with @koszti, they are both more a "sane maximum" than something based on actual limitations.

## Proposed changes

* Increase `batch_size_rows` from 1M to 5M
  * We observed 1M batch size resulting in ~36mb gzipped csv files in S3, whereas 100-200mb is considered more optimal for Snowflake.
* Increase `split_file_chunk_size_mb` from 2500 to 5000
  * We would have preferred even larger files, but S3 copy command imposes a limit of 5,368,709,120 bytes

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
