### PR TITLE
Increase logical_poll_total_seconds for Postgres e2e tests

### DIFF
--- a/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf.yml.template
@@ -14,7 +14,7 @@ owner: "test-runner"
 # ------------------------------------------------------------------------------
 db_conn:
   host: "${TAP_POSTGRES_HOST}"          # PostgreSQL host
-  logical_poll_total_seconds: 3         # Time out if no LOG_BASED changes received for 3 seconds
+  logical_poll_total_seconds: 10        # Time out if no LOG_BASED changes received for 10 seconds
   port: ${TAP_POSTGRES_PORT}            # PostgreSQL port
   user: "${TAP_POSTGRES_USER}"          # PostgreSQL user
   password: "${TAP_POSTGRES_PASSWORD}"  # Plain string or vault encrypted

--- a/tests/end_to_end/test-project/tap_postgres_to_sf_archive_load_files.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf_archive_load_files.yml.template
@@ -14,7 +14,7 @@ owner: "test-runner"
 # ------------------------------------------------------------------------------
 db_conn:
   host: "${TAP_POSTGRES_HOST}"          # PostgreSQL host
-  logical_poll_total_seconds: 3         # Time out if no LOG_BASED changes received for 3 seconds
+  logical_poll_total_seconds: 10        # Time out if no LOG_BASED changes received for 10 seconds
   port: ${TAP_POSTGRES_PORT}            # PostgreSQL port
   user: "${TAP_POSTGRES_USER}"          # PostgreSQL user
   password: "${TAP_POSTGRES_PASSWORD}"  # Plain string or vault encrypted

--- a/tests/end_to_end/test-project/tap_postgres_to_sf_split_large_files.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf_split_large_files.yml.template
@@ -14,7 +14,7 @@ owner: "test-runner"
 # ------------------------------------------------------------------------------
 db_conn:
   host: "${TAP_POSTGRES_HOST}"          # PostgreSQL host
-  logical_poll_total_seconds: 3         # Time out if no LOG_BASED changes received for 3 seconds
+  logical_poll_total_seconds: 10        # Time out if no LOG_BASED changes received for 10 seconds
   port: ${TAP_POSTGRES_PORT}            # PostgreSQL port
   user: "${TAP_POSTGRES_USER}"          # PostgreSQL user
   password: "${TAP_POSTGRES_PASSWORD}"  # Plain string or vault encrypted


### PR DESCRIPTION
## Problem

Postgres sometimes takes some time until it will start
sending the log stream. The current timeout of 3 seconds
would cause 80% of my test runs to fail as the sync would
end before Postgres starts streaming.

## Proposed changes

Increase timeout.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
