### PR TITLE
Fix: e2e tests fail when SF credentials are not present

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,5 @@ filterwarnings =
     ignore::DeprecationWarning:tabulate
     ignore::DeprecationWarning:_yaml
     ignore::DeprecationWarning:messytables
+    ignore::DeprecationWarning:setuptools
+    ignore::DeprecationWarning:pandas

--- a/tests/end_to_end/helpers/env.py
+++ b/tests/end_to_end/helpers/env.py
@@ -614,30 +614,32 @@ class E2EEnv:
 
     def setup_target_snowflake(self):
         """Clean snowflake target database and prepare for test run"""
-        self.run_query_target_snowflake(
-            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres{self.sf_schema_postfix} CASCADE'
-        )
-        self.run_query_target_snowflake(
-            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres_public2{self.sf_schema_postfix} CASCADE'
-        )
-        self.run_query_target_snowflake(
-            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres_logical1{self.sf_schema_postfix} CASCADE'
-        )
-        self.run_query_target_snowflake(
-            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres_logical2{self.sf_schema_postfix} CASCADE'
-        )
-        self.run_query_target_snowflake(
-            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_mysql{self.sf_schema_postfix} CASCADE'
-        )
-        self.run_query_target_postgres(
-            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_mysql_2{self.sf_schema_postfix} CASCADE'
-        )
-        self.run_query_target_snowflake(
-            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_s3_csv{self.sf_schema_postfix} CASCADE'
-        )
-        self.run_query_target_snowflake(
-            f'DROP SCHEMA IF EXISTS ppw_e2e_tap_mongodb{self.sf_schema_postfix} CASCADE'
-        )
+
+        if self.env['TARGET_SNOWFLAKE']['is_configured']:
+            self.run_query_target_snowflake(
+                f'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres{self.sf_schema_postfix} CASCADE'
+            )
+            self.run_query_target_snowflake(
+                f'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres_public2{self.sf_schema_postfix} CASCADE'
+            )
+            self.run_query_target_snowflake(
+                f'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres_logical1{self.sf_schema_postfix} CASCADE'
+            )
+            self.run_query_target_snowflake(
+                f'DROP SCHEMA IF EXISTS ppw_e2e_tap_postgres_logical2{self.sf_schema_postfix} CASCADE'
+            )
+            self.run_query_target_snowflake(
+                f'DROP SCHEMA IF EXISTS ppw_e2e_tap_mysql{self.sf_schema_postfix} CASCADE'
+            )
+            self.run_query_target_postgres(
+                f'DROP SCHEMA IF EXISTS ppw_e2e_tap_mysql_2{self.sf_schema_postfix} CASCADE'
+            )
+            self.run_query_target_snowflake(
+                f'DROP SCHEMA IF EXISTS ppw_e2e_tap_s3_csv{self.sf_schema_postfix} CASCADE'
+            )
+            self.run_query_target_snowflake(
+                f'DROP SCHEMA IF EXISTS ppw_e2e_tap_mongodb{self.sf_schema_postfix} CASCADE'
+            )
 
         # Clean config directory
         shutil.rmtree(os.path.join(CONFIG_DIR, 'snowflake'), ignore_errors=True)

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -60,7 +60,9 @@ class TestTargetSnowflake:
 
     @pytest.fixture(autouse=True)
     def skip_if_no_sf_credentials(self):
-
+        """
+        Test fixture to be used by all tests to check if SF is configured to decide whether to run the test or not.
+        """
         # Skip every test if required env vars not provided
         print('skip_if_no_sf_credentials executed')
         if self.e2e.env['TARGET_SNOWFLAKE']['is_configured']:

--- a/tests/end_to_end/test_target_snowflake.py
+++ b/tests/end_to_end/test_target_snowflake.py
@@ -33,7 +33,6 @@ class TestTargetSnowflake:
     """
     End to end tests for Target Snowflake
     """
-
     def setup_method(self):
         """Initialise test project by generating YAML files from
         templates for all the configured connectors"""
@@ -59,6 +58,16 @@ class TestTargetSnowflake:
     def teardown_method(self):
         """Delete test directories and database objects"""
 
+    @pytest.fixture(autouse=True)
+    def skip_if_no_sf_credentials(self):
+
+        # Skip every test if required env vars not provided
+        print('skip_if_no_sf_credentials executed')
+        if self.e2e.env['TARGET_SNOWFLAKE']['is_configured']:
+            yield
+        else:
+            pytest.skip('Target Snowflake environment variables are not provided')
+
     @pytest.mark.dependency(name='validate')
     def test_validate(self):
         """Validate the YAML project with taps and target """
@@ -75,10 +84,6 @@ class TestTargetSnowflake:
     def test_import_project(self):
         """Import the YAML project with taps and target and do discovery mode
         to write the JSON files for singer connectors"""
-
-        # Skip every target_postgres related test if required env vars not provided
-        if not self.e2e.env['TARGET_SNOWFLAKE']['is_configured']:
-            pytest.skip('Target Snowflake environment variables are not provided')
 
         # Setup and clean source and target databases
         self.e2e.setup_tap_mysql()
@@ -368,9 +373,6 @@ class TestTargetSnowflake:
     @pytest.mark.dependency(depends=['import_config'])
     def test_replicate_pg_to_sf_with_archive_load_files(self):
         """Fastsync tables from Postgres to Snowflake with archive load files enabled"""
-        if not self.e2e.env['TARGET_SNOWFLAKE']['is_configured']:
-            pytest.skip('Target Snowflake environment variables are not provided')
-
         archive_s3_prefix = 'archive_folder'  # Custom s3 prefix defined in TAP_POSTGRES_ARCHIVE_LOAD_FILES_ID
 
         s3_bucket = os.environ.get('TARGET_SNOWFLAKE_S3_BUCKET')


### PR DESCRIPTION
## Problem

Albeit SF credentials are provided in the CI environment, Github doesn't not share these credentials with PRs from forked repos, hence the SF tests are skipped but fail in the last step,
the issue lies in the teardown step when it's trying to clean up SF but cannot connect to it.

![image](https://user-images.githubusercontent.com/54845154/153377380-6257da55-6572-4a6d-9c7f-e2597c7cea2d.png)


## Proposed changes

* Create a class fixture to skip all tests if SF is not configured
* Only teardown if SF is configured

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
