### PR TITLE
Revert "[AP-1104] Ignore log file status when deciding if a tap can be started"

### DIFF
--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1155,6 +1155,12 @@ class PipelineWise:
             self.logger.info('Tap %s is not enabled.', self.tap['name'])
             sys.exit(1)
 
+        # Run only if not running
+        tap_status = self.detect_tap_status(target_id, tap_id)
+        if tap_status['currentStatus'] == 'running':
+            self.logger.info('Tap %s is currently running.', self.tap['name'])
+            sys.exit(1)
+
         # Generate and run the command to run the tap directly
         tap_config = self.tap['files']['config']
         tap_inheritable_config = self.tap['files']['inheritable_config']
@@ -1367,6 +1373,15 @@ class PipelineWise:
         # Run only if tap enabled
         if not self.tap.get('enabled', False):
             self.logger.info('Tap %s is not enabled.', self.tap['name'])
+            sys.exit(1)
+
+        # Run only if tap not running
+        tap_status = self.detect_tap_status(target_id, tap_id)
+        if tap_status['currentStatus'] == 'running':
+            self.logger.info(
+                'Tap %s is currently running and cannot sync. Stop the tap and try again.',
+                self.tap['name'],
+            )
             sys.exit(1)
 
         # Tap exists but configuration not completed


### PR DESCRIPTION
Reverts transferwise/pipelinewise#919

@amofakhar This will break distributed execution won't it? For example in Kubernetes the main process is always PID 1. So the PID in the pid_file will also always be 1. The PID file will therefore always identify the instance of PipelineWise which is running in the current Pod as the one who wrote the PID file (even if it didn't), check that the process name is correct (it will be) and continue running.

The log extension based checking was better as it could not collide with anything. PIDs can collide when running in a distributed setting.