### PR TITLE
AP-1226 bump target-s3-csv

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -31,7 +31,9 @@ jobs:
 
       - name: Setup test containers
         if: steps.check.outcome == 'failure'
-        run: docker-compose -f dev-project/docker-compose.yml up -d
+        run: |
+          cp dev-project/.env.template dev-project/.env
+          docker-compose -f dev-project/docker-compose.yml up -d
 
       - name: Wait for test containers to be ready
         if: steps.check.outcome == 'failure'

--- a/singer-connectors/target-s3-csv/requirements.txt
+++ b/singer-connectors/target-s3-csv/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-s3-csv==1.5.0
+pipelinewise-target-s3-csv==2.0.0


### PR DESCRIPTION
## Problem
We're running into some issues in target-s3-csv, latest release of the target has the fix
https://github.com/transferwise/pipelinewise-target-s3-csv/releases/tag/v2.0.0

end to end tests are failing due to this PR:  https://github.com/transferwise/pipelinewise/pull/959

## Proposed changes

- Bump target s3 csv to v2
- create .env file out of the the template file so that end 2 end tests pass.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- x ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
