### PR TITLE
Implement support for MongoDB Atlas fastsync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,41 @@
 FROM python:3.7-slim-buster
 
-ARG connectors=all
-COPY . /app
+ARG connectors=default
 
 RUN apt-get -qq update \
     && apt-get -qqy --no-install-recommends install \
         apt-utils \
         alien \
         libaio1 \
-        mongo-tools \
         mbuffer \
         wget \
+        git \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install -U --no-cache-dir pip \
+    && pip install -U --no-cache-dir pip
+
+# In order to use fastsync with MongoDB Atlas we need version 100+ of mongodump
+RUN cd /tmp && \
+    wget https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian10-x86_64-100.5.1.deb && \
+    dpkg -i mongodb-database-tools-debian10-x86_64-100.5.1.deb && \
+    rm mongodb-database-tools-debian10-x86_64-100.5.1.deb
+
+COPY singer-connectors/ /app/singer-connectors/
+COPY Makefile /app
+
+RUN echo "setup connectors" \
     # Install Oracle Instant Client for tap-oracle if its in the connectors list
     && bash -c "if grep -q \"tap-oracle\" <<< \"$connectors\"; then wget https://download.oracle.com/otn_software/linux/instantclient/193000/oracle-instantclient19.3-basiclite-19.3.0.0.0-1.x86_64.rpm -O /app/oracle-instantclient.rpm && alien -i /app/oracle-instantclient.rpm --scripts && rm -rf /app/oracle-instantclient.rpm ; fi" \
     && cd /app \
-    && make pipelinewise_no_test_extras -e pw_acceptlicenses=y\
     && if [ "$connectors" = "all" ]; then make all_connectors -e pw_acceptlicenses=y; fi\
     && if [ "$connectors" = "default" ]; then make default_connectors -e pw_acceptlicenses=y; fi\
     && if [ "$connectors" = "extra" ]; then make extra_connectors -e pw_acceptlicenses=y; fi\
-    && if [ "$connectors" != "all" ] && [ "$connectors" != "extra" ] && [ "$connectors" != "default" ] && [ "$connectors" != "none" ] && [ ! -z $connectors ]; then make connectors -e pw_connector=$connectors -e pw_acceptlicenses=y; fi\
+    && if [ "$connectors" != "all" ] && [ "$connectors" != "extra" ] && [ "$connectors" != "default" ] && [ "$connectors" != "none" ] && [ ! -z $connectors ]; then make connectors -e pw_connector=$connectors -e pw_acceptlicenses=y; fi
+
+COPY . /app
+
+RUN echo "setup pipelinewise" \
+    && cd /app \
+    && make pipelinewise_no_test_extras -e pw_acceptlicenses=y\
     && ln -s /root/.pipelinewise /app/.pipelinewise
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get -qq update \
     && apt-get -qqy --no-install-recommends install \
         apt-utils \
         alien \
+        gnupg \
         libaio1 \
         mbuffer \
         wget \
