### PR TITLE
Make sure that Postgres always get a consistent snapshot

### DIFF
--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -28,9 +28,7 @@ class FastSyncTapPostgres:
         self.tap_type_to_target_type = tap_type_to_target_type
         self.target_quote = target_quote
         self.conn = None
-        self.curr = None
         self.primary_host_conn = None
-        self.primary_host_curr = None
         self.version = None
 
     @staticmethod
@@ -188,7 +186,6 @@ class FastSyncTapPostgres:
         self.conn = self.get_connection(
             self.connection_config, prioritize_primary=False
         )
-        self.curr = self.conn.cursor()
 
     def close_connection(self):
         """
@@ -320,7 +317,6 @@ class FastSyncTapPostgres:
         self.primary_host_conn = self.get_connection(
             self.connection_config, prioritize_primary=True
         )
-        self.primary_host_curr = self.primary_host_conn.cursor()
 
         # Make sure PostgreSQL version is 9.4 or higher
         result = self.primary_host_query(
@@ -561,4 +557,5 @@ class FastSyncTapPostgres:
         )
 
         with gzip_splitter as split_gzip_files:
-            self.curr.copy_expert(sql, split_gzip_files, size=131072)
+            with self.conn.cursor() as cur:
+                cur.copy_expert(sql, split_gzip_files, size=131072)

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -3,6 +3,7 @@ import decimal
 import logging
 import re
 import sys
+import textwrap
 import psycopg2
 import psycopg2.errors
 import psycopg2.extras
@@ -280,6 +281,33 @@ class FastSyncTapPostgres:
                     'Logical replication not supported before PostgreSQL 9.4'
                 )
         return parse_lsn(result[0]['current_lsn'])
+
+    def get_confirmed_flush_lsn(self) -> int:
+        """
+        Get the last flushed LSN for the replication slot.
+
+        For Postgres <9.6 this defaults to the restart_lsn as confirmed_flush_lsn
+        is not availiable.
+        """
+        slot_name = self.__get_slot_name(
+            self.primary_host_conn,
+            self.connection_config['dbname'],
+            self.connection_config['tap_id'],
+        )
+
+        res = self.primary_host_query(
+            textwrap.dedent(
+                f"""SELECT *
+                    FROM pg_replication_slots
+                    WHERE slot_name = '{slot_name}'
+                    AND plugin = 'wal2json'
+                    AND slot_type = 'logical'"""
+            )
+        )[0]
+
+        # confirmed_flush_lsn was introduced in Postgres 9.6 so fallback to
+        # restart_lsn if needed.
+        return parse_lsn(res.get('confirmed_flush_lsn', res['restart_lsn']))
 
     # pylint: disable=too-many-branches,no-member,chained-comparison
     def fetch_current_log_pos(self):

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -529,8 +529,9 @@ class FastSyncTapPostgres:
             split_file_chunk_size_mb: File chunk sizes if `split_large_files` enabled. (Default: 1000)
             split_file_max_chunks: Max number of chunks if `split_large_files` enabled. (Default: 20)
         """
-        table_columns = self.get_table_columns(table_name, max_num, date_type)
-        column_safe_sql_values = [c.get('safe_sql_value') for c in table_columns]
+        column_safe_sql_values = [
+            c.get('safe_sql_value') for c in self.get_table_columns(table_name, max_num, date_type)
+        ]
 
         # If self.get_table_columns returns zero row then table not exist
         if len(column_safe_sql_values) == 0:

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -356,13 +356,10 @@ class FastSyncTapPostgres:
         if self.connection_config.get('replica_host'):
             # Ensure that the newest LSN availiable on the replica is newer than
             # the oldest LSN which is deliverable by the replication slot.
-            time_waited = 0  # seconds
-            wait_period = 1  # seconds
             max_time_waited = 60  # seconds
+            now = time.time()
             while oldest_lsn > current_lsn:
