### PR TITLE
Convert `NamedTuple` to `dataclass`

### DIFF
--- a/pipelinewise/cli/commands.py
+++ b/pipelinewise/cli/commands.py
@@ -61,7 +61,7 @@ class TapParams:
     """
     TapParams validates json properties.
     """
-    id: str  # pylint: disable=invalid-name
+    tap_id: str
     type: str
     bin: str
     python_bin: str
@@ -96,7 +96,7 @@ class TargetParams:
     """
     TargetParams validates json properties.
     """
-    id: str  # pylint: disable=invalid-name
+    target_id: str
     type: str
     bin: str
     python_bin: str
@@ -183,7 +183,7 @@ def build_tap_command(
     tap_command = f'{tap.bin} --config {tap.config} {catalog_argument} {tap.properties} {state_arg}'
 
     if profiling_mode:
-        dump_file = os.path.join(profiling_dir, f'tap_{tap.id}.pstat')
+        dump_file = os.path.join(profiling_dir, f'tap_{tap.tap_id}.pstat')
         tap_command = f'{tap.python_bin} -m cProfile -o {dump_file} {tap_command}'
 
     return tap_command
@@ -207,7 +207,7 @@ def build_target_command(
     target_command = f'{target.bin} --config {target.config}'
 
     if profiling_mode:
-        dump_file = os.path.join(profiling_dir, f'target_{target.id}.pstat')
+        dump_file = os.path.join(profiling_dir, f'target_{target.target_id}.pstat')
         target_command = (
             f'{target.python_bin} -m cProfile -o {dump_file} {target_command}'
         )
@@ -411,7 +411,7 @@ def build_fastsync_command(
     command = f'{fastsync_bin} {command_args}'
 
     if profiling_mode:
-        dump_file = os.path.join(profiling_dir, f'fastsync_{tap.id}_{target.id}.pstat')
+        dump_file = os.path.join(profiling_dir, f'fastsync_{tap.tap_id}_{target.target_id}.pstat')
         command = f'{ppw_python_bin} -m cProfile -o {dump_file} {command}'
 
     LOGGER.debug('FastSync command: %s', command)

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1202,7 +1202,7 @@ class PipelineWise:
         try:
             with pidfile.PIDFile(self.tap['files']['pidfile']):
                 target_params = TargetParams(
-                    id=target_id,
+                    target_id=target_id,
                     type=target_type,
                     bin=self.target_bin,
                     python_bin=self.target_python_bin,
@@ -1226,7 +1226,7 @@ class PipelineWise:
                         log_dir, f'{target_id}-{tap_id}-{current_time}.fastsync.log'
                     )
                     tap_params = TapParams(
-                        id=tap_id,
+                        tap_id=tap_id,
                         type=tap_type,
                         bin=self.tap_bin,
                         python_bin=self.tap_python_bin,
@@ -1252,7 +1252,7 @@ class PipelineWise:
                         log_dir, f'{target_id}-{tap_id}-{current_time}.singer.log'
                     )
                     tap_params = TapParams(
-                        id=tap_id,
+                        tap_id=tap_id,
                         type=tap_type,
                         bin=self.tap_bin,
                         python_bin=self.tap_python_bin,
@@ -1415,7 +1415,7 @@ class PipelineWise:
 
                 # Create parameters as NamedTuples
                 tap_params = TapParams(
-                    id=tap_id,
+                    tap_id=tap_id,
                     type=tap_type,
                     bin=self.tap_bin,
                     python_bin=self.tap_python_bin,
@@ -1425,7 +1425,7 @@ class PipelineWise:
                 )
 
                 target_params = TargetParams(
-                    id=target_id,
+                    target_id=target_id,
                     type=target_type,
                     bin=self.target_bin,
                     python_bin=self.target_python_bin,

--- a/tests/units/cli/test_commands.py
+++ b/tests/units/cli/test_commands.py
@@ -40,7 +40,7 @@ class TestCommands:
         # State file should not be included if state file path not passed
 
         tap = commands.TapParams(
-            id='my_tap_mysql',
+            tap_id='my_tap_mysql',
             type='tap_mysql',
             bin='/bin/tap_mysql.py',
             python_bin='/bin/python3',
@@ -72,7 +72,7 @@ class TestCommands:
 
         # State file should not be included if state file passed but file not exists
         tap = commands.TapParams(
-            id='my_tap_mysql',
+            tap_id='my_tap_mysql',
             type='tap_mysql',
             bin='/bin/tap_mysql.py',
             python_bin='/bin/python3',
@@ -106,7 +106,7 @@ class TestCommands:
         state_mock = __file__
 
         tap = commands.TapParams(
-            id='my_tap_mysql',
+            tap_id='my_tap_mysql',
             type='tap_mysql',
             bin='/bin/tap_mysql.py',
             python_bin='/bin/python3',
@@ -144,7 +144,7 @@ class TestCommands:
         # Should return a input piped command with an executable target command
 
         target = commands.TargetParams(
-            id='my_target',
+            target_id='my_target',
             type='target-snowflake',
             bin='/bin/target_postgres.py',
             python_bin='/bin/python',
@@ -284,7 +284,7 @@ class TestCommands:
 
         # Should generate a command with tap state and transformation
         tap_params = commands.TapParams(
-            id='my_tap',
+            tap_id='my_tap',
             type='tap-mysql',
             bin='/bin/tap_mysql.py',
             python_bin='/bin/python',
@@ -294,7 +294,7 @@ class TestCommands:
         )
 
         target_params = commands.TargetParams(
-            id='my_target',
+            target_id='my_target',
             type='target-postgres',
             bin='/bin/target_postgres.py',
             python_bin='/bin/python',
@@ -379,7 +379,7 @@ class TestCommands:
 
         # Should generate a command without state and with transformation
         tap_params = commands.TapParams(
-            id='my_tap',
+            tap_id='my_tap',
             type='tap-mysql',
             bin='/bin/tap_mysql.py',
             python_bin='/bin/python',
@@ -420,7 +420,7 @@ class TestCommands:
 
         # Should generate a command with state and without transformation
         tap_params = commands.TapParams(
-            id='my_tap',
+            tap_id='my_tap',
             type='tap-mysql',
             bin='/bin/tap_mysql.py',
             python_bin='/bin/python',
@@ -468,7 +468,7 @@ class TestCommands:
 
         # Should generate a command without state and transformation
         tap_params = commands.TapParams(
-            id='my_tap',
+            tap_id='my_tap',
             type='tap-mysql',
             bin='/bin/tap_mysql.py',
             python_bin='/bin/python',
@@ -520,7 +520,7 @@ class TestCommands:
         # Should generate a fastsync command with transformation
 
         tap_params = commands.TapParams(
-            id='my_tap',
+            tap_id='my_tap',
             type='tap-mysql',
             bin='/bin/tap_mysql.py',
             python_bin='/tap-mysql/bin/python',
@@ -530,7 +530,7 @@ class TestCommands:
         )
 
         target_params = commands.TargetParams(
-            id='my_target',
+            target_id='my_target',
             type='target-postgres',
             bin='/bin/target_postgres.py',
             python_bin='/target-postgres/bin/python',

--- a/tests/units/cli/test_config_validation.py
+++ b/tests/units/cli/test_config_validation.py
@@ -44,7 +44,7 @@ class TestConfigValidation(TestCase):
     @staticmethod
     def _assert_tap_config(config: str, properties: str, state: str) -> None:
         commands.TapParams(
-            id='foo',
+            tap_id='foo',
             type='bar',
             bin='foo_bin',
             python_bin='foo/python',
@@ -56,7 +56,7 @@ class TestConfigValidation(TestCase):
     @staticmethod
     def _assert_target_config(config: str) -> None:
         commands.TargetParams(
-            id='foo',
+            target_id='foo',
             type='bar',
             bin='foo_bin',
             python_bin='foo/python',


### PR DESCRIPTION
## Problem

- The `namedtuples` with overridden `__init__` methods are really, really ugly.

## Proposed changes

- Use `dataclasses`

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue._


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
