### PR TITLE
[AP-1058] fixed proc.info parsing in a case cmdline is None!

### DIFF
--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -559,7 +559,7 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
 
         # Should not have any remaining Pipelinewise related linux process
         for proc in psutil.process_iter(['cmdline']):
-            full_command = ' '.join(proc.info['cmdline'])
+            full_command = ' '.join(proc.info['cmdline']) if proc.info['cmdline'] else ''
             assert re.match('scheduler|pipelinewise|tap|target', full_command) is None
 
     def test_command_sync_tables(self):


### PR DESCRIPTION
## Problem

In some cases `proc.info['cmdline']` can be `None` and it causes this test crashes.

## Proposed changes

join the `proc.info['cmdline']` if it is not `None` otherwise an empty string.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
