### PR TITLE
Fix snowflake primary keys as nullable

### DIFF
--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -312,6 +312,32 @@ class FastSyncTargetSnowflake:
             ),
         )
 
+    def update_primary_keys_nullable(self,
+        target_schema: str,
+        table_name: str,
+        primary_key: List[str],
+        is_temporary: bool = False):
+
+        if primary_key is None:
+            return
+
+        table_dict = utils.tablename_to_dict(table_name)
+        target_table = (
+            table_dict.get('table_name')
+            if not is_temporary
+            else table_dict.get('temp_table_name')
+        )
+
+        for pk_column in primary_key:
+            sql = (
+                f'ALTER TABLE {target_schema}."{target_table.upper()}" '
+                f'ALTER COLUMN {pk_column} DROP NOT NULL'
+            )
+
+            self.query(
+                sql, query_tag_props={'schema': target_schema, 'table': target_table}
+            )
+
     # grant_... functions are common functions called by utils.py: grant_privilege function
     # "to_group" is not used here but exists for compatibility reasons with other database types
     # "to_group" is for databases that can grant to users and groups separately like Amazon Redshift

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -131,6 +131,9 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
             target_schema, table, snowflake_columns, primary_key, is_temporary=True
         )
 
+        # Update table primary keys to nullable
+        snowflake.update_primary_keys_nullable(target_schema, table, primary_key, is_temporary=True)
+
         # Load into Snowflake table
         snowflake.copy_to_table(
             s3_key_pattern, target_schema, table, size_bytes, is_temporary=True


### PR DESCRIPTION
## Problem

Snowflake changed its default behaviour whereby primary keys created are defaulted to be non nullable.


## Proposed changes

Add logic to update all primary keys to be nullable after temporary table is created within Snowflake (before populated and swapped).


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
