### PR TITLE
Handle dates out of range in PG source

### DIFF
--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -413,7 +413,10 @@ class FastSyncTapPostgres:
                 data_type,
                 CASE
                     WHEN data_type = 'ARRAY' THEN 'array_to_json("' || column_name || '") AS ' || column_name
-                    WHEN data_type = 'date' THEN column_name || '::{date_type} AS ' || column_name
+                    WHEN data_type = 'date' THEN
+                       'CASE WHEN "' ||column_name|| E'" < \\'0001-01-01\\' '
+                            'OR "' ||column_name|| E'" > \\'9999-12-31\\' THEN \\'9999-12-31\\' '
+                            'ELSE "' ||column_name|| '"::{date_type} END AS "' ||column_name|| '"'
                     WHEN udt_name = 'time' THEN 'replace("' || column_name || E'"::varchar,\\\'24:00:00\\\',\\\'00:00:00\\\') AS ' || column_name
                     WHEN udt_name = 'timetz' THEN 'replace(("' || column_name || E'" at time zone \'\'UTC\'\')::time::varchar,\\\'24:00:00\\\',\\\'00:00:00\\\') AS ' || column_name
                     WHEN udt_name in ('timestamp', 'timestamptz') THEN

--- a/tests/db/tap_postgres_data.sql
+++ b/tests/db/tap_postgres_data.sql
@@ -20,39 +20,40 @@ CREATE TABLE edgydata(
     cjson json,
     cjsonb jsonb,
     cvarchar varchar,
+    "date" date,
     PRIMARY KEY (cid)
 );
 
-insert into edgydata (ctimentz, ctimetz, cjson, cjsonb, cvarchar) values
-    (null, null, null, null, null),
-    ('23:00:15', '23:00:15+00', null, null, null),
-    ('12:00:15', '12:00:15+00:00', null, null, null),
-    ('12:00:15', '12:00:15+0300', null, null, null),
-    ('12:00:15', '12:00:15-0300', null, null, null),
-    ('24:00:00', '24:00:00', null, null, null),
-    ('24:00:00', '24:00:00+0000', null, null, null),
-    ('24:00:00', '24:00:00-0100', null, null, null),
-    ('00:00:00', '00:00:00', null, null, null),
-    (null, null, null, null,'Lorem ipsum dolor sit amet'),
-    (null, null, null, null,'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.'),
-    (null, null, null, null,'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช'),
-    (null, null, null, null,E'Special Characters: ["/\\,!@£$%^&*()]'),
-    (null, null, '[]', '[]', '[]' ),
-    (null, null, '{}', '{}', '{}'),
-    (null, null, '[{}, {}]', '[{}, {}]',  '[{}, {}]'),
+insert into edgydata (ctimentz, ctimetz, cjson, cjsonb, cvarchar, "date") values
+    (null, null, null, null, null, DATE '20107-05-28'),
+    ('23:00:15', '23:00:15+00', null, null, null, DATE '2011-09-10'),
+    ('12:00:15', '12:00:15+00:00', null, null, null, DATE '2019-12-10'),
+    ('12:00:15', '12:00:15+0300', null, null, null, DATE '0001-09-10'),
+    ('12:00:15', '12:00:15-0300', null, null, null, DATE '1990-09-30'),
+    ('24:00:00', '24:00:00', null, null, null, null),
+    ('24:00:00', '24:00:00+0000', null, null, null, DATE '333333-09-30'),
+    ('24:00:00', '24:00:00-0100', null, null, null, DATE '1990-09-30'),
+    ('00:00:00', '00:00:00', null, null, null, DATE '2021-01-30'),
+    (null, null, null, null,'Lorem ipsum dolor sit amet', DATE '2021-01-30'),
+    (null, null, null, null,'Chinese: 和毛泽东 <<重上井冈山>>. 严永欣, 一九八八年.', DATE '2021-01-30'),
+    (null, null, null, null,'Thai: แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช', DATE '2021-01-30'),
+    (null, null, null, null,E'Special Characters: ["/\\,!@£$%^&*()]', DATE '2021-01-30'),
+    (null, null, '[]', '[]', '[]' , DATE '2021-01-30'),
+    (null, null, '{}', '{}', '{}', DATE '2021-01-30'),
+    (null, null, '[{}, {}]', '[{}, {}]',  '[{}, {}]', DATE '2021-01-30'),
     (null, null, '[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]',
         '[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]',
-        '[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]'),
-    (null, null, E'{"key": "Value\'s One"}', E'{"key": "Value\'s One"}', E'{"key": "Value\'s One"}'),
+        '[{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}]', DATE '2021-01-30'),
+    (null, null, E'{"key": "Value\'s One"}', E'{"key": "Value\'s One"}', E'{"key": "Value\'s One"}', DATE '2021-01-30'),
     (null, null, E'[{"key": "Value\'s One", "actions": []},{"key": "Value\U00000027s Two", "actions": []}]',
         E'[{"key": "Value\'s One", "actions": []},{"key": "Value\U00000027s Two", "actions": []}]',
-        E'[{"key": "Value\'s One", "actions": []},{"key": "Value\U00000027s Two", "actions": []}]'),
-    (null, null, null, null,'	'),
+        E'[{"key": "Value\'s One", "actions": []},{"key": "Value\U00000027s Two", "actions": []}]', DATE '2021-01-30'),
+    (null, null, null, null,'	', DATE '2021-01-30'),
     (null, null, null, null,'Enter	The
-Ninja'),
+Ninja', DATE '2021-01-30'),
     (null, null, null, null,'Liewe
-Maatjies'),
-    (null, null, null, null,'Liewe	Maatjies')
+Maatjies', DATE '2021-01-30'),
+    (null, null, null, null,'Liewe	Maatjies', DATE '2021-01-30')
 ;
 
 COMMIT;


### PR DESCRIPTION
## Problem

PG Source can contain dates outside of the range [0001-01-01, 9999-12-31].
These dates cause FS and Singer replication to fail or results in invalid data.

Note: I haven't been able to produce a date < 0001-01-01 in postgres, but there could be some circumstance I'm not aware of, plus I wanted to keep consistent with the existing fix for timestamps so I made my change with that in mind.

## Proposed changes

I fixed a similar issue [in pipelinewise-tap-postgres](https://github.com/transferwise/pipelinewise-tap-postgres/pull/122#issuecomment-919781272), and was asked to take a stab at this fix.

I used [the fix for for handling out of range timestamps](https://github.com/transferwise/pipelinewise/pull/521) as a template.

I don't use pipelinewise so I'm not sure of the best way to test this, but I ran the modified query against a table with a `date` column called `start_date` and got the following for `safe_sql_value`:

```sql
CASE WHEN "start_date" < '0001-01-01' OR "start_date" > '9999-12-31' THEN '9999-12-31' ELSE "start_date"::date END AS "start_date"
```

Prior to the changes I got:

```sql
start_date::date AS start_date
```

### FS
Use push down processing to check the dates range and fallback to 9999-12-31 if they are outside of the above range.

### Singer replication
Use transferwise/pipelinewise-tap-postgres#122

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
