### PR TITLE
RULES-655 bumping tap-kafka version

### DIFF
--- a/docs/connectors/taps/kafka.rst
+++ b/docs/connectors/taps/kafka.rst
@@ -10,6 +10,7 @@ Messages from kafka topics are extracted into the following fields:
 * ``MESSAGE_OFFSET``: Offset extracted from the kafka metadata
 * ``MESSAGE_PARTITION``: Partition extracted from the kafka metadata
 * ``MESSAGE``: The original and full kafka message
+* ``MESSAGE_KEY``: (Optional) Key extracted from the Kafka message.
 * `Dynamic primary key columns`: (Optional) Fields extracted from the Kafka JSON messages by JSONPath selector(s).
 
 Supported message formats: JSON and Protobuf (experimental).
@@ -47,7 +48,6 @@ Example YAML for ``tap-kafka``:
       bootstrap_servers: "kafka1.foo.com:9092,kafka2.foo.com:9092,kafka3.foo.com:9092"
       topic: "myKafkaTopic"
 
-
       # --------------------------------------------------------------------------
       # Optionally you can define primary key(s) from the kafka JSON messages.
       # If primary keys defined then extra column(s) will be added to the output
@@ -55,6 +55,14 @@ Example YAML for ``tap-kafka``:
       # --------------------------------------------------------------------------
       primary_keys:
          transfer_id: "/transferMetadata/transferId"
+      
+      # --------------------------------------------------------------------------
+      # Additionally you can specify whether to use Kafka message key as a primary key.
+      # If custom primary keys were specified earlier, message key property is ignored
+      # and custom PKs are used instead.
+      # ! Message key should be a valid utf-8 encoded string.
+      # --------------------------------------------------------------------------      
+      use_message_key:                          # (Default: true)  
 
       #initial_start_time:                      # (Default: latest) Start time reference of the message consumption if
                                                 # no bookmarked position in state.json. One of: latest, earliest or an
@@ -76,9 +84,9 @@ Example YAML for ``tap-kafka``:
       # --------------------------------------------------------------------------
       #message_format: protobuf                 # (Default: json) Supported message formats are json and protobuf.
       #proto_schema: |                          # Protobuf message format in .proto syntax. Required if the message_format is protobuf.
-      #     syntax = "proto3";
+      #     syntax = "proto3";                  
       #
-      #     message ProtoMessage {
+      #     message ProtoMessage {          
       #       string query = 1;
       #       int32 page_number = 2;
       #       int32 result_per_page = 3;

--- a/singer-connectors/tap-kafka/requirements.txt
+++ b/singer-connectors/tap-kafka/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-kafka==6.0.0
+pipelinewise-tap-kafka==7.0.0


### PR DESCRIPTION
## Problem

There is a new release for tap-kafka (v7.0.0). 
Note: the change is breaking for some specific taps and is not backwards compatible out-of-the-box.

## Proposed changes

Bumping tap-kafka requirement to v7.0.0 as well as updating the documentation to reflect the change.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
