### PR TITLE
AP-1183: patch tap-mysql

### DIFF
--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mysql==1.5.0
+pipelinewise-tap-mysql==1.5.1


### PR DESCRIPTION
## Problem

There is a bug when switch a mariadb tap to use GTID, gtid lookup runs into an edge case.
see https://github.com/transferwise/pipelinewise-tap-mysql/pull/102

## Proposed changes

patch tap-mysql

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