@@ -13,11 +14,13 @@ RUN apt-get -qq update \
     && rm -rf /var/lib/apt/lists/* \
     && pip install -U --no-cache-dir pip
 
-# In order to use fastsync with MongoDB Atlas we need version 100+ of mongodump
-RUN cd /tmp && \
-    wget https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian10-x86_64-100.5.1.deb && \
-    dpkg -i mongodb-database-tools-debian10-x86_64-100.5.1.deb && \
-    rm mongodb-database-tools-debian10-x86_64-100.5.1.deb
+# Add Mongodb ppa
+RUN wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add - \
+    && echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb.list \
+    && apt-get -qq update \
+    && apt-get -qqy --no-install-recommends install \
+        mongodb-database-tools \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY singer-connectors/ /app/singer-connectors/
 COPY Makefile /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-slim-buster
 
-ARG connectors=default
+ARG connectors=all
 
 RUN apt-get -qq update \
     && apt-get -qqy --no-install-recommends install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get -qq update \
         libaio1 \
         mbuffer \
         wget \
-        git \
     && rm -rf /var/lib/apt/lists/* \
     && pip install -U --no-cache-dir pip
 

--- a/Dockerfile.barebone
+++ b/Dockerfile.barebone
@@ -4,6 +4,7 @@ RUN apt-get -qq update \
     && apt-get -qqy --no-install-recommends install \
         apt-utils \
         alien \
+        gnupg \
         libaio1 \
         wget \
     && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile.barebone
+++ b/Dockerfile.barebone
@@ -1,11 +1,17 @@
 FROM python:3.7-slim-buster
 
+RUN apt-get -qq update \
+    && apt-get -qqy --no-install-recommends install \
+        apt-utils \
+        alien \
+        libaio1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install -U --no-cache-dir pip
+
 COPY . /app
 
-RUN apt-get -qq update \
-    && apt-get -qqy --no-install-recommends install apt-utils alien libaio1 wget \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip install -U --no-cache-dir pip \
+RUN echo "setup pipelinewise" \
     && cd /app \
     && make pipelinewise_no_test_extras -e pw_acceptlicenses=y \
     && ln -s /root/.pipelinewise /app/.pipelinewise

--- a/dev-project/entrypoint.sh
+++ b/dev-project/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # Add Mongodb ppa
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 4B7C549A058F8B6B
-echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse" | tee /etc/apt/sources.list.d/mongodb.list
+echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb.list
 
 # Install OS dependencies
 apt-get update
@@ -14,7 +14,7 @@ apt-get install -y --no-install-recommends \
   libaio1 \
   mariadb-client \
   mbuffer \
-  mongo-tools \
+  mongodb-database-tools \
   mongodb-org-shell=4.2.7 \
   postgresql-client
 

--- a/dev-project/entrypoint.sh
+++ b/dev-project/entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Add Mongodb ppa
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 4B7C549A058F8B6B
+wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add -
 echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb.list
 
 # Install OS dependencies
@@ -15,7 +15,7 @@ apt-get install -y --no-install-recommends \
   mariadb-client \
   mbuffer \
   mongodb-database-tools \
-  mongodb-org-shell=4.2.7 \
+  mongodb-org-shell \
   postgresql-client
 
 rm -rf /var/lib/apt/lists/* \

--- a/docs/connectors/taps/mongodb.rst
+++ b/docs/connectors/taps/mongodb.rst
@@ -149,11 +149,11 @@ Example YAML for ``tap-mongodb``:
 Example connection to MongoDB Atlas
 """""""""""""""""""""""""""""""""""
 
-.. code_block:: yaml
+.. code_block:: bash
 	db_conn:
 		srv: "true"
 		host: "xxxxxxxxx.xxxxx.mongodb.net"
-		auth_database: "admin"         # the Mongodb database name to authenticate on
-		dbname: "db-name"           				# Mongodb database name to sync from
-		user: "user-name"							# User with read roles
-		password: "password"                            # Plain string or vault encrypted
+		auth_database: "admin"			# the Mongodb database name to authenticate on
+		dbname: "db-name"				# Mongodb database name to sync from
+		user: "user-name"				# User with read roles
+		password: "password"			# Plain string or vault encrypted

--- a/docs/connectors/taps/mongodb.rst
+++ b/docs/connectors/taps/mongodb.rst
@@ -149,7 +149,7 @@ Example YAML for ``tap-mongodb``:
 Example connection to MongoDB Atlas
 """""""""""""""""""""""""""""""""""
 
-.. code_block:: bash
+.. code-block:: bash
 
 	db_conn:
 		srv: "true"

--- a/docs/connectors/taps/mongodb.rst
+++ b/docs/connectors/taps/mongodb.rst
@@ -150,6 +150,7 @@ Example connection to MongoDB Atlas
 """""""""""""""""""""""""""""""""""
 
 .. code_block:: bash
+
 	db_conn:
 		srv: "true"
 		host: "xxxxxxxxx.xxxxx.mongodb.net"

--- a/docs/connectors/taps/mongodb.rst
+++ b/docs/connectors/taps/mongodb.rst
@@ -97,6 +97,7 @@ Example YAML for ``tap-mongodb``:
 	db_conn:
 		host: "mongodb_host1,mongodb_host2,mongodb_host3" 	# Mongodb host(s)
 		port: 27017                           				# Mongodb port
+		srv: "false"										# For MongoDB Atlas `srv` should be "true" and `port` will be ignored
 		user: "PipelineWiseUser"                  			# Mongodb user
 		password: "mY_VerY_StRonG_PaSSwoRd"                 # Mongodb plain string or vault encrypted
 		auth_database: "admin"            					# Mongodb database to authenticate on
@@ -143,3 +144,16 @@ Example YAML for ``tap-mongodb``:
 
 		  	# default replication method is LOG_BASED
 		  	- table_name: "my_other_collection"
+
+
+Example connection to MongoDB Atlas
+"""""""""""""""""""""""""""""""""""
+
+.. code_block:: yaml
+	db_conn:
+		srv: "true"
+		host: "xxxxxxxxx.xxxxx.mongodb.net"
+		auth_database: "admin"         # the Mongodb database name to authenticate on
+		dbname: "db-name"           				# Mongodb database name to sync from
+		user: "user-name"							# User with read roles
+		password: "password"                            # Plain string or vault encrypted

--- a/pipelinewise/fastsync/commons/tap_mongodb.py
+++ b/pipelinewise/fastsync/commons/tap_mongodb.py
@@ -5,7 +5,6 @@ import gzip
 import ujson
 import logging
 import os
-import ssl
 import subprocess
 import uuid
 import bson

--- a/pipelinewise/fastsync/commons/tap_mongodb.py
+++ b/pipelinewise/fastsync/commons/tap_mongodb.py
@@ -177,15 +177,11 @@ def get_connection_string(config: Dict):
         connection_query['replicaSet'] = config['replica_set']
 
     if use_ssl:
-        connection_query['tls'] = 'true'
+        connection_query['ssl'] = 'true'
 
     # NB: "sslAllowInvalidCertificates" must ONLY be supplied if `SSL` is true.
     if not verify_mode and use_ssl:
         connection_query['tlsAllowInvalidCertificates'] = 'true'
-
-    # looks like mongo dump and pymongo differ in ssl params
-    # if config.get('ssl', None) is not None:
-    #     conn += f'&ssl={config["ssl"]}'
 
     query_string = parse.urlencode(connection_query)
 

--- a/pipelinewise/fastsync/commons/tap_mongodb.py
+++ b/pipelinewise/fastsync/commons/tap_mongodb.py
@@ -225,7 +225,7 @@ class FastSyncTapMongoDB:
         Open connection
         """
 
-        self.database = MongoClient(self.connection_config["connection_string"])[
+        self.database = MongoClient(self.connection_config['connection_string'])[
             self.connection_config['database']
         ]
 

--- a/pipelinewise/fastsync/commons/tap_mongodb.py
+++ b/pipelinewise/fastsync/commons/tap_mongodb.py
@@ -11,6 +11,7 @@ import uuid
 import bson
 import pytz
 import tzlocal
+from urllib import parse
 
 from typing import Tuple, Optional, Dict, Callable, Any
 from pymongo import MongoClient
@@ -153,6 +154,54 @@ def transform_value(value: Any, path) -> Any:
     return value
 
 
+def get_connection_string(config: Dict):
+    """
+    Generates a MongoClientConnectionString based on configuration
+    Args:
+        config: DB config
+
+    Returns: A MongoClient connection string
+    """
+    srv = config.get('srv') == 'true'
+
+    # Default SSL verify mode to true, give option to disable
+    verify_mode = config.get('verify_mode', 'true') == 'true'
+    use_ssl = config.get('ssl') == 'true'
+
+    connection_query = {
+        'readPreference': 'secondaryPreferred',
+        'authSource': config['auth_database'],
+    }
+
+    if config.get('replica_set'):
+        connection_query['replicaSet'] = config['replica_set']
+
+    if use_ssl:
+        connection_query['tls'] = 'true'
+
+    # NB: "sslAllowInvalidCertificates" must ONLY be supplied if `SSL` is true.
+    if not verify_mode and use_ssl:
+        connection_query['tlsAllowInvalidCertificates'] = 'true'
+
+    # looks like mongo dump and pymongo differ in ssl params
+    # if config.get('ssl', None) is not None:
+    #     conn += f'&ssl={config["ssl"]}'
+
+    query_string = parse.urlencode(connection_query)
+
+    connection_string = '{protocol}://{user}:{password}@{host}{port}/{database}?{query_string}'.format(
+        protocol='mongodb+srv' if srv else 'mongodb',
+        user=config['user'],
+        password=config['password'],
+        host=config['host'],
+        port='' if srv else ':{port}'.format(port=int(config['port'])),
+        database=config['database'],
+        query_string=query_string
+    )
+
+    return connection_string
+
+
 class FastSyncTapMongoDB:
     """
     Common functions for fastsync from a MongoDB database
@@ -170,6 +219,8 @@ class FastSyncTapMongoDB:
             'write_batch_rows', DEFAULT_WRITE_BATCH_ROWS
         )
 
+        self.connection_config['connection_string'] = get_connection_string(self.connection_config)
+
         self.tap_type_to_target_type = tap_type_to_target_type
         self.database: Optional[Database] = None
 
@@ -177,26 +228,8 @@ class FastSyncTapMongoDB:
         """
         Open connection
         """
-        # Default SSL verify mode to true, give option to disable
-        verify_mode = self.connection_config.get('verify_mode', 'true') == 'true'
-        use_ssl = self.connection_config.get('ssl') == 'true'
 
-        connection_params = dict(
-            host=self.connection_config['host'],
-            port=int(self.connection_config['port']),
-            username=self.connection_config['user'],
-            password=self.connection_config['password'],
-            authSource=self.connection_config['auth_database'],
-            ssl=use_ssl,
-            replicaSet=self.connection_config.get('replica_set', None),
-            readPreference='secondaryPreferred',
-        )
-
-        # NB: "ssl_cert_reqs" must ONLY be supplied if `SSL` is true.
-        if not verify_mode and use_ssl:
-            connection_params['ssl_cert_reqs'] = ssl.CERT_NONE
-
-        self.database = MongoClient(**connection_params)[
+        self.database = MongoClient(self.connection_config["connection_string"])[
             self.connection_config['database']
         ]
 
@@ -395,32 +428,21 @@ class FastSyncTapMongoDB:
         """
         LOGGER.info('Starting export of table "%s"', collection_name)
 
-        url = (
-            f'mongodb://{self.connection_config["user"]}:{self.connection_config["password"]}'
-            f'@{self.connection_config["host"]}:{self.connection_config["port"]}/'
-            f'{self.connection_config["database"]}?authSource={self.connection_config["auth_database"]}'
-            f'&readPreference=secondaryPreferred'
-        )
+        cmd = [
+            'mongodump',
+            '--uri',
+            f'"{self.connection_config["connection_string"]}"',
+            '--forceTableScan',
+            '--gzip',
+            '-c',
+            collection_name,
+            '-o',
+            export_dir,
+        ]
 
-        if self.connection_config.get('replica_set', None) is not None:
-            url += f'&replicaSet={self.connection_config["replica_set"]}'
+        LOGGER.info("Running: %s", cmd)
 
-        if self.connection_config.get('ssl', None) is not None:
-            url += f'&ssl={self.connection_config["ssl"]}'
-
-        return_code = subprocess.call(
-            [
-                'mongodump',
-                '--uri',
-                f'"{url}"',
-                '--forceTableScan',
-                '--gzip',
-                '-c',
-                collection_name,
-                '-o',
-                export_dir,
-            ]
-        )
+        return_code = subprocess.call(cmd)
 
         LOGGER.debug('Export command return code %s', return_code)
 

--- a/pipelinewise/fastsync/commons/tap_mongodb.py
+++ b/pipelinewise/fastsync/commons/tap_mongodb.py
@@ -440,8 +440,6 @@ class FastSyncTapMongoDB:
             export_dir,
         ]
 
-        LOGGER.info("Running: %s", cmd)
-
         return_code = subprocess.call(cmd)
 
         LOGGER.debug('Export command return code %s', return_code)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name='pipelinewise',
           'slackclient>=2.7,<2.10',
           'psutil==5.8.0',
           'ujson>=4.1,<4.3',
-          'dnspython>=2.0,<2.2',
+          'dnspython==2.1.*',
       ],
       extras_require={
           'test': [

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(name='pipelinewise',
           'tzlocal>=2.0,<4.1',
           'slackclient>=2.7,<2.10',
           'psutil==5.8.0',
-          'ujson>=4.1,<4.3'
+          'ujson>=4.1,<4.3',
+          'dnspython>=2.0,<2.2',
       ],
       extras_require={
           'test': [

--- a/singer-connectors/tap-mongodb/requirements.txt
+++ b/singer-connectors/tap-mongodb/requirements.txt
@@ -1,2 +1,1 @@
-# We need unreleased support for "srv" property in order to sync with Atlas
-git+https://github.com/transferwise/pipelinewise-tap-mongodb.git
+pipelinewise-tap-mongodb==1.3.0

--- a/singer-connectors/tap-mongodb/requirements.txt
+++ b/singer-connectors/tap-mongodb/requirements.txt
@@ -1,1 +1,2 @@
-pipelinewise-tap-mongodb==1.2.0
+# We need unreleased support for "srv" property in order to sync with Atlas
+git+https://github.com/transferwise/pipelinewise-tap-mongodb.git

--- a/tests/units/fastsync/commons/test_fastsync_tap_mongodb.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_mongodb.py
@@ -179,7 +179,7 @@ class TestFastSyncTapMongoDB(TestCase):
                     'mongodump',
                     '--uri',
                     '"mongodb://my_user:secret@foo.com:3306/my_db'
-                    '?authSource=admin&readPreference=secondaryPreferred&ssl=true"',
+                    '?readPreference=secondaryPreferred&authSource=admin&ssl=true"',
                     '--forceTableScan',
                     '--gzip',
                     '-c',
@@ -239,7 +239,7 @@ class TestFastSyncTapMongoDB(TestCase):
                                 'mongodump',
                                 '--uri',
                                 '"mongodb://my_user:secret@foo.com:3306/my_db'
-                                '?authSource=admin&readPreference=secondaryPreferred&ssl=true"',
+                                '?readPreference=secondaryPreferred&authSource=admin&ssl=true"',
                                 '--forceTableScan',
                                 '--gzip',
                                 '-c',


### PR DESCRIPTION
## Problem

`tap-mongodb` does not support MongoDB Atlas in fastsync mode.

## Proposed changes

Copy approach from `pipelinewise-tap-mongodb`: build `MongoClient` connection string both for API client and `mongodump`.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
