### PR TITLE
AP-1101: Close mysql/mariab connections in FastSync 

### DIFF
--- a/pipelinewise/fastsync/mysql_to_postgres.py
+++ b/pipelinewise/fastsync/mysql_to_postgres.py
@@ -139,6 +139,7 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         # try closing connections again just in case, silence errors
         mysql.close_connections(silent=True)
 
+
 def main_impl():
     """Main sync logic"""
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)


### PR DESCRIPTION
## Problem

In FastSync mysql->X , two connections (buffered and unbuffered) are opened for each table that needs fastsync, if a failure happens before the `close_connections` method is called, these  orphaned connections end up being aborted by the server which shows up in the db logs like so: 

```
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140669979453184 [Warning] Aborted connection 129 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670126831360 [Warning] Aborted connection 136 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670127138560 [Warning] Aborted connection 131 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670127445760 [Warning] Aborted connection 139 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670128367360 [Warning] Aborted connection 132 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670125602560 [Warning] Aborted connection 140 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670128981760 [Warning] Aborted connection 130 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670126216960 [Warning] Aborted connection 138 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670584104704 [Warning] Aborted connection 137 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670126524160 [Warning] Aborted connection 142 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670128060160 [Warning] Aborted connection 145 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670583797504 [Warning] Aborted connection 141 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670124988160 [Warning] Aborted connection 135 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670128674560 [Warning] Aborted connection 144 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670125909760 [Warning] Aborted connection 134 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670581229312 [Warning] Aborted connection 143 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140670127752960 [Warning] Aborted connection 128 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
pipelinewise_dev_mysql_source | 2022-10-05 12:24:25 140669979760384 [Warning] Aborted connection 133 to db: 'unconnected' user: 'pipelinewise' host: '192.168.56.7' (Got an error reading communication packets)
```

## Proposed changes

For each mysql -> X:

* Re-arrange lines to close the connections earlier since no longer needed.
* Add a `finally` block to attempt closing connections in case of failures.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