-                time.sleep(wait_period)
-                time_waited += wait_period
-                if time_waited > max_time_waited:
+                if time.time() - now > max_time_waited:
                     raise RuntimeError('Replica database is lagging too far behind Primary.')
                 current_lsn = self.get_current_lsn()
 

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -295,7 +295,8 @@ class FastSyncTapPostgres:
 
         res = self.primary_host_query(
             textwrap.dedent(
-                f"""SELECT *
+                f"""\
+                    SELECT *
                     FROM pg_replication_slots
                     WHERE slot_name = '{slot_name}'
                     AND plugin = 'wal2json'

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -21,11 +21,6 @@ class TestFastSyncTapPostgres(TestCase):
         self.postgres.executed_queries_primary_host = []
         self.postgres.executed_queries = []
 
-        def primary_host_query_mock(query, _=None):
-            self.postgres.executed_queries_primary_host.append(query)
-
-        self.postgres.primary_host_query = primary_host_query_mock
-
     def test_generate_repl_slot_name(self):
         """Validate if the replication slot name generated correctly"""
         # Provide only database name
@@ -70,17 +65,20 @@ class TestFastSyncTapPostgres(TestCase):
         Validate if replication slot creation SQL commands generated correctly in case no v15 slots exists
         """
 
-        def execute_mock(query):
+        def execute_mock(query, _=None):
             print('Mocked execute called')
             self.postgres.executed_queries_primary_host.append(query)
 
         # mock cursor with execute method
         cursor_mock = MagicMock().return_value
         cursor_mock.__enter__.return_value.execute.side_effect = execute_mock
-        type(cursor_mock.__enter__.return_value).rowcount = PropertyMock(return_value=0)
+        # First query -> 0 rows, second query -> 1 row
+        type(cursor_mock.__enter__.return_value).rowcount = PropertyMock(side_effect=[0, 1])
+        cursor_mock.__enter__.return_value.fetchall.return_value = [{'lsn': '24368/44107178'}]
 
         # mock PG connection instance with ability to open cursor
-        pg_con = Mock()
+        pg_con = MagicMock()
+        pg_con.__enter__.return_value = pg_con
         pg_con.cursor.return_value = cursor_mock
 
         self.postgres.primary_host_conn = pg_con
@@ -96,17 +94,20 @@ class TestFastSyncTapPostgres(TestCase):
         Validate if replication slot creation SQL commands generated correctly in case a v15 slots exists
         """
 
-        def execute_mock(query):
+        def execute_mock(query, _=None):
             print('Mocked execute called')
             self.postgres.executed_queries_primary_host.append(query)
 
         # mock cursor with execute method
         cursor_mock = MagicMock().return_value
         cursor_mock.__enter__.return_value.execute.side_effect = execute_mock
-        type(cursor_mock.__enter__.return_value).rowcount = PropertyMock(return_value=1)
+        # First query -> 1 row, second query -> 1 row
+        type(cursor_mock.__enter__.return_value).rowcount = PropertyMock(side_effect=[1, 1])
+        cursor_mock.__enter__.return_value.fetchall.return_value = [{'lsn': '24368/44107178'}]
 
         # mock PG connection instance with ability to open cursor
-        pg_con = Mock()
+        pg_con = MagicMock()
+        pg_con.__enter__.return_value = pg_con
         pg_con.cursor.return_value = cursor_mock
 
         self.postgres.primary_host_conn = pg_con


### PR DESCRIPTION
## Problem

It is currently possible for PipelineWise to select an LSN to stream from which will result in missing data once the initial snapshot has been conducted.

This is due to the current mechanism of just selecting either the most recent LSN on the primary or the most recent LSN which has been replayed on the replica: https://github.com/thread/pipelinewise/blob/cfd2c2091eb60a5b71ea38486594ccfb91a4fe1c/pipelinewise/fastsync/commons/tap_postgres.py#L297-L322

This is not a safe thing to do as it does not guarantee a consistent view of the database.

Fixes: #930

## Proposed changes

Inspired by how Debezium (another CDC tool written in Java) deals with initial snapshots of Postgres databases we will take advantage of two behaviours:

1. When a replica slot is created Postgres calculates the first LSN at which the slot will provide a consistent view of the database (it also sets `confirmed_flush_lsn` to this value). We will stream from that point forward but use the current state of the database as the snapshot.
2. Since PipelineWise only relieves logically decoded messages of complete transactions it should be safe to assume that any LSN that PipelineWise receives (and confirms) provides a consistent view of the database. Therefore, if the replication slot already exists we will take the current value of `confirmed_flush_lsn` to be the point at which we will start streaming.

In both of these cases, we may have data which will also be streamed to us by the replication slot but this should not be an issue as we are relying on an 'at least once' delivery mechanism already.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions