### PR TITLE
[AP-913][Part-1] FastSync to pull supported columns only - mysql/mariadb

### DIFF
--- a/pipelinewise/fastsync/commons/type_mapping.py
+++ b/pipelinewise/fastsync/commons/type_mapping.py
@@ -6,33 +6,33 @@ from typing import Optional
 # Please keep this list up to date with Singer taps
 # https://github.com/transferwise/pipelinewise-tap-mysql/blob/master/tap_mysql/discover_utils.py
 
-__STRING_TYPES = {'char', 'varchar', 'text', 'tinytext', 'mediumtext', 'longtext', 'enum'}
+__MYSQL_STRING_TYPES = {'char', 'varchar', 'text', 'tinytext', 'mediumtext', 'longtext', 'enum'}
 
-__BINARY_TYPES = {'binary', 'varbinary'}
+__MYSQL_BINARY_TYPES = {'binary', 'varbinary'}
 
-__SPATIAL_TYPES = {
+__MYSQL_SPATIAL_TYPES = {
     'geometry', 'point', 'linestring', 'polygon', 'multipoint',
     'multilinestring', 'multipolygon', 'geometrycollection'
 }
 
-__FLOAT_TYPES = {'float', 'double', 'decimal'}
+__MYSQL_FLOAT_TYPES = {'float', 'double', 'decimal'}
 
-__JSON_TYPES = {'json'}
+__MYSQL_JSON_TYPES = {'json'}
 
-__BOOL_TYPES = {'bit', 'boolean', 'bool'}
+__MYSQL_BOOL_TYPES = {'bit', 'boolean', 'bool'}
 
-__DATETIME_TYPES = {'datetime', 'timestamp', 'time', 'date'}
+__MYSQL_DATETIME_TYPES = {'datetime', 'timestamp', 'time', 'date'}
 
-__INTEGER_TYPES = {'tinyint', 'int', 'smallint', 'mediumint', 'bigint'}
+__MYSQL_INTEGER_TYPES = {'tinyint', 'int', 'smallint', 'mediumint', 'bigint'}
 
-SUPPORTED_MYSQL_DATATYPES = (__STRING_TYPES
-                             .union(__FLOAT_TYPES)
-                             .union(__DATETIME_TYPES)
-                             .union(__BINARY_TYPES)
-                             .union(__SPATIAL_TYPES)
-                             .union(__BOOL_TYPES)
-                             .union(__JSON_TYPES)
-                             .union(__INTEGER_TYPES))
+SUPPORTED_MYSQL_DATATYPES = (__MYSQL_STRING_TYPES
+                             .union(__MYSQL_FLOAT_TYPES)
+                             .union(__MYSQL_DATETIME_TYPES)
+                             .union(__MYSQL_BINARY_TYPES)
+                             .union(__MYSQL_SPATIAL_TYPES)
+                             .union(__MYSQL_BOOL_TYPES)
+                             .union(__MYSQL_JSON_TYPES)
+                             .union(__MYSQL_INTEGER_TYPES))
 
 
 REDSHIFT_DEFAULT_VARCHAR_LENGTH = 10000
@@ -51,31 +51,31 @@ def __mysql_to_sf_mapper(mysql_column_datatype: str, mysql_column_type: str) -> 
     """
     target_type = None
 
-    if mysql_column_datatype in __STRING_TYPES:
+    if mysql_column_datatype in __MYSQL_STRING_TYPES:
         target_type = 'VARCHAR'
 
-    if mysql_column_datatype in __BINARY_TYPES:
+    elif mysql_column_datatype in __MYSQL_BINARY_TYPES:
         target_type = 'BINARY'
 
-    if mysql_column_datatype in __INTEGER_TYPES:
+    elif mysql_column_datatype in __MYSQL_INTEGER_TYPES:
         target_type = 'NUMBER'
 
         if mysql_column_datatype == 'tinyint' and mysql_column_type and mysql_column_type.startswith('tinyint(1)'):
             target_type = 'BOOLEAN'
 
-    if mysql_column_datatype in __BOOL_TYPES:
+    elif mysql_column_datatype in __MYSQL_BOOL_TYPES:
         target_type = 'BOOLEAN'
 
-    if mysql_column_datatype in __FLOAT_TYPES:
+    elif mysql_column_datatype in __MYSQL_FLOAT_TYPES:
         target_type = 'FLOAT'
 
-    if mysql_column_datatype in __DATETIME_TYPES:
+    elif mysql_column_datatype in __MYSQL_DATETIME_TYPES:
         target_type = 'TIMESTAMP_NTZ'
 
         if mysql_column_datatype == 'time':
             target_type = 'TIME'
 
-    if mysql_column_datatype in __JSON_TYPES or mysql_column_datatype in __SPATIAL_TYPES:
+    elif mysql_column_datatype in __MYSQL_JSON_TYPES or mysql_column_datatype in __MYSQL_SPATIAL_TYPES:
         target_type = 'VARIANT'
 
     return target_type
@@ -95,19 +95,19 @@ def __mysql_to_postgres_mapper(mysql_column_datatype: str, mysql_column_type: st
     """
     return_type = None
 
-    if mysql_column_datatype in __STRING_TYPES or mysql_column_datatype in __BINARY_TYPES:
+    if mysql_column_datatype in __MYSQL_STRING_TYPES or mysql_column_datatype in __MYSQL_BINARY_TYPES:
         return_type = 'CHARACTER VARYING'
 
-    if mysql_column_datatype in __JSON_TYPES or mysql_column_datatype in __SPATIAL_TYPES:
+    elif mysql_column_datatype in __MYSQL_JSON_TYPES or mysql_column_datatype in __MYSQL_SPATIAL_TYPES:
         return_type = 'JSONB'
 
-    if mysql_column_datatype in __BOOL_TYPES:
+    elif mysql_column_datatype in __MYSQL_BOOL_TYPES:
         return_type = 'BOOLEAN'
 
-    if mysql_column_datatype in __FLOAT_TYPES:
+    elif mysql_column_datatype in __MYSQL_FLOAT_TYPES:
         return_type = 'DOUBLE PRECISION'
 
-    if mysql_column_datatype in __INTEGER_TYPES:
+    elif mysql_column_datatype in __MYSQL_INTEGER_TYPES:
 
         if mysql_column_datatype == 'tinyint':
             return_type = 'BOOLEAN' if mysql_column_type and \
@@ -125,7 +125,7 @@ def __mysql_to_postgres_mapper(mysql_column_datatype: str, mysql_column_type: st
         else:
             return_type = 'NUMERIC'
 
-    if mysql_column_datatype in __DATETIME_TYPES:
+    elif mysql_column_datatype in __MYSQL_DATETIME_TYPES:
         return_type = 'TIME WITHOUT TIME ZONE' if mysql_column_datatype == 'time' else 'TIMESTAMP WITHOUT TIME ZONE'
 
     return return_type
@@ -145,25 +145,25 @@ def __mysql_to_bigquery_mapper(mysql_column_datatype: str, mysql_column_type: st
     """
     return_type = None
 
-    if mysql_column_datatype in __STRING_TYPES or \
-            mysql_column_datatype in __BINARY_TYPES \
-            or mysql_column_datatype in __SPATIAL_TYPES or \
-            mysql_column_datatype in __JSON_TYPES:
+    if mysql_column_datatype in __MYSQL_STRING_TYPES or \
+            mysql_column_datatype in __MYSQL_BINARY_TYPES \
+            or mysql_column_datatype in __MYSQL_SPATIAL_TYPES or \
+            mysql_column_datatype in __MYSQL_JSON_TYPES:
         return_type = 'STRING'
 
-    if mysql_column_datatype in __BOOL_TYPES:
+    elif mysql_column_datatype in __MYSQL_BOOL_TYPES:
         return_type = 'BOOL'
 
-    if mysql_column_datatype in __FLOAT_TYPES:
+    elif mysql_column_datatype in __MYSQL_FLOAT_TYPES:
         return_type = 'NUMERIC'
 
-    if mysql_column_datatype in __INTEGER_TYPES:
+    elif mysql_column_datatype in __MYSQL_INTEGER_TYPES:
         return_type = 'INT64'
 
         if mysql_column_datatype == 'tinyint' and mysql_column_type and mysql_column_type.startswith('tinyint(1)'):
             return_type = 'BOOLEAN'
 
-    if mysql_column_datatype in __DATETIME_TYPES:
+    elif mysql_column_datatype in __MYSQL_DATETIME_TYPES:
         if mysql_column_datatype == 'time':
             return_type = 'TIME'
         else:
@@ -187,7 +187,7 @@ def __mysql_to_redshift_mapper(mysql_column_datatype: str, mysql_column_type: st
 
     return_type = None
 
-    if mysql_column_datatype in __STRING_TYPES:
+    if mysql_column_datatype in __MYSQL_STRING_TYPES:
 
         return_type = f'CHARACTER VARYING({REDSHIFT_LONG_VARCHAR_LENGTH})'
 
@@ -197,25 +197,25 @@ def __mysql_to_redshift_mapper(mysql_column_datatype: str, mysql_column_type: st
         elif mysql_column_datatype == 'enum':
             return_type = f'CHARACTER VARYING({REDSHIFT_DEFAULT_VARCHAR_LENGTH})'
 
-    if mysql_column_datatype in __BINARY_TYPES or mysql_column_datatype in __JSON_TYPES:
+    elif mysql_column_datatype in __MYSQL_BINARY_TYPES or mysql_column_datatype in __MYSQL_JSON_TYPES:
         return_type = f'CHARACTER VARYING({REDSHIFT_LONG_VARCHAR_LENGTH})'
 
-    if mysql_column_datatype in __SPATIAL_TYPES:
+    elif mysql_column_datatype in __MYSQL_SPATIAL_TYPES:
         return_type = f'CHARACTER VARYING({REDSHIFT_DEFAULT_VARCHAR_LENGTH})'
 
-    if mysql_column_datatype in __BOOL_TYPES:
+    elif mysql_column_datatype in __MYSQL_BOOL_TYPES:
         return_type = 'BOOLEAN'
 
-    if mysql_column_datatype in __FLOAT_TYPES:
+    elif mysql_column_datatype in __MYSQL_FLOAT_TYPES:
         return_type = 'FLOAT'
 
-    if mysql_column_datatype in __INTEGER_TYPES:
+    elif mysql_column_datatype in __MYSQL_INTEGER_TYPES:
 
         return_type = 'NUMERIC NULL'
         if mysql_column_datatype == 'tinyint' and mysql_column_type and mysql_column_type.startswith('tinyint(1)'):
             return_type = 'BOOLEAN'
 
-    if mysql_column_datatype in __DATETIME_TYPES:
+    elif mysql_column_datatype in __MYSQL_DATETIME_TYPES:
         if mysql_column_datatype == 'time':
             return_type = 'TIME WITHOUT TIME ZONE'
         else:

--- a/pipelinewise/fastsync/commons/type_mapping.py
+++ b/pipelinewise/fastsync/commons/type_mapping.py
@@ -1,0 +1,227 @@
+"""
+ Support types in sources and their mapping to various targets
+"""
+from typing import Optional
+
+# Please keep this list up to date with Singer taps
+# https://github.com/transferwise/pipelinewise-tap-mysql/blob/master/tap_mysql/discover_utils.py
+
+__STRING_TYPES = {'char', 'varchar', 'text', 'tinytext', 'mediumtext', 'longtext', 'enum'}
+
+__BINARY_TYPES = {'binary', 'varbinary'}
+
+__SPATIAL_TYPES = {
+    'geometry', 'point', 'linestring', 'polygon', 'multipoint',
+    'multilinestring', 'multipolygon', 'geometrycollection'
+}
+
+__FLOAT_TYPES = {'float', 'double', 'decimal'}
+
+__JSON_TYPES = {'json'}
+
+__BOOL_TYPES = {'bit', 'boolean', 'bool'}
+
+__DATETIME_TYPES = {'datetime', 'timestamp', 'time', 'date'}
+
+__INTEGER_TYPES = {'tinyint', 'int', 'smallint', 'mediumint', 'bigint'}
+
+SUPPORTED_MYSQL_DATATYPES = (__STRING_TYPES
+                             .union(__FLOAT_TYPES)
+                             .union(__DATETIME_TYPES)
+                             .union(__BINARY_TYPES)
+                             .union(__SPATIAL_TYPES)
+                             .union(__BOOL_TYPES)
+                             .union(__JSON_TYPES)
+                             .union(__INTEGER_TYPES))
+
+
+REDSHIFT_DEFAULT_VARCHAR_LENGTH = 10000
+REDSHIFT_SHORT_VARCHAR_LENGTH = 256
+REDSHIFT_LONG_VARCHAR_LENGTH = 65535
+
+
+def __mysql_to_sf_mapper(mysql_column_datatype: str, mysql_column_type: str) -> Optional[str]:
+    """
+    Mapping Mysql/Mariadb DB column types to the equivalent in Snowflake
+    Args:
+        mysql_column_datatype: column datatype
+        mysql_column_type: column type
+
+    Returns: a string if column is supported, None otherwise
+    """
+    target_type = None
+
+    if mysql_column_datatype in __STRING_TYPES:
+        target_type = 'VARCHAR'
+
+    if mysql_column_datatype in __BINARY_TYPES:
+        target_type = 'BINARY'
+
+    if mysql_column_datatype in __INTEGER_TYPES:
+        target_type = 'NUMBER'
+
+        if mysql_column_datatype == 'tinyint' and mysql_column_type and mysql_column_type.startswith('tinyint(1)'):
+            target_type = 'BOOLEAN'
+
+    if mysql_column_datatype in __BOOL_TYPES:
+        target_type = 'BOOLEAN'
+
+    if mysql_column_datatype in __FLOAT_TYPES:
+        target_type = 'FLOAT'
+
+    if mysql_column_datatype in __DATETIME_TYPES:
+        target_type = 'TIMESTAMP_NTZ'
+
+        if mysql_column_datatype == 'time':
+            target_type = 'TIME'
+
+    if mysql_column_datatype in __JSON_TYPES or mysql_column_datatype in __SPATIAL_TYPES:
+        target_type = 'VARIANT'
+
+    return target_type
+
+
+MYSQL_TO_SNOWFLAKE_MAPPER = __mysql_to_sf_mapper
+
+
+def __mysql_to_postgres_mapper(mysql_column_datatype: str, mysql_column_type: str) -> Optional[str]:
+    """
+    Mapping Mysql/Mariadb DB column types to the equivalent in Postgres
+    Args:
+        mysql_column_datatype: column datatype
+        mysql_column_type: column type
+
+    Returns: a string if column is supported, None otherwise
+    """
+    return_type = None
+
+    if mysql_column_datatype in __STRING_TYPES or mysql_column_datatype in __BINARY_TYPES:
+        return_type = 'CHARACTER VARYING'
+
+    if mysql_column_datatype in __JSON_TYPES or mysql_column_datatype in __SPATIAL_TYPES:
+        return_type = 'JSONB'
+
+    if mysql_column_datatype in __BOOL_TYPES:
+        return_type = 'BOOLEAN'
+
+    if mysql_column_datatype in __FLOAT_TYPES:
+        return_type = 'DOUBLE PRECISION'
+
+    if mysql_column_datatype in __INTEGER_TYPES:
+
+        if mysql_column_datatype == 'tinyint':
+            return_type = 'BOOLEAN' if mysql_column_type and \
+                                       mysql_column_type.startswith('tinyint(1)') else 'SMALLINT NULL'
+
+        elif mysql_column_datatype == 'smallint':
+            return_type = 'SMALLINT NULL'
+
+        elif mysql_column_datatype == 'bigint':
+            return_type = 'BIGINT NULL'
+
+        elif mysql_column_datatype in ('int', 'mediumint'):
+            return_type = 'INTEGER NULL'
+
+        else:
+            return_type = 'NUMERIC'
+
+    if mysql_column_datatype in __DATETIME_TYPES:
+        return_type = 'TIME WITHOUT TIME ZONE' if mysql_column_datatype == 'time' else 'TIMESTAMP WITHOUT TIME ZONE'
+
+    return return_type
+
+
+MYSQL_TO_POSTGRES_MAPPER = __mysql_to_postgres_mapper
+
+
+def __mysql_to_bigquery_mapper(mysql_column_datatype: str, mysql_column_type: str) -> Optional[str]:
+    """
+    Mapping Mysql/Mariadb DB column types to the equivalent in BigQuery
+    Args:
+        mysql_column_datatype: column datatype
+        mysql_column_type: column type
+
+    Returns: a string if column is supported, None otherwise
+    """
+    return_type = None
+
+    if mysql_column_datatype in __STRING_TYPES or \
+            mysql_column_datatype in __BINARY_TYPES \
+            or mysql_column_datatype in __SPATIAL_TYPES or \
+            mysql_column_datatype in __JSON_TYPES:
+        return_type = 'STRING'
+
+    if mysql_column_datatype in __BOOL_TYPES:
+        return_type = 'BOOL'
+
+    if mysql_column_datatype in __FLOAT_TYPES:
+        return_type = 'NUMERIC'
+
+    if mysql_column_datatype in __INTEGER_TYPES:
+        return_type = 'INT64'
+
+        if mysql_column_datatype == 'tinyint' and mysql_column_type and mysql_column_type.startswith('tinyint(1)'):
+            return_type = 'BOOLEAN'
+
+    if mysql_column_datatype in __DATETIME_TYPES:
+        if mysql_column_datatype == 'time':
+            return_type = 'TIME'
+        else:
+            return_type = 'TIMESTAMP'
+
+    return return_type
+
+
+MYSQL_TO_BIGQUERY_MAPPER = __mysql_to_bigquery_mapper
+
+
+def __mysql_to_redshift_mapper(mysql_column_datatype: str, mysql_column_type: str) -> Optional[str]:
+    """
+    Mapping Mysql/Mariadb DB column types to the equivalent in Redshift
+    Args:
+        mysql_column_datatype: column datatype
+        mysql_column_type: column type
+
+    Returns: a string if column is supported, None otherwise
+    """
+
+    return_type = None
+
+    if mysql_column_datatype in __STRING_TYPES:
+
+        return_type = f'CHARACTER VARYING({REDSHIFT_LONG_VARCHAR_LENGTH})'
+
+        if mysql_column_datatype in {'char', 'varchar', 'tinytext'}:
+            return_type = f'CHARACTER VARYING({REDSHIFT_SHORT_VARCHAR_LENGTH})'
+
+        elif mysql_column_datatype == 'enum':
+            return_type = f'CHARACTER VARYING({REDSHIFT_DEFAULT_VARCHAR_LENGTH})'
+
+    if mysql_column_datatype in __BINARY_TYPES or mysql_column_datatype in __JSON_TYPES:
+        return_type = f'CHARACTER VARYING({REDSHIFT_LONG_VARCHAR_LENGTH})'
+
+    if mysql_column_datatype in __SPATIAL_TYPES:
+        return_type = f'CHARACTER VARYING({REDSHIFT_DEFAULT_VARCHAR_LENGTH})'
+
+    if mysql_column_datatype in __BOOL_TYPES:
+        return_type = 'BOOLEAN'
+
+    if mysql_column_datatype in __FLOAT_TYPES:
+        return_type = 'FLOAT'
+
+    if mysql_column_datatype in __INTEGER_TYPES:
+
+        return_type = 'NUMERIC NULL'
+        if mysql_column_datatype == 'tinyint' and mysql_column_type and mysql_column_type.startswith('tinyint(1)'):
+            return_type = 'BOOLEAN'
+
+    if mysql_column_datatype in __DATETIME_TYPES:
+        if mysql_column_datatype == 'time':
+            return_type = 'TIME WITHOUT TIME ZONE'
+        else:
+            return_type = 'TIMESTAMP WITHOUT TIME ZONE'
+
+    return return_type
+
+
+MYSQL_TO_REDSHIFT_MAPPER = __mysql_to_redshift_mapper

--- a/pipelinewise/fastsync/mysql_to_postgres.py
+++ b/pipelinewise/fastsync/mysql_to_postgres.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 import os
 import sys
-from functools import partial
-from argparse import Namespace
 import multiprocessing
-from typing import Union
 
+from typing import Union
+from argparse import Namespace
+from functools import partial
 from datetime import datetime
+
 from ..logger import Logger
 from .commons import utils
+from .commons.type_mapping import MYSQL_TO_POSTGRES_MAPPER
 from .commons.tap_mysql import FastSyncTapMySql
 from .commons.target_postgres import FastSyncTargetPostgres
 
@@ -22,57 +24,9 @@ REQUIRED_CONFIG_KEYS = {
 LOCK = multiprocessing.Lock()
 
 
-def tap_type_to_target_type(mysql_type, mysql_column_type):
-    """Data type mapping from MySQL to Postgres"""
-    return {
-        'char': 'CHARACTER VARYING',
-        'varchar': 'CHARACTER VARYING',
-        'binary': 'CHARACTER VARYING',
-        'varbinary': 'CHARACTER VARYING',
-        'blob': 'CHARACTER VARYING',
-        'tinyblob': 'CHARACTER VARYING',
-        'mediumblob': 'CHARACTER VARYING',
-        'longblob': 'CHARACTER VARYING',
-        'geometry': 'JSONB',
-        'point': 'JSONB',
-        'linestring': 'JSONB',
-        'polygon': 'JSONB',
-        'multipoint': 'JSONB',
-        'multilinestring': 'JSONB',
-        'multipolygon': 'JSONB',
-        'geometrycollection': 'JSONB',
-        'text': 'CHARACTER VARYING',
-        'tinytext': 'CHARACTER VARYING',
-        'mediumtext': 'CHARACTER VARYING',
-        'longtext': 'CHARACTER VARYING',
-        'enum': 'CHARACTER VARYING',
-        'int': 'INTEGER NULL',
-        'tinyint': 'BOOLEAN'
-        if mysql_column_type and mysql_column_type.startswith('tinyint(1)')
-        else 'SMALLINT NULL',
-        'smallint': 'SMALLINT NULL',
-        'mediumint': 'INTEGER NULL',
-        'bigint': 'BIGINT NULL',
-        'bit': 'BOOLEAN',
-        'decimal': 'DOUBLE PRECISION',
-        'double': 'DOUBLE PRECISION',
-        'float': 'DOUBLE PRECISION',
-        'bool': 'BOOLEAN',
-        'boolean': 'BOOLEAN',
-        'date': 'TIMESTAMP WITHOUT TIME ZONE',
-        'datetime': 'TIMESTAMP WITHOUT TIME ZONE',
-        'timestamp': 'TIMESTAMP WITHOUT TIME ZONE',
-        'time': 'TIME WITHOUT TIME ZONE',
-        'json': 'JSONB',
-    }.get(
-        mysql_type,
-        'CHARACTER VARYING',
-    )
-
-
 def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     """Sync one table"""
-    mysql = FastSyncTapMySql(args.tap, tap_type_to_target_type)
+    mysql = FastSyncTapMySql(args.tap, MYSQL_TO_POSTGRES_MAPPER)
     postgres = FastSyncTargetPostgres(args.target, args.transform)
 
     try:

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -11,6 +11,7 @@ from typing import Union
 from datetime import datetime
 from ..logger import Logger
 from .commons import utils
+from .commons.type_mapping import MYSQL_TO_SNOWFLAKE_MAPPER
 from .commons.tap_mysql import FastSyncTapMySql
 from .commons.target_snowflake import FastSyncTargetSnowflake
 
@@ -33,55 +34,10 @@ REQUIRED_CONFIG_KEYS = {
 LOCK = multiprocessing.Lock()
 
 
-def tap_type_to_target_type(mysql_type, mysql_column_type):
-    """Data type mapping from MySQL to Snowflake"""
-    return {
-        'char': 'VARCHAR',
-        'varchar': 'VARCHAR',
-        'binary': 'BINARY',
-        'varbinary': 'BINARY',
-        'blob': 'VARCHAR',
-        'tinyblob': 'VARCHAR',
-        'mediumblob': 'VARCHAR',
-        'longblob': 'VARCHAR',
-        'geometry': 'VARIANT',
-        'point': 'VARIANT',
-        'linestring': 'VARIANT',
-        'polygon': 'VARIANT',
-        'multipoint': 'VARIANT',
-        'multilinestring': 'VARIANT',
-        'multipolygon': 'VARIANT',
-        'geometrycollection': 'VARIANT',
-        'text': 'VARCHAR',
-        'tinytext': 'VARCHAR',
-        'mediumtext': 'VARCHAR',
-        'longtext': 'VARCHAR',
-        'enum': 'VARCHAR',
-        'int': 'NUMBER',
-        'tinyint': 'BOOLEAN'
-        if mysql_column_type and mysql_column_type.startswith('tinyint(1)')
-        else 'NUMBER',
-        'smallint': 'NUMBER',
-        'mediumint': 'NUMBER',
-        'bigint': 'NUMBER',
-        'bit': 'BOOLEAN',
-        'decimal': 'FLOAT',
-        'double': 'FLOAT',
-        'float': 'FLOAT',
-        'bool': 'BOOLEAN',
-        'boolean': 'BOOLEAN',
-        'date': 'TIMESTAMP_NTZ',
-        'datetime': 'TIMESTAMP_NTZ',
-        'timestamp': 'TIMESTAMP_NTZ',
-        'time': 'TIME',
-        'json': 'VARIANT',
-    }.get(mysql_type, 'VARCHAR')
-
-
 # pylint: disable=too-many-locals
 def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     """Sync one table"""
-    mysql = FastSyncTapMySql(args.tap, tap_type_to_target_type)
+    mysql = FastSyncTapMySql(args.tap, MYSQL_TO_SNOWFLAKE_MAPPER)
     snowflake = FastSyncTargetSnowflake(args.target, args.transform)
     tap_id = args.target.get('tap_id')
     archive_load_files = args.target.get('archive_load_files', False)

--- a/tests/end_to_end/helpers/assertions.py
+++ b/tests/end_to_end/helpers/assertions.py
@@ -240,7 +240,7 @@ def assert_row_counts_equal(
     assert row_counts_in_target == row_counts_in_source
 
 
-# pylint: disable=too-many-locals
+# pylint: disable=too-many-locals,too-many-statements
 def assert_all_columns_exist(
     tap_query_runner_fn: callable,
     target_query_runner_fn: callable,

--- a/tests/end_to_end/test_target_bigquery.py
+++ b/tests/end_to_end/test_target_bigquery.py
@@ -7,7 +7,7 @@ from random import randint
 import bson
 import pytest
 from bson import Timestamp
-from pipelinewise.fastsync import mysql_to_bigquery
+from pipelinewise.fastsync.commons.type_mapping import MYSQL_TO_BIGQUERY_MAPPER
 
 from .helpers import tasks
 from .helpers import assertions
@@ -81,7 +81,7 @@ class TestTargetBigquery:
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.e2e.run_query_target_bigquery,
-            mysql_to_bigquery.tap_type_to_target_type,
+            MYSQL_TO_BIGQUERY_MAPPER,
         )
 
         # 2. Make changes in MariaDB source database
@@ -128,7 +128,7 @@ class TestTargetBigquery:
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.e2e.run_query_target_bigquery,
-            mysql_to_bigquery.tap_type_to_target_type,
+            MYSQL_TO_BIGQUERY_MAPPER,
             {'blob_col'},
         )
 
@@ -168,7 +168,7 @@ class TestTargetBigquery:
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.run_query_target_bigquery,
-            mysql_to_bigquery.tap_type_to_target_type,
+            MYSQL_TO_BIGQUERY_MAPPER,
         )
 
     # pylint: disable=invalid-name
@@ -186,7 +186,7 @@ class TestTargetBigquery:
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.run_query_target_bigquery,
-            mysql_to_bigquery.tap_type_to_target_type,
+            MYSQL_TO_BIGQUERY_MAPPER,
         )
 
     # pylint: disable=invalid-name
@@ -204,7 +204,7 @@ class TestTargetBigquery:
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.run_query_target_bigquery,
-            mysql_to_bigquery.tap_type_to_target_type,
+            MYSQL_TO_BIGQUERY_MAPPER,
         )
 
     # pylint: disable=invalid-name

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -1,13 +1,14 @@
 import decimal
 import os
 import uuid
-from datetime import datetime
-from random import randint
-
 import bson
 import pytest
+
+from datetime import datetime
+from random import randint
 from bson import Timestamp
-from pipelinewise.fastsync import mysql_to_postgres
+
+from pipelinewise.fastsync.commons.type_mapping import MYSQL_TO_POSTGRES_MAPPER
 
 from .helpers import tasks
 from .helpers import assertions
@@ -81,7 +82,7 @@ class TestTargetPostgres:
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.run_query_target_postgres,
-            mysql_to_postgres.tap_type_to_target_type,
+            MYSQL_TO_POSTGRES_MAPPER,
         )
 
         # 2. Make changes in MariaDB source database
@@ -145,7 +146,7 @@ class TestTargetPostgres:
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.run_query_target_postgres,
-            mysql_to_postgres.tap_type_to_target_type,
+            MYSQL_TO_POSTGRES_MAPPER,
             {'blob_col'},
         )
 
@@ -185,7 +186,7 @@ class TestTargetPostgres:
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.run_query_target_postgres,
-            mysql_to_postgres.tap_type_to_target_type,
+            MYSQL_TO_POSTGRES_MAPPER,
         )
 
     # pylint: disable=invalid-name

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -3,13 +3,14 @@ import gzip
 import os
 import tempfile
 import uuid
-from datetime import datetime
-from random import randint
-
 import bson
 import pytest
+
+from datetime import datetime
+from random import randint
 from bson import Timestamp
-from pipelinewise.fastsync import mysql_to_snowflake
+
+from pipelinewise.fastsync.commons.type_mapping import MYSQL_TO_SNOWFLAKE_MAPPER
 
 from .helpers import tasks
 from .helpers import assertions
@@ -84,7 +85,7 @@ class TestTargetSnowflake:
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.e2e.run_query_target_snowflake,
-            mysql_to_snowflake.tap_type_to_target_type,
+            MYSQL_TO_SNOWFLAKE_MAPPER,
         )
 
         # 2. Make changes in MariaDB source database
@@ -131,7 +132,7 @@ class TestTargetSnowflake:
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.e2e.run_query_target_snowflake,
-            mysql_to_snowflake.tap_type_to_target_type,
+            MYSQL_TO_SNOWFLAKE_MAPPER,
             {'blob_col'},
         )
 
@@ -171,7 +172,7 @@ class TestTargetSnowflake:
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.run_query_target_snowflake,
-            mysql_to_snowflake.tap_type_to_target_type,
+            MYSQL_TO_SNOWFLAKE_MAPPER,
         )
 
     # pylint: disable=invalid-name
@@ -189,7 +190,7 @@ class TestTargetSnowflake:
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.run_query_target_snowflake,
-            mysql_to_snowflake.tap_type_to_target_type,
+            MYSQL_TO_SNOWFLAKE_MAPPER,
         )
 
     # pylint: disable=invalid-name
@@ -207,7 +208,7 @@ class TestTargetSnowflake:
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.run_query_target_snowflake,
-            mysql_to_snowflake.tap_type_to_target_type,
+            MYSQL_TO_SNOWFLAKE_MAPPER,
         )
 
     # pylint: disable=invalid-name

--- a/tests/units/fastsync/commons/test_type_mapping.py
+++ b/tests/units/fastsync/commons/test_type_mapping.py
@@ -1,0 +1,98 @@
+from unittest import TestCase
+from pipelinewise.fastsync.commons.type_mapping import (
+    MYSQL_TO_POSTGRES_MAPPER, MYSQL_TO_SNOWFLAKE_MAPPER,
+    MYSQL_TO_REDSHIFT_MAPPER, MYSQL_TO_BIGQUERY_MAPPER
+)
+
+
+class TestTypeMapping(TestCase):
+    """
+    Unit test for Type Mapping in FastSync components
+    """
+    def test_mysql_type_to_pg_mapper(self):
+        """
+        tests that mysql types are mapped correctly to postgres types
+        """
+        self.assertEqual('CHARACTER VARYING', MYSQL_TO_POSTGRES_MAPPER('binary', None))
+
+        self.assertEqual('JSONB', MYSQL_TO_POSTGRES_MAPPER('geometry', None))
+
+        self.assertEqual('BOOLEAN', MYSQL_TO_POSTGRES_MAPPER('bit', None))
+        self.assertEqual('BOOLEAN', MYSQL_TO_POSTGRES_MAPPER('tinyint', 'tinyint(1)'))
+
+        self.assertEqual('JSONB', MYSQL_TO_POSTGRES_MAPPER('json', None))
+
+        self.assertEqual('INTEGER NULL', MYSQL_TO_POSTGRES_MAPPER('int', None))
+
+        self.assertEqual('DOUBLE PRECISION', MYSQL_TO_POSTGRES_MAPPER('double', None))
+
+        self.assertEqual('TIMESTAMP WITHOUT TIME ZONE', MYSQL_TO_POSTGRES_MAPPER('timestamp', None))
+
+        self.assertEqual('TIME WITHOUT TIME ZONE', MYSQL_TO_POSTGRES_MAPPER('time', None))
+
+        self.assertEqual('CHARACTER VARYING', MYSQL_TO_POSTGRES_MAPPER('longtext', None))
+
+    def test_mysql_to_pg_with_undefined_type_returns_none(self):
+        """test that an unsupported mysql datatype returns None"""
+        self.assertIsNone(MYSQL_TO_POSTGRES_MAPPER('random-type', 'random-type'))
+
+    def test_mysql_type_to_sf_mapper(self):
+        """
+        tests that mysql types are mapped correctly to snowflake types
+        """
+        self.assertEqual('BINARY', MYSQL_TO_SNOWFLAKE_MAPPER('binary', None))
+
+        self.assertEqual('VARIANT', MYSQL_TO_SNOWFLAKE_MAPPER('geometry', None))
+
+        self.assertEqual('BOOLEAN', MYSQL_TO_SNOWFLAKE_MAPPER('bit', None))
+        self.assertEqual('BOOLEAN', MYSQL_TO_SNOWFLAKE_MAPPER('tinyint', 'tinyint(1)'))
+
+        self.assertEqual('VARIANT', MYSQL_TO_SNOWFLAKE_MAPPER('json', None))
+
+        self.assertEqual('NUMBER', MYSQL_TO_SNOWFLAKE_MAPPER('int', None))
+
+        self.assertEqual('FLOAT', MYSQL_TO_SNOWFLAKE_MAPPER('double', None))
+
+        self.assertEqual('TIMESTAMP_NTZ', MYSQL_TO_SNOWFLAKE_MAPPER('timestamp', None))
+
+        self.assertEqual('TIME', MYSQL_TO_SNOWFLAKE_MAPPER('time', None))
+
+        self.assertEqual('VARCHAR', MYSQL_TO_SNOWFLAKE_MAPPER('longtext', None))
+
+    def test_mysql_to_sf_with_undefined_type_returns_none(self):
+        """test that an unsupported mysql datatype returns None"""
+        self.assertIsNone(MYSQL_TO_SNOWFLAKE_MAPPER('random-type', 'random-type'))
+
+    def test_mysql_to_redshift_with_defined_type_returns_target_type(self):
+        """
+        tests that mysql types are mapped correctly to redshift types
+        """
+        self.assertEqual('CHARACTER VARYING(65535)', MYSQL_TO_REDSHIFT_MAPPER('binary', None))
+        self.assertEqual('CHARACTER VARYING(10000)', MYSQL_TO_REDSHIFT_MAPPER('geometry', None))
+        self.assertEqual('CHARACTER VARYING(10000)', MYSQL_TO_REDSHIFT_MAPPER('point', None))
+        self.assertEqual('CHARACTER VARYING(10000)', MYSQL_TO_REDSHIFT_MAPPER('linestring', None))
+        self.assertEqual('CHARACTER VARYING(10000)', MYSQL_TO_REDSHIFT_MAPPER('polygon', None))
+        self.assertEqual('CHARACTER VARYING(10000)', MYSQL_TO_REDSHIFT_MAPPER('multipoint', None))
+        self.assertEqual('CHARACTER VARYING(10000)', MYSQL_TO_REDSHIFT_MAPPER('multilinestring', None))
+        self.assertEqual('CHARACTER VARYING(10000)', MYSQL_TO_REDSHIFT_MAPPER('multipolygon', None))
+        self.assertEqual('CHARACTER VARYING(10000)', MYSQL_TO_REDSHIFT_MAPPER('geometrycollection', None))
+
+    def test_mysql_to_redshift_with_undefined_type_returns_none(self):
+        """test that an unsupported mysql datatype returns None"""
+        self.assertIsNone(MYSQL_TO_REDSHIFT_MAPPER('random-type', 'random-type'))
+
+    def test_mysql_to_bq_with_defined_type_returns_target_type(self):
+        """test that supported mysql datatypes returns equivalent in Bigquery"""
+        self.assertEqual('STRING', MYSQL_TO_BIGQUERY_MAPPER('binary', None))
+        self.assertEqual('STRING', MYSQL_TO_BIGQUERY_MAPPER('geometry', None))
+        self.assertEqual('STRING', MYSQL_TO_BIGQUERY_MAPPER('point', None))
+        self.assertEqual('STRING', MYSQL_TO_BIGQUERY_MAPPER('linestring', None))
+        self.assertEqual('STRING', MYSQL_TO_BIGQUERY_MAPPER('polygon', None))
+        self.assertEqual('STRING', MYSQL_TO_BIGQUERY_MAPPER('multipoint', None))
+        self.assertEqual('STRING', MYSQL_TO_BIGQUERY_MAPPER('multilinestring', None))
+        self.assertEqual('STRING', MYSQL_TO_BIGQUERY_MAPPER('multipolygon', None))
+        self.assertEqual('STRING', MYSQL_TO_BIGQUERY_MAPPER('geometrycollection', None))
+
+    def test_mysql_to_bq_with_undefined_type_returns_none(self):
+        """test that an unsupported mysql datatype returns None"""
+        self.assertIsNone(MYSQL_TO_BIGQUERY_MAPPER('random-type', 'random-type'))

--- a/tests/units/fastsync/test_mongodb_to_bigquery.py
+++ b/tests/units/fastsync/test_mongodb_to_bigquery.py
@@ -15,7 +15,7 @@ TARGET = 'FastSyncTargetBigquery'
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
 class MongoDBToBigquery(unittest.TestCase):
     """
-    Unit tests for fastsync MongoDB to postgres
+    Unit tests for fastsync MongoDB to BigQuery
     """
 
     def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(

--- a/tests/units/fastsync/test_mysql_to_bigquery.py
+++ b/tests/units/fastsync/test_mysql_to_bigquery.py
@@ -2,7 +2,6 @@ import unittest
 from . import assertions
 
 from pipelinewise.fastsync.mysql_to_bigquery import (
-    tap_type_to_target_type,
     sync_table,
     main_impl,
 )
@@ -17,25 +16,6 @@ class MySQLToBigQuery(unittest.TestCase):
     """
     Unit tests for fastsync mysql to bigquery
     """
-
-    def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(
-        self,
-    ):
-        self.assertEqual('STRING', tap_type_to_target_type('binary', None))
-        self.assertEqual('STRING', tap_type_to_target_type('geometry', None))
-        self.assertEqual('STRING', tap_type_to_target_type('point', None))
-        self.assertEqual('STRING', tap_type_to_target_type('linestring', None))
-        self.assertEqual('STRING', tap_type_to_target_type('polygon', None))
-        self.assertEqual('STRING', tap_type_to_target_type('multipoint', None))
-        self.assertEqual('STRING', tap_type_to_target_type('multilinestring', None))
-        self.assertEqual('STRING', tap_type_to_target_type('multipolygon', None))
-        self.assertEqual('STRING', tap_type_to_target_type('geometrycollection', None))
-
-    def test_tap_type_to_target_type_with_undefined_tap_type_returns_STRING(self):
-        self.assertEqual(
-            'STRING', tap_type_to_target_type('random-type', 'random-type')
-        )
-
     @staticmethod
     def test_sync_table_runs_successfully_returns_true():
         assertions.assert_sync_table_returns_true_on_success(

--- a/tests/units/fastsync/test_mysql_to_postgres.py
+++ b/tests/units/fastsync/test_mysql_to_postgres.py
@@ -1,11 +1,7 @@
 import unittest
 from . import assertions
 
-from pipelinewise.fastsync.mysql_to_postgres import (
-    tap_type_to_target_type,
-    sync_table,
-    main_impl,
-)
+from pipelinewise.fastsync.mysql_to_postgres import sync_table, main_impl
 
 PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.mysql_to_postgres'
 TAP = 'FastSyncTapMySql'
@@ -13,31 +9,10 @@ TARGET = 'FastSyncTargetPostgres'
 
 
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
-class S3CsvToPostgres(unittest.TestCase):
+class MysqlToPostgres(unittest.TestCase):
     """
     Unit tests for fastsync mysql to postgres
     """
-
-    def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(
-        self,
-    ):
-        self.assertEqual('CHARACTER VARYING', tap_type_to_target_type('binary', None))
-        self.assertEqual('JSONB', tap_type_to_target_type('geometry', None))
-        self.assertEqual('JSONB', tap_type_to_target_type('point', None))
-        self.assertEqual('JSONB', tap_type_to_target_type('linestring', None))
-        self.assertEqual('JSONB', tap_type_to_target_type('polygon', None))
-        self.assertEqual('JSONB', tap_type_to_target_type('multipoint', None))
-        self.assertEqual('JSONB', tap_type_to_target_type('multilinestring', None))
-        self.assertEqual('JSONB', tap_type_to_target_type('multipolygon', None))
-        self.assertEqual('JSONB', tap_type_to_target_type('geometrycollection', None))
-
-    def test_tap_type_to_target_type_with_undefined_tap_type_returns_CHARACTER_VARYING(
-        self,
-    ):
-        self.assertEqual(
-            'CHARACTER VARYING', tap_type_to_target_type('random-type', 'random-type')
-        )
-
     @staticmethod
     def test_sync_table_runs_successfully_returns_true():
         assertions.assert_sync_table_returns_true_on_success(

--- a/tests/units/fastsync/test_mysql_to_redshift.py
+++ b/tests/units/fastsync/test_mysql_to_redshift.py
@@ -1,11 +1,7 @@
 import unittest
 from . import assertions
 
-from pipelinewise.fastsync.mysql_to_redshift import (
-    tap_type_to_target_type,
-    sync_table,
-    main_impl,
-)
+from pipelinewise.fastsync.mysql_to_redshift import sync_table, main_impl
 
 PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.mysql_to_redshift'
 TAP = 'FastSyncTapMySql'
@@ -13,51 +9,10 @@ TARGET = 'FastSyncTargetRedshift'
 
 
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
-class S3CsvToPostgres(unittest.TestCase):
+class MysqlToRedshift(unittest.TestCase):
     """
     Unit tests for fastsync mysql to redshift
     """
-
-    def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(
-        self,
-    ):
-        self.assertEqual(
-            'CHARACTER VARYING(65535)', tap_type_to_target_type('binary', None)
-        )
-        self.assertEqual(
-            'CHARACTER VARYING(10000)', tap_type_to_target_type('geometry', None)
-        )
-        self.assertEqual(
-            'CHARACTER VARYING(10000)', tap_type_to_target_type('point', None)
-        )
-        self.assertEqual(
-            'CHARACTER VARYING(10000)', tap_type_to_target_type('linestring', None)
-        )
-        self.assertEqual(
-            'CHARACTER VARYING(10000)', tap_type_to_target_type('polygon', None)
-        )
-        self.assertEqual(
-            'CHARACTER VARYING(10000)', tap_type_to_target_type('multipoint', None)
-        )
-        self.assertEqual(
-            'CHARACTER VARYING(10000)', tap_type_to_target_type('multilinestring', None)
-        )
-        self.assertEqual(
-            'CHARACTER VARYING(10000)', tap_type_to_target_type('multipolygon', None)
-        )
-        self.assertEqual(
-            'CHARACTER VARYING(10000)',
-            tap_type_to_target_type('geometrycollection', None),
-        )
-
-    def test_tap_type_to_target_type_with_undefined_tap_type_returns_CHARACTER_VARYING(
-        self,
-    ):
-        self.assertEqual(
-            'CHARACTER VARYING(10000)',
-            tap_type_to_target_type('random-type', 'random-type'),
-        )
-
     @staticmethod
     def test_sync_table_runs_successfully_returns_true():
         assertions.assert_sync_table_returns_true_on_success(

--- a/tests/units/fastsync/test_mysql_to_snowflake.py
+++ b/tests/units/fastsync/test_mysql_to_snowflake.py
@@ -1,11 +1,7 @@
 import unittest
 from . import assertions
 
-from pipelinewise.fastsync.mysql_to_snowflake import (
-    tap_type_to_target_type,
-    sync_table,
-    main_impl,
-)
+from pipelinewise.fastsync.mysql_to_snowflake import sync_table, main_impl
 
 PACKAGE_IN_SCOPE = 'pipelinewise.fastsync.mysql_to_snowflake'
 TAP = 'FastSyncTapMySql'
@@ -13,31 +9,10 @@ TARGET = 'FastSyncTargetSnowflake'
 
 
 # pylint: disable=missing-function-docstring,invalid-name,no-self-use
-class S3CsvToPostgres(unittest.TestCase):
+class MysqlToSnowflake(unittest.TestCase):
     """
     Unit tests for fastsync mysql to snowflake
     """
-
-    def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(
-        self,
-    ):
-        self.assertEqual('BINARY', tap_type_to_target_type('binary', None))
-        self.assertEqual('VARIANT', tap_type_to_target_type('geometry', None))
-        self.assertEqual('VARIANT', tap_type_to_target_type('point', None))
-        self.assertEqual('VARIANT', tap_type_to_target_type('linestring', None))
-        self.assertEqual('VARIANT', tap_type_to_target_type('polygon', None))
-        self.assertEqual('VARIANT', tap_type_to_target_type('multipoint', None))
-        self.assertEqual('VARIANT', tap_type_to_target_type('multilinestring', None))
-        self.assertEqual('VARIANT', tap_type_to_target_type('multipolygon', None))
-        self.assertEqual('VARIANT', tap_type_to_target_type('geometrycollection', None))
-
-    def test_tap_type_to_target_type_with_undefined_tap_type_returns_CHARACTER_VARYING(
-        self,
-    ):
-        self.assertEqual(
-            'VARCHAR', tap_type_to_target_type('random-type', 'random-type')
-        )
-
     @staticmethod
     def test_sync_table_runs_successfully_returns_true():
         assertions.assert_sync_table_returns_true_on_success(


### PR DESCRIPTION
## Problem

FastSync currenctly when extracting data from sources, it pulls all columns even the ones with types unsupported by the equivalent taps making the FastSync and Singer not in sync.

## Proposed changes

__This PR is for Mysql/mariadb__

Add the list of supported column types in mysql/mariadb and centralize the mapping in one file to avoid repetition in every mysql -> target X file.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
