### PR TITLE
[AP-1104] Ignore log file status when deciding if a tap can be started

### DIFF
--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1154,12 +1154,6 @@ class PipelineWise:
             self.logger.info('Tap %s is not enabled.', self.tap['name'])
             sys.exit(1)
 
-        # Run only if not running
-        tap_status = self.detect_tap_status(target_id, tap_id)
-        if tap_status['currentStatus'] == 'running':
-            self.logger.info('Tap %s is currently running.', self.tap['name'])
-            sys.exit(1)
-
         # Generate and run the command to run the tap directly
         tap_config = self.tap['files']['config']
         tap_inheritable_config = self.tap['files']['inheritable_config']
@@ -1371,15 +1365,6 @@ class PipelineWise:
         # Run only if tap enabled
         if not self.tap.get('enabled', False):
             self.logger.info('Tap %s is not enabled.', self.tap['name'])
-            sys.exit(1)
-
-        # Run only if tap not running
-        tap_status = self.detect_tap_status(target_id, tap_id)
-        if tap_status['currentStatus'] == 'running':
-            self.logger.info(
-                'Tap %s is currently running and cannot sync. Stop the tap and try again.',
-                self.tap['name'],
-            )
             sys.exit(1)
 
         # Tap exists but configuration not completed


### PR DESCRIPTION
## Problem

Since the implementation of a PID file, checking these log files should not longer be done.

## Proposed changes

Removed log file status checking to decide if a tap can be started


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
