### PR TITLE
[AP-992] make a postfix for sf schemas in e2e

### DIFF
--- a/tests/end_to_end/helpers/env.py
+++ b/tests/end_to_end/helpers/env.py
@@ -4,6 +4,7 @@ import glob
 import boto3
 import shutil
 import subprocess
+import uuid
 
 from dotenv import load_dotenv
 from . import db
@@ -21,6 +22,7 @@ class E2EEnv:
     on the supported databases"""
 
     def __init__(self, project_dir):
+        self.sf_schema_postfix = f'_{str(uuid.uuid4())[:8]}'
         self._load_env()
 
         # Generate test project YAMLs from templates
@@ -195,6 +197,10 @@ class E2EEnv:
                         ),
                         'optional': True,
                     },
+                    'SCHEMA_POSTFIX': {
+                        'value': os.environ.get('TARGET_SNOWFLAKE_SCHEMA_POSTFIX', self.sf_schema_postfix),
+                        'optional': True,
+                    }
                 },
             },
             # ------------------------------------------------------------------
@@ -588,25 +594,25 @@ class E2EEnv:
     def setup_target_snowflake(self):
         """Clean snowflake target database and prepare for test run"""
         self.run_query_target_snowflake(
-            'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres CASCADE'
+            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres{self.sf_schema_postfix} CASCADE'
         )
         self.run_query_target_snowflake(
-            'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres_public2 CASCADE'
+            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres_public2{self.sf_schema_postfix} CASCADE'
         )
         self.run_query_target_snowflake(
-            'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres_logical1 CASCADE'
+            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres_logical1{self.sf_schema_postfix} CASCADE'
         )
         self.run_query_target_snowflake(
-            'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres_logical2 CASCADE'
+            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres_logical2{self.sf_schema_postfix} CASCADE'
         )
         self.run_query_target_snowflake(
-            'DROP SCHEMA IF EXISTS ppw_e2e_tap_mysql CASCADE'
+            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_mysql{self.sf_schema_postfix} CASCADE'
         )
         self.run_query_target_snowflake(
-            'DROP SCHEMA IF EXISTS ppw_e2e_tap_s3_csv CASCADE'
+            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_s3_csv{self.sf_schema_postfix} CASCADE'
         )
         self.run_query_target_snowflake(
-            'DROP SCHEMA IF EXISTS ppw_e2e_tap_mongodb CASCADE'
+            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_mongodb{self.sf_schema_postfix} CASCADE'
         )
 
         # Clean config directory

--- a/tests/end_to_end/test-project/tap_mongodb_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_mongodb_to_sf.yml.template
@@ -37,7 +37,7 @@ stream_buffer_size: 0                  # In-memory buffer size (MB) between taps
 # ------------------------------------------------------------------------------
 schemas:
   - source_schema: "${TAP_MONGODB_DB}"
-    target_schema: "ppw_e2e_tap_mongodb"
+    target_schema: "ppw_e2e_tap_mongodb${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
 
     tables:
       - table_name: "listings"

--- a/tests/end_to_end/test-project/tap_mysql_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_sf.yml.template
@@ -34,7 +34,7 @@ stream_buffer_size: 0                  # In-memory buffer size (MB) between taps
 # ------------------------------------------------------------------------------
 schemas:
   - source_schema: "mysql_source_db"
-    target_schema: "ppw_e2e_tap_mysql"
+    target_schema: "ppw_e2e_tap_mysql${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
 
     tables:
       ### Table with LOG_BASED replication

--- a/tests/end_to_end/test-project/tap_mysql_to_sf_buffered_stream.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_sf_buffered_stream.yml.template
@@ -34,7 +34,7 @@ stream_buffer_size: 20                 # In-memory buffer size (MB) between taps
 # ------------------------------------------------------------------------------
 schemas:
   - source_schema: "mysql_source_db"
-    target_schema: "ppw_e2e_tap_mysql"
+    target_schema: "ppw_e2e_tap_mysql${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
 
     tables:
       ### Table with LOG_BASED replication

--- a/tests/end_to_end/test-project/tap_mysql_to_sf_split_large_files.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_sf_split_large_files.yml.template
@@ -39,7 +39,7 @@ split_file_max_chunks: 5
 # ------------------------------------------------------------------------------
 schemas:
   - source_schema: "mysql_source_db"
-    target_schema: "ppw_e2e_tap_mysql"
+    target_schema: "ppw_e2e_tap_mysql${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
 
     tables:
       - table_name: "address"

--- a/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
@@ -88,7 +88,7 @@ schemas:
 
   ### SOURCE SCHEMA 2: public2
   - source_schema: "public2"
-    target_schema: "ppw_e2e_tap_postgres_public2"
+    target_schema: "ppw_e2e_tap_postgres_public2${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
 
     tables:
       ### Table with FULL_TABLE replication
@@ -102,7 +102,7 @@ schemas:
 
   ### SOURCE SCHEMA 3: logical 1
   #- source_schema: "logical1"
-  #  target_schema: "ppw_e2e_tap_postgres_logical1"
+  #  target_schema: "ppw_e2e_tap_postgres_logical1${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
   #
   #  tables:
   #    - table_name: "logical1_table1"
@@ -112,6 +112,6 @@ schemas:
 
   ### SOURCE SCHEMA 4: logical2
   #- source_schema: "logical2"
-  #  target_schema: "ppw_e2e_tap_postgres_logical2"
+  #  target_schema: "ppw_e2e_tap_postgres_logical2${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
   #  tables:
   #    - table_name: "logical2_table1"

--- a/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
@@ -37,7 +37,7 @@ schemas:
 
   ### SOURCE SCHEMA 1: public
   - source_schema: "public"
-    target_schema: "ppw_e2e_tap_postgres"
+    target_schema: "ppw_e2e_tap_postgres${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
 
     tables:
 

--- a/tests/end_to_end/test-project/tap_postgres_to_sf_archive_load_files.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf_archive_load_files.yml.template
@@ -39,7 +39,7 @@ schemas:
 
   ### SOURCE SCHEMA 1: public
   - source_schema: "public"
-    target_schema: "ppw_e2e_tap_postgres"
+    target_schema: "ppw_e2e_tap_postgres${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
 
     tables:
 
@@ -54,7 +54,7 @@ schemas:
 
   ### SOURCE SCHEMA 2: public2
   - source_schema: "public2"
-    target_schema: "ppw_e2e_tap_postgres_public2"
+    target_schema: "ppw_e2e_tap_postgres_public2${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
 
     tables:
       ### Table with FULL_TABLE replication

--- a/tests/end_to_end/test-project/tap_postgres_to_sf_split_large_files.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf_split_large_files.yml.template
@@ -40,7 +40,7 @@ split_file_max_chunks: 5
 # ------------------------------------------------------------------------------
 schemas:
   - source_schema: "public"
-    target_schema: "ppw_e2e_tap_postgres"
+    target_schema: "ppw_e2e_tap_postgres${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
 
     tables:
       - table_name: "city"

--- a/tests/end_to_end/test-project/tap_s3_csv_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_s3_csv_to_sf.yml.template
@@ -41,7 +41,7 @@ default_target_schema: "ppw_e2e_tap_s3_csv"
 # ------------------------------------------------------------------------------
 schemas:
   - source_schema: "s3_feeds" # This is mandatory, but can be anything in this tap type
-    target_schema: "ppw_e2e_tap_s3_csv" # Target schema in the destination Data Warehouse
+    target_schema: "ppw_e2e_tap_s3_csv${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}" # Target schema in the destination Data Warehouse
     
     # List of CSV files to destination tables
     tables:

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -37,7 +37,6 @@ class TestTargetSnowflake:
         """Initialise test project by generating YAML files from
         templates for all the configured connectors"""
 
-
         # Init query runner methods
         self.run_query_tap_mysql = self.e2e.run_query_tap_mysql
         self.run_query_tap_postgres = self.e2e.run_query_tap_postgres

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -36,14 +36,21 @@ class TestTargetSnowflake:
     def setup_method(self):
         """Initialise test project by generating YAML files from
         templates for all the configured connectors"""
-        self.project_dir = os.path.join(DIR, 'test-project')
+
 
         # Init query runner methods
-        self.e2e = E2EEnv(self.project_dir)
         self.run_query_tap_mysql = self.e2e.run_query_tap_mysql
         self.run_query_tap_postgres = self.e2e.run_query_tap_postgres
         self.run_query_target_snowflake = self.e2e.run_query_target_snowflake
         self.mongodb_con = self.e2e.get_tap_mongodb_connection()
+        self.snowflake_schema_postfix = self.e2e.sf_schema_postfix
+
+    def setup_class(self):
+        self.project_dir = os.path.join(DIR, 'test-project')
+        self.e2e = E2EEnv(self.project_dir)
+
+    def teardown_class(self):
+        self.e2e.setup_target_snowflake()
 
     def teardown_method(self):
         """Delete test directories and database objects"""
@@ -79,12 +86,13 @@ class TestTargetSnowflake:
             tap_mariadb_id, TARGET_ID, ['fastsync', 'singer']
         )
         assertions.assert_row_counts_equal(
-            self.run_query_tap_mysql, self.run_query_target_snowflake
+            self.run_query_tap_mysql, self.run_query_target_snowflake, self.snowflake_schema_postfix
         )
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.e2e.run_query_target_snowflake,
             mysql_to_snowflake.tap_type_to_target_type,
+            schema_postfix=self.snowflake_schema_postfix
         )
 
         # 2. Make changes in MariaDB source database
@@ -126,35 +134,36 @@ class TestTargetSnowflake:
             tap_mariadb_id, TARGET_ID, ['fastsync', 'singer']
         )
         assertions.assert_row_counts_equal(
-            self.run_query_tap_mysql, self.run_query_target_snowflake
+            self.run_query_tap_mysql, self.run_query_target_snowflake, schema_postfix=self.snowflake_schema_postfix
         )
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.e2e.run_query_target_snowflake,
             mysql_to_snowflake.tap_type_to_target_type,
             {'blob_col'},
+            schema_postfix=self.snowflake_schema_postfix
         )
 
         # Checking if mask-date transformation is working
         result = self.run_query_target_snowflake(
-            'SELECT count(1) FROM ppw_e2e_tap_mysql.address '
-            'where MONTH(date_created) != 1 or DAY(date_created)::int != 1;'
+            f'SELECT count(1) FROM ppw_e2e_tap_mysql{self.snowflake_schema_postfix}.address '
+            f'where MONTH(date_created) != 1 or DAY(date_created)::int != 1;'
         )[0][0]
 
         assert result == 0
 
         # Checking if conditional MASK-NUMBER transformation is working
         result = self.run_query_target_snowflake(
-            'SELECT count(1) FROM ppw_e2e_tap_mysql.address '
-            'where zip_code_zip_code_id != 0 and street_number REGEXP \'[801]\';'
+            f'SELECT count(1) FROM ppw_e2e_tap_mysql{self.snowflake_schema_postfix}.address '
+            f'where zip_code_zip_code_id != 0 and street_number REGEXP \'[801]\';'
         )[0][0]
 
         assert result == 0
 
         # Checking if conditional SET-NULL transformation is working
         result = self.run_query_target_snowflake(
-            'SELECT count(1) FROM ppw_e2e_tap_mysql.edgydata '
-            'where "GROUP" is not null and "CASE" = \'B\';'
+            f'SELECT count(1) FROM ppw_e2e_tap_mysql{self.snowflake_schema_postfix}.edgydata '
+            f'where "GROUP" is not null and "CASE" = \'B\';'
         )[0][0]
 
         assert result == 0
@@ -166,12 +175,13 @@ class TestTargetSnowflake:
             tap_mariadb_id, TARGET_ID, profiling=True
         )
         assertions.assert_row_counts_equal(
-            self.run_query_tap_mysql, self.run_query_target_snowflake
+            self.run_query_tap_mysql, self.run_query_target_snowflake, schema_postfix=self.snowflake_schema_postfix
         )
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.run_query_target_snowflake,
             mysql_to_snowflake.tap_type_to_target_type,
+            schema_postfix=self.snowflake_schema_postfix
         )
 
     # pylint: disable=invalid-name
@@ -184,12 +194,13 @@ class TestTargetSnowflake:
             tap_mariadb_id, TARGET_ID, profiling=True
         )
         assertions.assert_row_counts_equal(
-            self.run_query_tap_mysql, self.run_query_target_snowflake
+            self.run_query_tap_mysql, self.run_query_target_snowflake, schema_postfix=self.snowflake_schema_postfix
         )
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.run_query_target_snowflake,
             mysql_to_snowflake.tap_type_to_target_type,
+            schema_postfix=self.snowflake_schema_postfix
         )
 
     # pylint: disable=invalid-name
@@ -202,12 +213,13 @@ class TestTargetSnowflake:
             tap_postgres_id, TARGET_ID, profiling=True
         )
         assertions.assert_row_counts_equal(
-            self.run_query_tap_mysql, self.run_query_target_snowflake
+            self.run_query_tap_mysql, self.run_query_target_snowflake, schema_postfix=self.snowflake_schema_postfix
         )
         assertions.assert_all_columns_exist(
             self.run_query_tap_mysql,
             self.run_query_target_snowflake,
             mysql_to_snowflake.tap_type_to_target_type,
+            schema_postfix=self.snowflake_schema_postfix
         )
 
     # pylint: disable=invalid-name
@@ -225,29 +237,29 @@ class TestTargetSnowflake:
             TAP_POSTGRES_ID, TARGET_ID, ['fastsync', 'singer']
         )
         assertions.assert_row_counts_equal(
-            self.run_query_tap_postgres, self.run_query_target_snowflake
+            self.run_query_tap_postgres, self.run_query_target_snowflake, schema_postfix=self.snowflake_schema_postfix
         )
         assertions.assert_all_columns_exist(
-            self.run_query_tap_postgres, self.run_query_target_snowflake
+            self.run_query_tap_postgres, self.run_query_target_snowflake, schema_postfix=self.snowflake_schema_postfix
         )
         assertions.assert_date_column_naive_in_target(
             self.run_query_target_snowflake,
             'updated_at',
-            'ppw_e2e_tap_postgres."TABLE_WITH_SPACE AND UPPERCASE"',
+            f'ppw_e2e_tap_postgres{self.snowflake_schema_postfix}."TABLE_WITH_SPACE AND UPPERCASE"',
         )
 
         result = self.run_query_target_snowflake(
-            'SELECT updated_at FROM '
-            'ppw_e2e_tap_postgres."TABLE_WITH_SPACE AND UPPERCASE" '
-            'where cvarchar=\'H\';'
+            f'SELECT updated_at FROM '
+            f'ppw_e2e_tap_postgres{self.snowflake_schema_postfix}."TABLE_WITH_SPACE AND UPPERCASE" '
+            f'where cvarchar=\'H\';'
         )[0][0]
 
         assert result == datetime(9999, 12, 31, 23, 59, 59, 998993)
 
         result = self.run_query_target_snowflake(
-            'SELECT updated_at FROM '
-            'ppw_e2e_tap_postgres."TABLE_WITH_SPACE AND UPPERCASE" '
-            'where cvarchar=\'I\';'
+            f'SELECT updated_at FROM '
+            f'ppw_e2e_tap_postgres{self.snowflake_schema_postfix}."TABLE_WITH_SPACE AND UPPERCASE" '
+            f'where cvarchar=\'I\';'
         )[0][0]
 
         assert result == datetime(9999, 12, 31, 23, 59, 59, 998993)
@@ -282,35 +294,37 @@ class TestTargetSnowflake:
             TAP_POSTGRES_ID, TARGET_ID, ['fastsync', 'singer'], profiling=True
         )
         assertions.assert_row_counts_equal(
-            self.run_query_tap_postgres, self.run_query_target_snowflake
+            self.run_query_tap_postgres, self.run_query_target_snowflake, schema_postfix=self.snowflake_schema_postfix
         )
         assertions.assert_all_columns_exist(
-            self.run_query_tap_postgres, self.run_query_target_snowflake
+            self.run_query_tap_postgres, self.run_query_target_snowflake, schema_postfix=self.snowflake_schema_postfix
         )
         assertions.assert_date_column_naive_in_target(
             self.run_query_target_snowflake,
             'updated_at',
-            'ppw_e2e_tap_postgres."TABLE_WITH_SPACE AND UPPERCASE"',
+            f'ppw_e2e_tap_postgres{self.snowflake_schema_postfix}."TABLE_WITH_SPACE AND UPPERCASE"',
         )
 
         result = self.run_query_target_snowflake(
-            'SELECT updated_at FROM ppw_e2e_tap_postgres."TABLE_WITH_SPACE AND UPPERCASE" where cvarchar=\'X\';'
+            f'SELECT updated_at FROM '
+            f'ppw_e2e_tap_postgres{self.snowflake_schema_postfix}."TABLE_WITH_SPACE AND UPPERCASE"'
+            f' where cvarchar=\'X\';'
         )[0][0]
 
         assert result == datetime(2019, 12, 31, 22, 53, 56, 800000)
 
         result = self.run_query_target_snowflake(
-            'SELECT updated_at FROM '
-            'ppw_e2e_tap_postgres."TABLE_WITH_SPACE AND UPPERCASE" '
-            'where cvarchar=\'faaaar future\';'
+            f'SELECT updated_at FROM '
+            f'ppw_e2e_tap_postgres{self.snowflake_schema_postfix}."TABLE_WITH_SPACE AND UPPERCASE" '
+            f'where cvarchar=\'faaaar future\';'
         )[0][0]
 
         assert result == datetime(9999, 12, 31, 23, 59, 59, 998993)
 
         result = self.run_query_target_snowflake(
-            'SELECT updated_at FROM '
-            'ppw_e2e_tap_postgres."TABLE_WITH_SPACE AND UPPERCASE" '
-            'where cvarchar=\'BC\';'
+            f'SELECT updated_at FROM '
+            f'ppw_e2e_tap_postgres{self.snowflake_schema_postfix}."TABLE_WITH_SPACE AND UPPERCASE" '
+            f'where cvarchar=\'BC\';'
         )[0][0]
 
         assert result == datetime(9999, 12, 31, 23, 59, 59, 998993)
@@ -423,6 +437,7 @@ class TestTargetSnowflake:
                 'ppw_e2e_tap_s3_csv',
                 'countries',
                 ['CITY', 'COUNTRY', 'CURRENCY', 'ID', 'LANGUAGE'],
+                schema_postfix=self.snowflake_schema_postfix
             )
             assertions.assert_cols_in_table(
                 self.run_query_target_snowflake,
@@ -439,6 +454,7 @@ class TestTargetSnowflake:
                     'IS_PENSIONEER',
                     'LAST_NAME',
                 ],
+                schema_postfix=self.snowflake_schema_postfix
             )
 
         # 1. Run tap first time - both fastsync and a singer should be triggered
@@ -461,7 +477,7 @@ class TestTargetSnowflake:
             """Helper inner function to test if every table and column exists in the target"""
             assertions.assert_cols_in_table(
                 self.run_query_target_snowflake,
-                'ppw_e2e_tap_mongodb',
+                f'ppw_e2e_tap_mongodb{self.snowflake_schema_postfix}',
                 table,
                 [
                     '_ID',
@@ -470,6 +486,7 @@ class TestTargetSnowflake:
                     '_SDC_BATCHED_AT',
                     '_SDC_DELETED_AT',
                 ],
+                schema_postfix=self.snowflake_schema_postfix,
             )
 
         def assert_row_counts_equal(target_schema, table, count_in_source):
@@ -492,10 +509,10 @@ class TestTargetSnowflake:
         my_coll_count = self.mongodb_con['my_collection'].count_documents({})
         all_datatypes_count = self.mongodb_con['all_datatypes'].count_documents({})
 
-        assert_row_counts_equal('ppw_e2e_tap_mongodb', 'listings', listing_count)
-        assert_row_counts_equal('ppw_e2e_tap_mongodb', 'my_collection', my_coll_count)
+        assert_row_counts_equal(f'ppw_e2e_tap_mongodb{self.snowflake_schema_postfix}', 'listings', listing_count)
+        assert_row_counts_equal(f'ppw_e2e_tap_mongodb{self.snowflake_schema_postfix}', 'my_collection', my_coll_count)
         assert_row_counts_equal(
-            'ppw_e2e_tap_mongodb', 'all_datatypes', all_datatypes_count
+            f'ppw_e2e_tap_mongodb{self.snowflake_schema_postfix}', 'all_datatypes', all_datatypes_count
         )
 
         result_insert = self.mongodb_con.my_collection.insert_many(
@@ -542,8 +559,9 @@ class TestTargetSnowflake:
         assert (
             result_update.modified_count
             == self.run_query_target_snowflake(
-                'select count(_id) from ppw_e2e_tap_mongodb.my_collection where document:id = 0'
+                f'select count(_id) from ppw_e2e_tap_mongodb{self.snowflake_schema_postfix}.my_collection'
+                f' where document:id = 0'
             )[0][0]
         )
 
-        assert_row_counts_equal('ppw_e2e_tap_mongodb', 'my_collection', my_coll_count)
+        assert_row_counts_equal(f'ppw_e2e_tap_mongodb{self.snowflake_schema_postfix}', 'my_collection', my_coll_count)

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -46,10 +46,13 @@ class TestTargetSnowflake:
         self.snowflake_schema_postfix = self.e2e.sf_schema_postfix
 
     def setup_class(self):
+        """Initialise test suite"""
         self.project_dir = os.path.join(DIR, 'test-project')
         self.e2e = E2EEnv(self.project_dir)
 
     def teardown_class(self):
+        """Teardown test suite"""
+        # Cleanup the Snowflake test schemas
         self.e2e.setup_target_snowflake()
 
     def teardown_method(self):


### PR DESCRIPTION
## Problem

e2e test with target Snowflake are susceptible to collision when running at the same time from multiple machine/branch and cause CI failures.

## Proposed changes

Generating a UUID string which will be added to the name of schema as a postfix. in this case each test suite will have a unique SF schema.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
