### PR TITLE
Add support for Postgres' hstore type to fast sync

### DIFF
--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -415,9 +415,13 @@ class FastSyncTapPostgres:
                     ,character_maximum_length
                 FROM (SELECT
                 column_name,
-                data_type,
+                CASE 
+                  WHEN data_type = 'USER-DEFINED' AND udt_name = 'hstore' THEN 'hstore'
+                  ELSE data_type
+                END as data_type,
                 CASE
                     WHEN data_type = 'ARRAY' THEN 'array_to_json("' || column_name || '") AS ' || column_name
+                    WHEN data_type = 'USER-DEFINED' AND udt_name = 'hstore' THEN column_name|| '::json AS ' || column_name
                     WHEN data_type = 'date' THEN
                        'CASE WHEN "' ||column_name|| E'" < \\'0001-01-01\\' '
                             'OR "' ||column_name|| E'" > \\'9999-12-31\\' THEN \\'9999-12-31\\' '

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -41,8 +41,13 @@ REQUIRED_CONFIG_KEYS = {
 LOCK = multiprocessing.Lock()
 
 
-def tap_type_to_target_type(pg_type, *_):
+def tap_type_to_target_type(pg_type, extra=None):
     """Data type mapping from Postgres to Snowflake"""
+
+    # Needed for call from assertion test helper
+    if pg_type == 'user-defined' and extra == 'hstore':
+        pg_type = 'hstore'
+
     return {
         'char': 'VARCHAR',
         'character': 'VARCHAR',
@@ -75,6 +80,7 @@ def tap_type_to_target_type(pg_type, *_):
         'ARRAY': 'VARIANT',
         'json': 'VARIANT',
         'jsonb': 'VARIANT',
+        'hstore': 'VARIANT'
     }.get(pg_type, 'VARCHAR')
 
 

--- a/tests/db/tap_postgres_data.sql
+++ b/tests/db/tap_postgres_data.sql
@@ -59,6 +59,26 @@ Maatjies', DATE '2021-01-30'),
 COMMIT;
 
 BEGIN;
+SET client_encoding = 'UTF8';
+
+CREATE EXTENSION IF NOT EXISTS hstore;
+
+DROP TABLE IF EXISTS public.special_data_types;
+
+CREATE TABLE public.special_data_types(
+    id serial PRIMARY KEY,
+    cHstore hstore
+);
+
+INSERt INTO public.special_data_types
+    (cHstore)
+VALUES
+    ('"key" => "some value"'),
+    ('"spaced key" => "another value"');
+COMMIT;
+
+
+BEGIN;
 SET client_encoding = 'LATIN1';
 
 DROP SCHEMA IF EXISTS public2 CASCADE;

--- a/tests/end_to_end/helpers/db.py
+++ b/tests/end_to_end/helpers/db.py
@@ -133,7 +133,7 @@ def sql_get_columns_postgres(schemas: list) -> str:
     sql_schemas = ', '.join(f"'{schema}'" for schema in schemas)
 
     return f"""
-    SELECT table_name, STRING_AGG(CONCAT(column_name, ':', data_type, ':'), ';' ORDER BY column_name)
+    SELECT table_name, STRING_AGG(CONCAT(column_name, ':', data_type, ':', udt_name), ';' ORDER BY column_name)
      FROM information_schema.columns
     WHERE table_schema IN ({sql_schemas})
     GROUP BY table_name

--- a/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
@@ -67,6 +67,10 @@ schemas:
         replication_method: "INCREMENTAL"
         replication_key: "id"
 
+      ### Table with special data types
+      - table_name: "special_data_types"
+        replication_method: "LOG_BASED"
+
       ### Table with space and mixed upper and lowercase characters
       - table_name: "table_with_space and UPPERCase"
         replication_method: "LOG_BASED"


### PR DESCRIPTION
## Problem

Fast sync would map an hstore type to VARCHAR in Snowflake. However, log-based replication would then migrate the column to VARIANT during the first run.

## Proposed changes

Serialize hstore as json and create column of type VARIANT in Snowflake.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
