### PR TITLE
Simple approach to pipelinewise extension

### DIFF
--- a/docs/user_guide/transformations.rst
+++ b/docs/user_guide/transformations.rst
@@ -42,6 +42,8 @@ The following transformations can be added optionally into the :ref:`yaml_config
 
 * **MASK-STRING-SKIP-ENDS-n**: Transforms string columns to masked version skipping first and last n characters, e.g. MASK-STRING-SKIP-ENDS-3
 
+* **NULL-OR-REDACTED**: Transforms any column to '<redacted>', but maintains NULL values as NULL.
+
 
 .. _transformation_validation:
 

--- a/docs/user_guide/transformations.rst
+++ b/docs/user_guide/transformations.rst
@@ -42,8 +42,6 @@ The following transformations can be added optionally into the :ref:`yaml_config
 
 * **MASK-STRING-SKIP-ENDS-n**: Transforms string columns to masked version skipping first and last n characters, e.g. MASK-STRING-SKIP-ENDS-3
 
-* **NULL-OR-REDACTED**: Transforms any column to '<redacted>', but maintains NULL values as NULL.
-
 
 .. _transformation_validation:
 

--- a/pipelinewise/cli/config.py
+++ b/pipelinewise/cli/config.py
@@ -314,7 +314,7 @@ class Config:
                     if 'external_type' in trans:
                         external_type = trans['external_type']
                     else:
-                        external_type = None
+                        external_type = 'INTERNAL'
                     if 'param' in trans:
                         param = trans['param']
                     else:

--- a/pipelinewise/cli/schemas/tap.json
+++ b/pipelinewise/cli/schemas/tap.json
@@ -158,7 +158,8 @@
           "type": "string",
           "enum": [
             "NULL-OR-REDACTED",
-            "NULL-OR-REDACTED-SKIP-FIRST"
+            "NULL-OR-REDACTED-SKIP-FIRST",
+            "INTERNAL"
           ]
         },
         "param": {

--- a/pipelinewise/cli/schemas/tap.json
+++ b/pipelinewise/cli/schemas/tap.json
@@ -38,19 +38,13 @@
           "type": "object",
           "properties": {
             "column": {
-              "type": "string",
-              "minLength": 1
-            },
-            "field_path": {
-              "type": "string",
-              "minLength": 1
+              "type": "string"
             },
             "equals": {
               "type": ["null", "integer", "string", "boolean", "number"]
             }
           },
-          "required": ["column", "equals"],
-          "additionalProperties": false
+          "required": ["column", "equals"]
         },
         {
           "type": "object",
@@ -60,10 +54,6 @@
             },
             "regex_match": {
               "type": "string"
-            },
-            "field_path": {
-              "type": "string",
-              "minLength": 1
             }
           },
           "required": ["column", "regex_match"]
@@ -132,19 +122,9 @@
     },
     "transformation": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "column": {
-          "type": "string",
-          "minLength": 1
-        },
-        "field_paths": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "minItems": 1
+          "type": "string"
         },
         "type": {
           "type": "string",
@@ -174,6 +154,16 @@
             "MASK-STRING-SKIP-ENDS-9"
           ]
         },
+        "external_type": {
+          "type": "string",
+          "enum": [
+            "NULL-OR-REDACTED",
+            "NULL-OR-REDACTED-SKIP-FIRST"
+          ]
+        },
+        "param": {
+          "type": "integer"
+        },
         "when": {
           "type": "array",
           "items": {
@@ -189,7 +179,6 @@
     },
     "s3_csv_mapping": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "search_prefix": {
           "type": "string"
@@ -383,7 +372,7 @@
     "split_file_max_chunks": {
       "type": "integer",
       "min": 1,
-      "max": 99999
+      "max": 100
     },
     "schemas": {
       "type": "array",

--- a/pipelinewise/fastsync/commons/transform_utils.py
+++ b/pipelinewise/fastsync/commons/transform_utils.py
@@ -37,8 +37,10 @@ class ExternalTransformationType(Enum):
     """
     List of external supported transformation types
     """
+
     NULL_OR_REDACTED = 'NULL-OR-REDACTED'
     NULL_OR_REDACTED_SKIP_FIRST = 'NULL-OR-REDACTED-SKIP-FIRST'
+    INTERNAL = 'INTERNAL'
 
 
 @unique
@@ -85,15 +87,11 @@ class TransformationHelper:
             if trans_item.get('tap_stream_name').lower() == stream_name.lower():
 
                 transform_type = TransformationType(trans_item['type'])
-                if 'external_type' in trans_item:
-                    external_type = ExternalTransformationType(trans_item['external_type'])
-                else:
-                    external_type = None
 
-                if 'param' in trans_item:
-                    param = trans_item['param']
-                else:
-                    param = None
+                external_type = ExternalTransformationType(trans_item['external_type'])
+
+                param = trans_item['param']
+
 
                 # Make the field id safe in case it's a reserved word
                 column = cls.__safe_column(trans_item['field_id'], sql_flavor)
@@ -109,7 +107,7 @@ class TransformationHelper:
                     )
 
                 elif transform_type == TransformationType.HASH:
-                    if external_type is None:
+                    if external_type == ExternalTransformationType.INTERNAL:
                         trans_map.append(
                             {
                                 'trans': cls.__hash_to_sql(column, sql_flavor),


### PR DESCRIPTION
Edited 
* `pipelinewise/cli/config.py`
* `pipelinewise/cli/schemas/tap.json`
* `pipelinewise/fastsync/commons/transform_utils.py`

To allow for optional parameters `external_type` and `param` in the tap yaml. 
* There are new, external transforms in `transform_utils` that overload the HASH `type`, using an (inferred when missing) `ExternalTransformationType` switch