### PR TITLE
[DOC] Document tap kafka YAML format after 5.x

### DIFF
--- a/docs/connectors/taps/kafka.rst
+++ b/docs/connectors/taps/kafka.rst
@@ -12,12 +12,7 @@ Messages from kafka topics are extracted into the following fields:
 * ``MESSAGE``: The original and full kafka message
 * `Dynamic primary key columns`: (Optional) Fields extracted from the Kafka JSON messages by JSONPath selector(s).
 
-Consuming Kafka messages
-''''''''''''''''''''''''
-
-Tap Kafka saves consumed messages into a local disk storage and sends commit messages to Kafka after every
-consumed message. A batching mechanism keeps maintaining of deleting and flushing messages from the local storage
-and sends singer compatible messages in small batches to standard output.
+Supported message formats: JSON and Protobuf (experimental).
 
 
 Configuring what to replicate
@@ -60,19 +55,34 @@ Example YAML for ``tap-kafka``:
       primary_keys:
          transfer_id: "/transferMetadata/transferId"
 
+      #initial_start_time:                      # (Default: latest) Start time reference of the message consumption if
+                                                # no bookmarked position in state.json. One of: latest, earliest or an
+                                                # ISO-8601 formatted timestamp string.
+
       # --------------------------------------------------------------------------
-      # Kafka Consumer optional parameters
+      # Kafka Consumer optional parameters. Commented values are default values.
       # --------------------------------------------------------------------------
       #max_runtime_ms: 300000                   # The maximum time for the tap to collect new messages from Kafka topic.
       #consumer_timeout_ms: 10000               # KafkaConsumer setting. Number of milliseconds to block during message iteration before raising StopIteration
       #session_timeout_ms: 30000                # KafkaConsumer setting. The timeout used to detect failures when using Kafka’s group management facilities.
       #heartbeat_interval_ms: 10000             # KafkaConsumer setting. The expected time in milliseconds between heartbeats to the consumer coordinator when using Kafka’s group management facilities.
       #max_poll_interval_ms: 300000             # KafkaConsumer setting. The maximum delay between invocations of poll() when using consumer group management.
-      #max_poll_records: 500                    # KafkaConsumer setting. The maximum number of records returned in a single call to poll().
 
       #commit_interval_ms: 5000                 # Number of milliseconds between two commits. This is different than the kafka auto commit feature. Tap-kafka sends commit messages automatically but only when the data consumed successfully and persisted to local store.
-      #local_store_dir: ./tap-kafka-local-store # Path to the local store with consumed kafka messages
-      #local_store_batch_size_rows: 1000        # Number of messages to write to disk in one go. This can avoid high I/O issues when messages written to local store disk too frequently.
+
+      # --------------------------------------------------------------------------
+      # Protobuf support - Experimental
+      # --------------------------------------------------------------------------
+      #message_format: protobuf                 # (Default: json) Supported message formats are json and protobuf.
+      #proto_schema: |                          # Protobuf message format in .proto syntax. Required if the message_format is protobuf.
+      #     syntax = "proto3";
+      #
+      #     message ProtoMessage {
+      #       string query = 1;
+      #       int32 page_number = 2;
+      #       int32 result_per_page = 3;
+      #     }
+      #proto_classess_dir:                      # (Default: current working dir) Directory where to store runtime compiled proto classes
 
 
     # ------------------------------------------------------------------------------

--- a/pipelinewise/cli/samples/tap_kafka.yml.sample
+++ b/pipelinewise/cli/samples/tap_kafka.yml.sample
@@ -27,19 +27,34 @@ db_conn:
   primary_keys:
      transfer_id: "/transferMetadata/transferId"
 
+  #initial_start_time:                      # (Default: latest) Start time reference of the message consumption if
+                                            # no bookmarked position in state.json. One of: latest, earliest or an
+                                            # ISO-8601 formatted timestamp string.
+
   # --------------------------------------------------------------------------
-  # Kafka Consumer optional parameters
+  # Kafka Consumer optional parameters. Commented values are default values.
   # --------------------------------------------------------------------------
   #max_runtime_ms: 300000                   # The maximum time for the tap to collect new messages from Kafka topic.
   #consumer_timeout_ms: 10000               # KafkaConsumer setting. Number of milliseconds to block during message iteration before raising StopIteration
   #session_timeout_ms: 30000                # KafkaConsumer setting. The timeout used to detect failures when using Kafka’s group management facilities.
   #heartbeat_interval_ms: 10000             # KafkaConsumer setting. The expected time in milliseconds between heartbeats to the consumer coordinator when using Kafka’s group management facilities.
   #max_poll_interval_ms: 300000             # KafkaConsumer setting. The maximum delay between invocations of poll() when using consumer group management.
-  #max_poll_records: 500                    # KafkaConsumer setting. The maximum number of records returned in a single call to poll().
 
   #commit_interval_ms: 5000                 # Number of milliseconds between two commits. This is different than the kafka auto commit feature. Tap-kafka sends commit messages automatically but only when the data consumed successfully and persisted to local store.
-  #local_store_dir: ./tap-kafka-local-store # Path to the local store with consumed kafka messages
-  #local_store_batch_size_rows: 1000        # Number of messages to write to disk in one go. This can avoid high I/O issues when messages written to local store disk too frequently.
+
+  # --------------------------------------------------------------------------
+  # Protobuf support - Experimental
+  # --------------------------------------------------------------------------
+  #message_format: protobuf                 # (Default: json) Supported message formats are json and protobuf.
+  #proto_schema: |                          # Protobuf message format in .proto syntax. Required if the message_format is protobuf.
+  #     syntax = "proto3";
+  #
+  #     message ProtoMessage {
+  #       string query = 1;
+  #       int32 page_number = 2;
+  #       int32 result_per_page = 3;
+  #     }
+  #proto_classess_dir:                      # (Default: current working dir) Directory where to store runtime compiled proto classes
 
 # ------------------------------------------------------------------------------
 # Destination (Target) - Target properties

--- a/singer-connectors/tap-kafka/requirements.txt
+++ b/singer-connectors/tap-kafka/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-kafka==5.0.1
+pipelinewise-tap-kafka==5.1.0


### PR DESCRIPTION
## Problem

[pipelinewise-tap-kafka](github.com/transferwise/pipelinewise-tap-kafka) introduced some changes in the tap YAML format that's not in sync with the online documentation.

## Proposed changes

Document [pipelinewise-tap-kafka 5.x](github.com/transferwise/pipelinewise-tap-kafka) YAML format.


## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
