### PR TITLE
[AP-1250] Fix for table with space in the name

### DIFF
--- a/pipelinewise/cli/commands.py
+++ b/pipelinewise/cli/commands.py
@@ -385,9 +385,9 @@ def build_fastsync_partial_command(
                     if transform.config and os.path.isfile(transform.config)
                     else '',
                     f'--table "{table}"',
-                    f'--column {column}',
-                    f'--start_value {start_value}',
-                    f'--end_value {end_value}' if end_value else None
+                    f'--column "{column}"',
+                    f'--start_value "{start_value}"',
+                    f'--end_value "{end_value}"' if end_value else None
                 ],
             )
         )

--- a/pipelinewise/cli/commands.py
+++ b/pipelinewise/cli/commands.py
@@ -384,7 +384,7 @@ def build_fastsync_partial_command(
                     f'--transform {transform.config}'
                     if transform.config and os.path.isfile(transform.config)
                     else '',
-                    f'--table {table}',
+                    f'--table "{table}"',
                     f'--column {column}',
                     f'--start_value {start_value}',
                     f'--end_value {end_value}' if end_value else None

--- a/tests/units/cli/resources/test_partial_sync/target_snowflake/tap_mysql/properties.json
+++ b/tests/units/cli/resources/test_partial_sync/target_snowflake/tap_mysql/properties.json
@@ -36,6 +36,17 @@
                         "selected-by-default": true,
                         "sql-datatype": "character varying"
                     }
