### PR TITLE
Cluster by primary key if available

### DIFF
--- a/pipelinewise/fastsync/commons/target_bigquery.py
+++ b/pipelinewise/fastsync/commons/target_bigquery.py
@@ -1,7 +1,7 @@
 import logging
 import json
 import re
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 from google.cloud import bigquery
 from google.api_core import exceptions
@@ -104,6 +104,7 @@ class FastSyncTargetBigquery:
         target_schema: str,
         table_name: str,
         columns: List[str],
+        primary_key: Optional[List[str]],
         is_temporary: bool = False,
         sort_columns=False,
     ):
@@ -144,6 +145,9 @@ class FastSyncTargetBigquery:
             f'CREATE OR REPLACE TABLE {target_schema}.{target_table} ('
             f'{",".join(columns)})'
         )
+        if primary_key:
+            primary_key = [c.lower() for c in primary_key]
+            sql = sql + f' CLUSTER BY {",".join(primary_key)}'
 
         self.query(sql)
 

--- a/pipelinewise/fastsync/mongodb_to_bigquery.py
+++ b/pipelinewise/fastsync/mongodb_to_bigquery.py
@@ -70,11 +70,12 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         size_bytes = os.path.getsize(filepath)
         bigquery_types = mongodb.map_column_types_to_target()
         bigquery_columns = bigquery_types.get('columns', [])
+        primary_key = bigquery_types.get('primary_key', [])
         mongodb.close_connection()
 
         # Creating temp table in Bigquery
         bigquery.create_schema(target_schema)
-        bigquery.create_table(target_schema, table, bigquery_columns, is_temporary=True)
+        bigquery.create_table(target_schema, table, bigquery_columns, primary_key, is_temporary=True)
 
         # Load into Bigquery table
         bigquery.copy_to_table(
@@ -91,7 +92,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         bigquery.obfuscate_columns(target_schema, table)
 
         # Create target table and swap with the temp table in Bigquery
-        bigquery.create_table(target_schema, table, bigquery_columns)
+        bigquery.create_table(target_schema, table, bigquery_columns, primary_key)
         bigquery.swap_tables(target_schema, table)
 
         # Save bookmark to singer state file

--- a/pipelinewise/fastsync/mysql_to_bigquery.py
+++ b/pipelinewise/fastsync/mysql_to_bigquery.py
@@ -90,11 +90,12 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         size_bytes = sum([os.path.getsize(file_part) for file_part in file_parts])
         bigquery_types = mysql.map_column_types_to_target(table)
         bigquery_columns = bigquery_types.get('columns', [])
+        primary_key = bigquery_types.get('primary_key', [])
         mysql.close_connections()
 
         # Creating temp table in Bigquery
         bigquery.create_schema(target_schema)
-        bigquery.create_table(target_schema, table, bigquery_columns, is_temporary=True)
+        bigquery.create_table(target_schema, table, bigquery_columns, primary_key, is_temporary=True)
 
         # Load into Bigquery table
         for num, file_part in enumerate(file_parts):
@@ -113,7 +114,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         bigquery.obfuscate_columns(target_schema, table)
 
         # Create target table and swap with the temp table in Bigquery
-        bigquery.create_table(target_schema, table, bigquery_columns)
+        bigquery.create_table(target_schema, table, bigquery_columns, primary_key)
         bigquery.swap_tables(target_schema, table)
 
         # Save bookmark to singer state file

--- a/pipelinewise/fastsync/postgres_to_bigquery.py
+++ b/pipelinewise/fastsync/postgres_to_bigquery.py
@@ -94,11 +94,12 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
 
         bigquery_types = postgres.map_column_types_to_target(table)
         bigquery_columns = bigquery_types.get('columns', [])
+        primary_key = bigquery_types.get('primary_key', [])
         postgres.close_connection()
 
         # Creating temp table in Bigquery
         bigquery.create_schema(target_schema)
-        bigquery.create_table(target_schema, table, bigquery_columns, is_temporary=True)
+        bigquery.create_table(target_schema, table, bigquery_columns, primary_key, is_temporary=True)
 
         # Load into Bigquery table
         for num, file_part in enumerate(file_parts):
@@ -117,7 +118,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         bigquery.obfuscate_columns(target_schema, table)
 
         # Create target table and swap with the temp table in Bigquery
-        bigquery.create_table(target_schema, table, bigquery_columns)
+        bigquery.create_table(target_schema, table, bigquery_columns, primary_key)
         bigquery.swap_tables(target_schema, table)
 
         # Save bookmark to singer state file

--- a/pipelinewise/fastsync/s3_csv_to_bigquery.py
+++ b/pipelinewise/fastsync/s3_csv_to_bigquery.py
@@ -56,6 +56,7 @@ def sync_table(table_name: str, args: Namespace) -> Union[bool, str]:
 
         bigquery_types = s3_csv.map_column_types_to_target(filepath, table_name)
         bigquery_columns = bigquery_types.get('columns', [])
+        primary_key = bigquery_types.get('primary_key', [])
 
         # Creating temp table in Bigquery
         bigquery.create_schema(target_schema)
@@ -63,6 +64,7 @@ def sync_table(table_name: str, args: Namespace) -> Union[bool, str]:
             target_schema,
             table_name,
             bigquery_columns,
+            primary_key,
             is_temporary=True,
             sort_columns=True,
         )
