### PR TITLE
AP-1276 Bump tap-postgres to use wal2json format version 2

### DIFF
--- a/dev-project/docker-compose.yml
+++ b/dev-project/docker-compose.yml
@@ -72,7 +72,7 @@ services:
   db_postgres_source:
     build:
       context: ./pg
-      dockerfile: pg/Dockerfile
+      dockerfile: Dockerfile
     container_name: pipelinewise_dev_postgres_source
     # Making some logical decoding adjustments
     command: -c "wal_level=logical" -c "max_replication_slots=5" -c "max_wal_senders=5"

--- a/dev-project/docker-compose.yml
+++ b/dev-project/docker-compose.yml
@@ -70,7 +70,9 @@ services:
   # PostgreSQL service container used as test source database
   # Using Debezium image with wal2json plugin for logical decoding
   db_postgres_source:
-    image: debezium/postgres:12-alpine
+    build:
+      context: ./pg
+      dockerfile: pg/Dockerfile
     container_name: pipelinewise_dev_postgres_source
     # Making some logical decoding adjustments
     command: -c "wal_level=logical" -c "max_replication_slots=5" -c "max_wal_senders=5"

--- a/dev-project/pg/Dockerfile
+++ b/dev-project/pg/Dockerfile
@@ -1,0 +1,10 @@
+FROM debezium/postgres:12-alpine
+
+RUN apk add --no-cache --virtual .debezium-build-deps gcc clang llvm git make musl-dev pkgconf \
+    && git clone --depth 1 --branch wal2json_2_3 https://github.com/eulerto/wal2json.git \
+    && cd /wal2json \
+    && make && make install \
+    && cd / \
+    && rm -rf wal2json \
+    && apk del .debezium-build-deps
+

--- a/docs/connectors/taps/postgres.rst
+++ b/docs/connectors/taps/postgres.rst
@@ -8,8 +8,6 @@ Tap PostgreSQL
 PostgreSQL setup requirements
 '''''''''''''''''''''''''''''
 
-*(Section based on Stitch documentation)*
-
 **Step 1: Check if you have all the required credentials for replicating data from PostgreSQL**
 
 * ``CREATEROLE`` or ``SUPERUSER`` privilege - Either permission is required to create a database user for PipelineWise.
@@ -59,7 +57,9 @@ In order for pipelinewise user to automatically be able to access any tables cre
 
 **Step 3.1: Install the wal2json plugin**
 
-To use :ref:`log_based` for your PostgreSQL integration, you must install the `wal2json <https://github.com/eulerto/wal2json>`_ plugin. The wal2json plugin outputs JSON objects for logical decoding, which Stitch then uses to perform Log-based Replication.
+To use :ref:`log_based` for your PostgreSQL integration, you must install the `wal2json <https://github
+.com/eulerto/wal2json>`_ plugin that has support for format-version=2 (wal2json >= 2.3). The wal2json plugin outputs
+JSON objects for logical decoding, which the tap then uses to perform Log-based Replication.
 
 Steps for installing the plugin vary depending on your operating system. Instructions for each operating system type are in the wal2json’s GitHub repository:
 

--- a/singer-connectors/tap-postgres/requirements.txt
+++ b/singer-connectors/tap-postgres/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-postgres==1.8.4
+-e git+https://github.com/transferwise/pipelinewise-tap-postgres.git@master#egg=pipelinewise-tap-postgres

--- a/singer-connectors/tap-postgres/requirements.txt
+++ b/singer-connectors/tap-postgres/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/transferwise/pipelinewise-tap-postgres.git@master#egg=pipelinewise-tap-postgres
+pipelinewise-tap-postgres==2.0.0


### PR DESCRIPTION
## Problem

Tap-postgres now supports using format-version 2 wen consuming WAL using wal2json  

## Proposed changes

Bump tap-postgres and update test container to have wal2json >= v2.3 

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
