### PR TITLE
[AP-1059] downgrade setuptools to support use_2to3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -61,6 +61,9 @@ make_virtualenv() {
     source $VENV_DIR/$1/bin/activate
     python3 -m pip install --upgrade pip setuptools wheel
 
+    if [ -f "pre_requirements.txt" ]; then
+        python3 -m pip install --upgrade -r pre_requirements.txt
+    fi
     if [ -f "requirements.txt" ]; then
         python3 -m pip install --upgrade -r requirements.txt
     fi

--- a/singer-connectors/tap-adwords/pre_requirements.txt
+++ b/singer-connectors/tap-adwords/pre_requirements.txt
@@ -1,0 +1,3 @@
+# setuptools>58.0.0 is not compatible with googleads==17.0.0
+# remove this file whenever tap-adwards upgrades googleads version
+setuptools<=57.0.5

--- a/singer-connectors/tap-adwords/requirements.txt
+++ b/singer-connectors/tap-adwords/requirements.txt
@@ -1,2 +1,1 @@
-setuptools<=57.0.5
 tap-adwords==1.11.2

--- a/singer-connectors/tap-adwords/requirements.txt
+++ b/singer-connectors/tap-adwords/requirements.txt
@@ -1,1 +1,2 @@
+setuptools<=57.0.5
 tap-adwords==1.11.2


### PR DESCRIPTION
## Problem

`tap-adwords` causes connection workflow not be successful and crashes on it.

## Proposed changes

`tap-adwords` required version `17.0.0` of `googleads` and this version uses `use_2to3` which is removed in `setuptools` > `58.0.0`, so to be able to install `googleads==17.0.0` we need to downgrade `setuptools`

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