@@ -82,7 +84,7 @@ def sync_table(table_name: str, args: Namespace) -> Union[bool, str]:
         bigquery.obfuscate_columns(target_schema, table_name)
 
         # Create target table and swap with the temp table in Bigquery
-        bigquery.create_table(target_schema, table_name, bigquery_columns)
+        bigquery.create_table(target_schema, table_name, bigquery_columns, primary_key)
         bigquery.swap_tables(target_schema, table_name)
 
         # Get bookmark

--- a/tests/units/fastsync/commons/test_fastsync_target_bigquery.py
+++ b/tests/units/fastsync/commons/test_fastsync_target_bigquery.py
@@ -115,6 +115,7 @@ class TestFastSyncTargetBigquery:
             target_schema='test_schema',
             table_name='test_table',
             columns=['`id` INTEGER', '`txt` STRING'],
+            primary_key=[],
         )
         client().query.assert_called_with(
             'CREATE OR REPLACE TABLE test_schema.`test_table` ('
@@ -130,6 +131,7 @@ class TestFastSyncTargetBigquery:
             target_schema='test_schema',
             table_name='order',
             columns=['`id` INTEGER', '`txt` STRING', '`select` STRING'],
+            primary_key=[],
         )
         client().query.assert_called_with(
             'CREATE OR REPLACE TABLE test_schema.`order` ('
@@ -145,6 +147,7 @@ class TestFastSyncTargetBigquery:
             target_schema='test_schema',
             table_name='TABLE with SPACE',
             columns=['`ID` INTEGER', '`COLUMN WITH SPACE` STRING'],
+            primary_key=[],
         )
         client().query.assert_called_with(
             'CREATE OR REPLACE TABLE test_schema.`table_with_space` ('
@@ -160,6 +163,7 @@ class TestFastSyncTargetBigquery:
             target_schema='test_schema',
             table_name='test_table_no_pk',
             columns=['`ID` INTEGER', '`TXT` STRING'],
+            primary_key=[],
         )
         client().query.assert_called_with(
             'CREATE OR REPLACE TABLE test_schema.`test_table_no_pk` ('
@@ -167,6 +171,22 @@ class TestFastSyncTargetBigquery:
             '_sdc_extracted_at timestamp,'
             '_sdc_batched_at timestamp,'
             '_sdc_deleted_at timestamp)',
+            job_config=ANY,
+        )
+
+        # Create table with primary key
+        self.bigquery.create_table(
+            target_schema='test_schema',
+            table_name='test_table_no_pk',
+            columns=['`ID` INTEGER', '`TXT` STRING'],
+            primary_key=['`id`', '`txt`'],
+        )
+        client().query.assert_called_with(
+            'CREATE OR REPLACE TABLE test_schema.`test_table_no_pk` ('
+            '`id` integer,`txt` string,'
+            '_sdc_extracted_at timestamp,'
+            '_sdc_batched_at timestamp,'
+            '_sdc_deleted_at timestamp) CLUSTER BY `id`,`txt`',
             job_config=ANY,
         )
 


### PR DESCRIPTION
## Problem

Using unclustered tables makes MERGE statements very expensive in BigQuery as they require full table scans regardless on the data to be merged.

## Proposed changes

Set the clustered key based on the primary key.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
