### PR TITLE
 Bump tap-kafka from 5.0.0 to 5.0.1

### DIFF
--- a/singer-connectors/tap-kafka/requirements.txt
+++ b/singer-connectors/tap-kafka/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-kafka==5.0.0
+pipelinewise-tap-kafka==5.0.1


### PR DESCRIPTION
## Problem

`pipelinewise-tap-kafka 5.0.0` doesn't include some required modules and producing runtime error: `ModuleNotFoundError: No module named 'tap_kafka.serialization':`

## Proposed changes

Bump `pipelinewise-tap-kafka` from `5.0.0` to `5.0.1` which includes the fix.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
