### PR TITLE
Relax upper limit on `split_file_max_chunks`

### DIFF
--- a/pipelinewise/cli/schemas/tap.json
+++ b/pipelinewise/cli/schemas/tap.json
@@ -383,7 +383,7 @@
     "split_file_max_chunks": {
       "type": "integer",
       "min": 1,
-      "max": 100
+      "max": 99999
     },
     "schemas": {
       "type": "array",


### PR DESCRIPTION
## Problem

For extremely large tables the current limits can result in insufficient splits being allowed.

## Proposed changes

- Relax the upper limit to `99,999`. This is the largest number which can be represented with the 5 digit file part numbering scheme.

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue._


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
