### PR TITLE
RULES-655 updating tap json schema

### DIFF
--- a/pipelinewise/cli/schemas/tap.json
+++ b/pipelinewise/cli/schemas/tap.json
@@ -35,6 +35,9 @@
           "type": "integer",
           "minimum": 1,
           "maximum": 1000
+        },
+        "use_message_key": {
+          "type": "boolean"
         }
       }
     },


### PR DESCRIPTION
## Problem

Tap json schema is currently misaligned with the changes introduced in tap-kafka v7.0.0 (and the subsequent bump of requirement https://github.com/transferwise/pipelinewise/pull/928).

## Proposed changes

Added new property, `use_message_key`, to the tap schema.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
