### PR TITLE
AP-1072|Issue:806 FastSync Pg to Pg fails on empty tables

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run Unit tests
         if: steps.check.outcome == 'failure'
         run: |
-          pytest --cov=pipelinewise --cov-fail-under=72 -v tests/units
+          pytest --cov=pipelinewise --cov-fail-under=74 -v tests/units
 
   e2e_tests:
     runs-on: ubuntu-20.04

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -351,7 +351,7 @@ class FastSyncTapPostgres:
             key_value = float(postgres_key_value)
 
         if key_value is None:
-            LOGGER.warning('Not replication value found for table %s, returning empty bookmark', table)
+            LOGGER.warning('No replication value found for table %s, returning empty bookmark', table)
             return {}
 
         return {

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -338,6 +338,11 @@ class FastSyncTapPostgres:
             )
 
         postgres_key_value = result[0].get('key_value')
+
+        if postgres_key_value is None:
+            LOGGER.warning('No replication value found for table %s, returning empty bookmark', table)
+            return {}
+
         key_value = postgres_key_value
 
         # Convert postgres data/datetime format to JSON friendly values
@@ -349,10 +354,6 @@ class FastSyncTapPostgres:
 
         elif isinstance(postgres_key_value, decimal.Decimal):
             key_value = float(postgres_key_value)
-
-        if key_value is None:
-            LOGGER.warning('No replication value found for table %s, returning empty bookmark', table)
-            return {}
 
         return {
             'replication_key': replication_key,

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -332,7 +332,7 @@ class FastSyncTapPostgres:
         result = self.query(
             f'SELECT MAX({replication_key}) AS key_value FROM {schema_name}."{table_name}"'
         )
-        if len(result) == 0:
+        if not result:
             raise Exception(
                 'Cannot get replication key value for table: {}'.format(table)
             )
@@ -349,6 +349,10 @@ class FastSyncTapPostgres:
 
         elif isinstance(postgres_key_value, decimal.Decimal):
             key_value = float(postgres_key_value)
+
+        if key_value is None:
+            LOGGER.warning('Not replication value found for table %s, returning empty bookmark', table)
+            return {}
 
         return {
             'replication_key': replication_key,

--- a/singer-connectors/tap-postgres/requirements.txt
+++ b/singer-connectors/tap-postgres/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-postgres==1.8.2
+pipelinewise-tap-postgres==1.8.3

--- a/tests/db/tap_postgres_data.sql
+++ b/tests/db/tap_postgres_data.sql
@@ -4559,3 +4559,11 @@ INSERT INTO customers (name, phone, email) VALUES ('Martelle Cristoforetti', '20
 	('Ransell Fardo', '9584912534', 'rfardoh@de.vu'),
 	('Leonard Buche', '9391842560', 'lbuchei@netscape.com'),
 	('Xylia Adnet', '6784481146', 'xadnetj@auda.org.au');
+
+-----
+DROP TABLE IF EXISTS public.empty_table CASCADE;
+
+CREATE TABLE public.empty_table (
+                           id serial primary key,
+                           cbool bool
+);

--- a/tests/end_to_end/test-project/tap_postgres_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_pg.yml.template
@@ -89,6 +89,11 @@ schemas:
           - column: "email"
             type: "MASK-STRING-SKIP-ENDS-6"
 
+      ### Empty table
+      - table_name: "empty_table"
+        replication_method: "INCREMENTAL"
+        replication_key: "id"
+
   ### SOURCE SCHEMA 2: public2
   - source_schema: "public2"
     target_schema: "ppw_e2e_tap_postgres_public2"

--- a/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
@@ -86,6 +86,11 @@ schemas:
           - column: "email"
             type: "MASK-STRING-SKIP-ENDS-6"
 
+      ### Empty table
+      - table_name: "empty_table"
+        replication_method: "INCREMENTAL"
+        replication_key: "id"
+
   ### SOURCE SCHEMA 2: public2
   - source_schema: "public2"
     target_schema: "ppw_e2e_tap_postgres_public2${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"

--- a/tests/end_to_end/test-project/tap_postgres_to_sf_split_large_files.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf_split_large_files.yml.template
@@ -71,6 +71,11 @@ schemas:
         replication_method: "INCREMENTAL"
         replication_key: "id"
 
+      ### Table with reserved word
+      - table_name: "empty_table"
+        replication_method: "INCREMENTAL"
+        replication_key: "id"
+
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_space and UPPERCase"
         replication_method: "LOG_BASED"
@@ -103,19 +108,3 @@ schemas:
       - table_name: "public2_edgydata"
         replication_method: "INCREMENTAL"
         replication_key: "cid"
-
-  ### SOURCE SCHEMA 3: logical 1
-  #- source_schema: "logical1"
-  #  target_schema: "ppw_e2e_tap_postgres_logical1${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
-  #
-  #  tables:
-  #    - table_name: "logical1_table1"
-  #      replication_method: "LOG_BASED"
-  #    - table_name: "logical1_table2"
-  #    - table_name: "logical1_edgydata"
-
-  ### SOURCE SCHEMA 4: logical2
-  #- source_schema: "logical2"
-  #  target_schema: "ppw_e2e_tap_postgres_logical2${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
-  #  tables:
-  #    - table_name: "logical2_table1"

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -307,7 +307,9 @@ class TestFastSyncTapPostgres(TestCase):
         ]
 
     def test_fetch_current_incremental_key_pos_empty_result_expect_exception(self):
-
+        """
+        test fetch_current_incremental_key_pos where result is empty, it should raise an exception
+        """
         with patch.object(self.postgres, 'query') as query_mock:
             query_mock.return_value = None
 
@@ -317,7 +319,9 @@ class TestFastSyncTapPostgres(TestCase):
             self.assertEqual('Cannot get replication key value for table: schema.table1', str(cm.exception))
 
     def test_fetch_current_incremental_key_pos_empty_key_value_return_empty_state(self):
-
+        """
+        test fetch_current_incremental_key_pos where result has empty value is empty, it should return an empty state
+        """
         with patch.object(self.postgres, 'query') as query_mock:
             query_mock.return_value = [{}]
 
@@ -326,7 +330,9 @@ class TestFastSyncTapPostgres(TestCase):
             self.assertFalse(state)
 
     def test_fetch_current_incremental_key_pos_non_empty_key_value_return_state(self):
-
+        """
+        test fetch_current_incremental_key_pos where result exists, it should return a non empty state with key value
+        """
         with patch.object(self.postgres, 'query') as query_mock:
             query_mock.return_value = [{'key_value': 123}]
 
@@ -339,7 +345,10 @@ class TestFastSyncTapPostgres(TestCase):
             }, state)
 
     def test_fetch_current_incremental_key_pos_datetime_key_value_return_state(self):
-
+        """
+        test fetch_current_incremental_key_pos where result is datetime, it should return a state with iso formatted
+         datetime key value
+        """
         with patch.object(self.postgres, 'query') as query_mock:
             query_mock.return_value = [{'key_value': datetime.datetime(2020, 1, 24, 7, 12, 6)}]
 
@@ -352,7 +361,10 @@ class TestFastSyncTapPostgres(TestCase):
             }, state)
 
     def test_fetch_current_incremental_key_pos_date_key_value_return_state(self):
-
+        """
+        test fetch_current_incremental_key_pos where result is date, it should return a state with iso formatted
+         datetime key value
+        """
         with patch.object(self.postgres, 'query') as query_mock:
             query_mock.return_value = [{'key_value': datetime.date(2020, 1, 24)}]
 
@@ -365,7 +377,9 @@ class TestFastSyncTapPostgres(TestCase):
             }, state)
 
     def test_fetch_current_incremental_key_pos_decimal_key_value_return_state(self):
-
+        """
+        test fetch_current_incremental_key_pos where result is decimal, it should return a state with float key value
+        """
         with patch.object(self.postgres, 'query') as query_mock:
             query_mock.return_value = [{'key_value': Decimal(4.222222222)}]
 

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -313,10 +313,10 @@ class TestFastSyncTapPostgres(TestCase):
         with patch.object(self.postgres, 'query') as query_mock:
             query_mock.return_value = None
 
-            with self.assertRaises(Exception) as cm:
+            with self.assertRaises(Exception) as context:
                 self.postgres.fetch_current_incremental_key_pos('schema.table1', 'id')
 
-            self.assertEqual('Cannot get replication key value for table: schema.table1', str(cm.exception))
+            self.assertEqual('Cannot get replication key value for table: schema.table1', str(context.exception))
 
     def test_fetch_current_incremental_key_pos_empty_key_value_return_empty_state(self):
         """


### PR DESCRIPTION
## Problem

https://github.com/transferwise/pipelinewise/issues/806

The bookmark for incremental is also wrong, it's returning a null replication key value because there is no data.

## Proposed changes

Add condition on the existence of exported file, and only import into target PG if this file exists.
Return empty bookmarks for empty tables.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