+                },
+                {
+                    "breadcrumb": [
+                        "properties",
+                        "test column"
+                    ],
+                    "metadata": {
+                        "inclusion": "available",
+                        "selected-by-default": true,
+                        "sql-datatype": "character varying"
+                    }
                 }
             ],
             "schema": {
@@ -112,6 +123,13 @@
                         ]
                     },
                     "email": {
+                        "maxLength": 200,
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "test column": {
                         "maxLength": 200,
                         "type": [
                             "null",

--- a/tests/units/cli/resources/test_partial_sync/target_snowflake/tap_mysql/properties.json
+++ b/tests/units/cli/resources/test_partial_sync/target_snowflake/tap_mysql/properties.json
@@ -127,9 +127,9 @@
                 },
                 "type": "object"
             },
-            "stream": "table_one",
-            "table_name": "table_one",
-            "tap_stream_id": "db_test_mysql-table_one"
+            "stream": "table one",
+            "table_name": "table one",
+            "tap_stream_id": "db_test_mysql-table one"
         },
         {
             "metadata": [

--- a/tests/units/cli/resources/test_partial_sync/target_snowflake/tap_mysql/transformation.json
+++ b/tests/units/cli/resources/test_partial_sync/target_snowflake/tap_mysql/transformation.json
@@ -2,7 +2,7 @@
     "transformations": [
         {
             "field_id": "email",
-            "tap_stream_name": "db_test_mysql-table_one",
+            "tap_stream_name": "db_test_mysql-table one",
             "type": "HASH",
             "when": null
         }

--- a/tests/units/cli/test_partial_sync.py
+++ b/tests/units/cli/test_partial_sync.py
@@ -177,7 +177,7 @@ class PartialSyncCLITestCase(TestCase):
         arguments = {
             'tap': 'tap_mysql',
             'target': 'target_snowflake',
-            'table': 'mysql_source_db.table_one',
+            'table': 'mysql_source_db.table one',
             'column': 'id',
             'start_value': '1',
             'end_value': '10'
@@ -199,7 +199,7 @@ class PartialSyncCLITestCase(TestCase):
             f'--target {self.test_cli.CONFIG_DIR}/tmp/target_config_[a-z0-9_]{{8}}.json '
             f'--temp_dir {self.test_cli.CONFIG_DIR}/tmp '
             f'--transform {self.test_cli.CONFIG_DIR}/target_snowflake/tap_mysql/transformation.json '
-            f'--table {arguments["table"]} --column {arguments["column"]} '
+            f'--table \"{arguments["table"]}\" --column {arguments["column"]} '
             f'--start_value {arguments["start_value"]} --end_value {arguments["end_value"]}$'
         )
 
@@ -216,7 +216,7 @@ class PartialSyncCLITestCase(TestCase):
         arguments = {
             'tap': 'tap_mysql',
             'target': 'target_snowflake',
-            'table': 'mysql_source_db.table_one',
+            'table': 'mysql_source_db.table one',
             'column': 'id',
             'start_value': '1',
         }
@@ -236,7 +236,7 @@ class PartialSyncCLITestCase(TestCase):
             f'--target {self.test_cli.CONFIG_DIR}/tmp/target_config_[a-z0-9_]{{8}}.json '
             f'--temp_dir {self.test_cli.CONFIG_DIR}/tmp '
             f'--transform {self.test_cli.CONFIG_DIR}/target_snowflake/tap_mysql/transformation.json '
-            f'--table {arguments["table"]} --column {arguments["column"]} '
+            f'--table \"{arguments["table"]}\" --column {arguments["column"]} '
             f'--start_value {arguments["start_value"]}$'
         )
 
@@ -274,7 +274,7 @@ class PartialSyncCLITestCase(TestCase):
         arguments = {
             'tap': 'tap_mysql',
             'target': 'target_snowflake',
-            'table': 'mysql_source_db.table_one',
+            'table': 'mysql_source_db.table one',
             'column': 'foo_column',
             'start_value': '1',
             'end_value': '10'
@@ -296,7 +296,7 @@ class PartialSyncCLITestCase(TestCase):
         arguments = {
             'tap': 'tap_mysql',
             'target': 'target_snowflake',
-            'table': 'mysql_source_db.table_one',
+            'table': 'mysql_source_db.table one',
             'column': 'boolean_column',
             'start_value': '1'
         }

--- a/tests/units/cli/test_partial_sync.py
+++ b/tests/units/cli/test_partial_sync.py
@@ -199,8 +199,8 @@ class PartialSyncCLITestCase(TestCase):
             f'--target {self.test_cli.CONFIG_DIR}/tmp/target_config_[a-z0-9_]{{8}}.json '
             f'--temp_dir {self.test_cli.CONFIG_DIR}/tmp '
             f'--transform {self.test_cli.CONFIG_DIR}/target_snowflake/tap_mysql/transformation.json '
-            f'--table \"{arguments["table"]}\" --column {arguments["column"]} '
-            f'--start_value {arguments["start_value"]} --end_value {arguments["end_value"]}$'
+            f'--table "{arguments["table"]}" --column "{arguments["column"]}" '
+            f'--start_value "{arguments["start_value"]}" --end_value "{arguments["end_value"]}"$'
         )
 
         self.assertRegex(call_args[1], f'^{self.test_cli.CONFIG_DIR}/{arguments["target"]}/{arguments["tap"]}/log/'
@@ -217,7 +217,7 @@ class PartialSyncCLITestCase(TestCase):
             'tap': 'tap_mysql',
             'target': 'target_snowflake',
             'table': 'mysql_source_db.table one',
-            'column': 'id',
+            'column': 'test column',
             'start_value': '1',
         }
 
@@ -236,8 +236,8 @@ class PartialSyncCLITestCase(TestCase):
             f'--target {self.test_cli.CONFIG_DIR}/tmp/target_config_[a-z0-9_]{{8}}.json '
             f'--temp_dir {self.test_cli.CONFIG_DIR}/tmp '
             f'--transform {self.test_cli.CONFIG_DIR}/target_snowflake/tap_mysql/transformation.json '
-            f'--table \"{arguments["table"]}\" --column {arguments["column"]} '
-            f'--start_value {arguments["start_value"]}$'
+            f'--table "{arguments["table"]}" --column "{arguments["column"]}" '
+            f'--start_value "{arguments["start_value"]}"$'
         )
 
         self.assertRegex(call_args[1], f'^{self.test_cli.CONFIG_DIR}/{arguments["target"]}/{arguments["tap"]}/log/'


### PR DESCRIPTION
## Problem

It could not find the table if there is any space in the name

## Proposed changes

fixing the command generation to have double quotes around the table name

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
