### PR TITLE
AP-1121 Support log_based using GTID for MariaDB(tap-mysql).

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run Unit tests
         if: steps.check.outcome == 'failure'
         run: |
-          pytest --cov=pipelinewise --cov-fail-under=72 -v tests/units
+          pytest --cov=pipelinewise --cov-fail-under=74 -v tests/units
 
   e2e_tests:
     runs-on: ubuntu-20.04

--- a/docs/connectors/taps/mysql.rst
+++ b/docs/connectors/taps/mysql.rst
@@ -4,11 +4,10 @@
 Tap MySQL
 ---------
 
+This tap is compatible with Mysql and Mariadb servers to some extent.
 
 MySQL setup requirements
 ''''''''''''''''''''''''
-
-*(Section based on Stitch documentation)*
 
 **Step 1: Check if you have all the required credentials for replicating data from MySQL**
 
@@ -92,6 +91,13 @@ following the steps in the :ref:`generating_pipelines` section.
   Read more info about this decision in `this github issue <https://github.com/singer-io/tap-mysql/issues/82>`_
   or browse the codebase `here <https://github.com/transferwise/pipelinewise-tap-mysql/blob/34cbd9b085146c08003bfa460f1550ce78c65e4c/tap_mysql/__init__.py#L73>`_.
 
+
+.. note::
+
+  This tap supports :ref:`log_based` replication method with GTID position, at the time
+  of writing this, only MariaDB GTID is implemented.
+
+
 Example YAML for ``tap-mysql``:
 
 .. code-block:: yaml
@@ -117,6 +123,8 @@ Example YAML for ``tap-mysql``:
     user: "<USER>"                       # MySQL/ MariaDB user
     password: "<PASSWORD>"               # Plain string or vault encrypted
     dbname: "<DB_NAME>"                  # MySQL/ MariaDB database name
+    use_gtid: <boolean>                  # Flag to enable using GTID as the state bookmark for log based tables
+    engine: "mariadb/mysql"              # Flavor of the server, used in conjunction with "use_gtid"
     #filter_dbs: "schema1,schema2"       # Optional: Scan only the required schemas
                                          #           to improve the performance of
                                          #           data extraction

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1658,7 +1658,9 @@ class PipelineWise:
             or (
                 replication_method == self.LOG_BASED
                 and 'lsn' not in stream_bookmark
+                and 'log_file' not in stream_bookmark
                 and 'log_pos' not in stream_bookmark
+                and 'gtid' not in stream_bookmark
                 and 'token' not in stream_bookmark
             )
         )

