### PR TITLE
fix tap_mysql_to_sf_split_large_files.yml.template

### DIFF
--- a/tests/end_to_end/test-project/tap_mysql_to_sf_split_large_files.yml.template
+++ b/tests/end_to_end/test-project/tap_mysql_to_sf_split_large_files.yml.template
@@ -42,4 +42,76 @@ schemas:
     target_schema: "ppw_e2e_tap_mysql${TARGET_SNOWFLAKE_SCHEMA_POSTFIX}"
 
     tables:
+      ### Table with LOG_BASED replication
+      - table_name: "weight_unit"
+        replication_method: "LOG_BASED"
+        transformations:
+          - column: "weight_unit_name"
+            type: "HASH-SKIP-FIRST-2"
+
+      ### Table with INCREMENTAL replication
       - table_name: "address"
+        replication_method: "INCREMENTAL"
+        replication_key: "date_updated"
+        transformations:
+          - column: "zip_code_zip_code_id"
+            type: "MASK-NUMBER"
+            when:
+              - column: 'street_number'
+                regex_match: '[801]'
+
+          - column: "date_created"
+            type: "MASK-DATE"
+
+      ### Table with FULL_TABLE replication
+      - table_name: "order"
+        replication_method: "FULL_TABLE"
+
+      ### Table with no primary key
+      - table_name: "no_pk_table"
+        replication_method: "FULL_TABLE"
+
+      ### Table with binary and varbinary columns
+      - table_name: "table_with_binary"
+        replication_method: "LOG_BASED"
+
+      ### Table with reserved words and columns and special characters
+      - table_name: "edgydata"
+        replication_method: "LOG_BASED"
+        transformations:
+          - column: "case"
+            type: "HASH"
+
+          - column: "group"
+            type: "MASK-NUMBER"
+            when:
+              - column: 'case'
+                equals: 'A'
+          - column: "group"
+            type: "SET-NULL"
+            when:
+              - column: 'case'
+                equals: 'B'
+
+      ### Table with reserved word
+      - table_name: "full"
+        replication_method: "INCREMENTAL"
+        replication_key: "begin"
+
+      ### Table with space and mixed upper and lowercase characters
+      - table_name: "table_with_space and UPPERCase"
+        replication_method: "LOG_BASED"
+
+      ### Table with all possible data types
+      - table_name: "all_datatypes"
+        replication_method: "LOG_BASED"
+
+      ### Table with LOG_BASED replication
+      - table_name: "customers"
+        replication_method: "LOG_BASED"
+        transformations:
+          - column: "phone"
+            type: "MASK-STRING-SKIP-ENDS-2"
+
+          - column: "email"
+            type: "MASK-STRING-SKIP-ENDS-6"


### PR DESCRIPTION
If E2E test `test_resync_mariadb_to_sf_with_split_large_files` is run independently, then it fails. But it passes if it's run as a part of the entire test suite.

## Proposed changes

Fixing `tap_mysql_to_sf_split_large_files.yml.template` so that the test can succeed if run independently also.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
