### PR TITLE
AP-NNN Fix: Do not log invalid json object

### DIFF
--- a/pipelinewise/cli/utils.py
+++ b/pipelinewise/cli/utils.py
@@ -275,8 +275,8 @@ def validate(instance, schema):
         # Serialise vault encrypted objects to string
         schema_safe_inst = json.loads(json.dumps(instance, cls=AnsibleJSONEncoder))
         jsonschema.validate(instance=schema_safe_inst, schema=schema)
-    except jsonschema.exceptions.ValidationError as exc:
-        LOGGER.critical('Invalid object %s', exc)
+    except jsonschema.exceptions.ValidationError:
+        LOGGER.critical('json object doesn\'t match schema %s', schema)
         sys.exit(1)
 
 


### PR DESCRIPTION
## Problem

When a tap/target is being validated against json schema, the object gets logged if it's invalid thus exposing any credentials in it.

## Proposed changes

Do not log the object


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