--- a/pipelinewise/cli/schemas/tap.json
+++ b/pipelinewise/cli/schemas/tap.json
@@ -25,6 +25,12 @@
     "db_conn": {
       "type": "object",
       "properties": {
+        "use_gtid": {
+          "type": "boolean"
+        },
+        "engine": {
+          "enum": ["mariadb", "mysql"]
+        },
         "fastsync_parallelism": {
           "type": "integer",
           "minimum": 1,

--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mysql==1.4.3
+-e git+https://github.com/transferwise/pipelinewise-tap-mysql.git@AP-1116_log_based_with_gtid#egg=pipelinewise-tap-mysql

--- a/tests/end_to_end/test-project/tap_mysql_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_pg.yml.template
@@ -18,7 +18,8 @@ db_conn:
   user: "${TAP_MYSQL_USER}"             # MySQL user
   password: "${TAP_MYSQL_PASSWORD}"     # Plain string or vault encrypted
   dbname: "${TAP_MYSQL_DB}"             # MySQL database name
-
+  use_gtid: true
+  engine: mariadb
 
 # ------------------------------------------------------------------------------
 # Destination (Target) - Target properties

--- a/tests/end_to_end/test-project/tap_mysql_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_sf.yml.template
@@ -18,7 +18,8 @@ db_conn:
   user: "${TAP_MYSQL_USER}"             # MySQL user
   password: "${TAP_MYSQL_PASSWORD}"     # Plain string or vault encrypted
   dbname: "${TAP_MYSQL_DB}"             # MySQL database name
-
+  use_gtid: true
+  engine: mariadb
 
 # ------------------------------------------------------------------------------
 # Destination (Target) - Target properties

--- a/tests/units/fastsync/commons/test_fastsync_tap_mysql.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_mysql.py
@@ -55,8 +55,8 @@ class TestFastSyncTapMySql(TestCase):
             self.mysql.open_connections()
 
         # Test if session variables applied on both connections
-        assert self.mysql.executed_queries == tap_mysql.DEFAULT_SESSION_SQLS
-        assert self.mysql.executed_queries_unbuffered == self.mysql.executed_queries
+        self.assertListEqual(self.mysql.executed_queries, tap_mysql.DEFAULT_SESSION_SQLS)
+        self.assertListEqual(self.mysql.executed_queries_unbuffered, self.mysql.executed_queries)
 
     def test_get_connection_to_primary(self):
         """
@@ -121,8 +121,8 @@ class TestFastSyncTapMySql(TestCase):
             self.mysql.open_connections()
 
         # Test if session variables applied on both connections
-        assert self.mysql.executed_queries == session_sqls
-        assert self.mysql.executed_queries_unbuffered == self.mysql.executed_queries
+        self.assertListEqual(self.mysql.executed_queries, session_sqls)
+        self.assertListEqual(self.mysql.executed_queries_unbuffered, self.mysql.executed_queries)
 
     def test_open_connections_with_invalid_session_sqls(self):
         """Invalid SQLs in session_sqls should be ignored"""
@@ -142,11 +142,11 @@ class TestFastSyncTapMySql(TestCase):
             self.mysql.open_connections()
 
         # Test if session variables applied on both connections
-        assert self.mysql.executed_queries == [
+        self.assertListEqual(self.mysql.executed_queries, [
             'SET SESSION max_statement_time=0',
             'SET SESSION wait_timeout=28800',
-        ]
-        self.assertEqual(self.mysql.executed_queries_unbuffered, self.mysql.executed_queries)
+        ])
+        self.assertListEqual(self.mysql.executed_queries_unbuffered, self.mysql.executed_queries)
 
     def test_fetch_current_log_pos_with_gtid_and_mysql_engine_fails(self):
         """
@@ -185,7 +185,7 @@ class TestFastSyncTapMySql(TestCase):
             result = self.mysql.fetch_current_log_pos()
 
             query_method_mock.assert_called_once_with('select @@gtid_slave_pos as current_gtid;')
-            self.assertEqual(result, {'gtid': expected_gtid})
+            self.assertDictEqual(result, {'gtid': expected_gtid})
 
     def test_fetch_current_log_pos_with_gtid_and_replica_mariadb_engine_gtid_not_found(self):
         """
@@ -234,7 +234,7 @@ class TestFastSyncTapMySql(TestCase):
                     call('select @@server_id as server_id;'),
                 ]
             )
-            self.assertEqual(result, {'gtid': expected_gtid})
+            self.assertDictEqual(result, {'gtid': expected_gtid})
 
     def test_fetch_current_log_pos_with_gtid_and_primary_mariadb_engine_no_gtid_found_expect_exception(self):
         """
@@ -308,7 +308,7 @@ class TestFastSyncTapMySql(TestCase):
 
             query_method_mock.assert_called_once_with('SHOW SLAVE STATUS')
 
-            self.assertEqual(result, {
+            self.assertDictEqual(result, {
                 'log_file': 'binlog_xyz',
                 'log_pos': 444,
                 'version': 1,
@@ -332,7 +332,7 @@ class TestFastSyncTapMySql(TestCase):
             ]
 
             result = self.mysql.fetch_current_log_pos()
-            self.assertEqual(result, {
+            self.assertDictEqual(result, {
                 'log_file': 'binlog_xyz',
                 'log_pos': 444,
                 'version': 1,


### PR DESCRIPTION
## Problem

When `log_based` tap changes host to a new primary, the log coordinates in the state bookmarks are not longer valid and it can't resume from where it left off, and so the need to run a historical sync again which can be problematic or impossible with large tables.

Using GTID would help the tap survive changing primary without the need for historical sync.

## Proposed changes

Support log based replication that uses GTID as the bookmark, for now this is implemented for Mariadb since mysql has a different GTID structure.

Fastsync will fetch the gtid from the server and use it as the bookmark, tap-mysql will continue then log based thanks to the implementation in this PR: https://github.com/transferwise/pipelinewise-tap-mysql/pull/90

Support for mysql will come later.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
