### PR TITLE
AP-1311: remove all reliance on log files for tap status

### DIFF
--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -946,8 +946,6 @@ class PipelineWise:
         """
         Prints a status summary table of every imported pipeline with their tap and target.
         """
-        targets = self.get_targets()
-
         tab_headers = [
             'Tap ID',
             'Tap Type',
@@ -960,20 +958,20 @@ class PipelineWise:
         ]
         tab_body = []
         pipelines = 0
-        for target in targets:
-            taps = self.get_taps(target['id'])
+        for target in self.config.get('targets', []):
+            for tap in target['taps']:
+                status = self.detect_tap_status(target['id'], tap['id'])
 
-            for tap in taps:
                 tab_body.append(
                     [
-                        tap.get('id', '<Unknown>'),
-                        tap.get('type', '<Unknown>'),
-                        target.get('id', '<Unknown>'),
-                        target.get('type', '<Unknown>'),
-                        tap.get('enabled', '<Unknown>'),
-                        tap.get('status', {}).get('currentStatus', '<Unknown>'),
-                        tap.get('status', {}).get('lastTimestamp', '<Unknown>'),
-                        tap.get('status', {}).get('lastStatus', '<Unknown>'),
+                        tap['id'],
+                        tap['type'],
+                        target['id'],
+                        target['type'],
+                        tap['enabled'],
+                        status['currentStatus'],
+                        status['lastTimestamp'],
+                        status['lastStatus'],
                     ]
                 )
                 pipelines += 1

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -925,9 +925,9 @@ class PipelineWise:
         # Tap exists but configuration not completed
         if not os.path.isfile(connector_files['config']):
             status['currentStatus'] = 'not-configured'
-
-        pid = pidfile.PIDFile(connector_files['pidfile'])
-        status['currentStatus'] = 'running' if pid.is_running else 'ready'
+        else:
+            pid = pidfile.PIDFile(connector_files['pidfile'])
+            status['currentStatus'] = 'running' if pid.is_running else 'ready'
 
         # Get last run instance
         if os.path.isdir(log_dir):

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1023,19 +1023,6 @@ class PipelineWise:
             profiling_dir=self.profiling_dir,
         )
 
-        # Do not run if another instance is already running
-        log_dir = os.path.dirname(self.tap_run_log_file)
-        if (
-            os.path.isdir(log_dir)
-            and len(utils.search_files(log_dir, patterns=['*.log.running'])) > 0
-        ):
-            self.logger.info(
-                'Failed to run. Another instance of the same tap is already running. '
-                'Log file detected in running status at %s',
-                log_dir,
-            )
-            sys.exit(1)
-
         start = None
         state = None
 

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -939,16 +939,8 @@ class PipelineWise:
         if not os.path.isfile(connector_files['config']):
             status['currentStatus'] = 'not-configured'
 
-        # Tap exists and has log in running status
-        elif (
-            os.path.isdir(log_dir)
-            and len(utils.search_files(log_dir, patterns=['*.log.running'])) > 0
-        ):
-            status['currentStatus'] = 'running'
-
-        # Configured and not running
-        else:
-            status['currentStatus'] = 'ready'
+        pid = pidfile.PIDFile(connector_files['pidfile'])
+        status['currentStatus'] = 'running' if pid.is_running else 'ready'
 
         # Get last run instance
         if os.path.isdir(log_dir):

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1115,19 +1115,6 @@ class PipelineWise:
             drop_pg_slot=self.drop_pg_slot,
         )
 
-        # Do not run if another instance is already running
-        log_dir = os.path.dirname(self.tap_run_log_file)
-        if (
-            os.path.isdir(log_dir)
-            and len(utils.search_files(log_dir, patterns=['*.log.running'])) > 0
-        ):
-            self.logger.info(
-                'Failed to run. Another instance of the same tap is already running. '
-                'Log file detected in running status at %s',
-                log_dir,
-            )
-            sys.exit(1)
-
         # Fastsync is running in subprocess.
         # Collect the formatted logs and log it in the main PipelineWise process as well
         # Logs are already formatted at this stage so not using logging functions to avoid double formatting.

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -408,25 +408,12 @@ class PipelineWise:
         """
         return os.path.join(self.venv_dir, connector_type, 'bin', 'python')
 
-    def get_targets(self):
-        """
-        Get every target
-        """
-        self.logger.debug('Getting targets from %s', self.config_path)
-        self.load_config()
-        try:
-            targets = self.config.get('targets', [])
-        except Exception as exc:
-            raise Exception('Targets not defined') from exc
-
-        return targets
-
     def get_target(self, target_id: str) -> Dict:
         """
         Get target by id
         """
         self.logger.debug('Getting %s target', target_id)
-        targets = self.get_targets()
+        targets = self.config.get('targets', [])
 
         target = next((item for item in targets if item['id'] == target_id), None)
 

--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -580,12 +580,13 @@ class TestCli:
     def test_command_status(self, capsys):
         """Test status command output"""
         # Status table should be printed to stdout
-        with patch('pipelinewise.cli.pipelinewise.pidfile.PIDFile') as PIDFile:
+        with patch('pipelinewise.cli.pipelinewise.pidfile.PIDFile') as pidfile_class:
             @dataclasses.dataclass
             class MockedPidFile:
+                """Mocked PIDFile class"""
                 is_running: bool
 
-            PIDFile.side_effect = [
+            pidfile_class.side_effect = [
                 MockedPidFile(False),
                 MockedPidFile(True),
             ]
@@ -608,7 +609,7 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
 """
         )
 
-        assert PIDFile.call_count == 2
+        assert pidfile_class.call_count == 2
 
     def test_command_discover_tap(self):
         """Test discover tap command"""


### PR DESCRIPTION
## Problem

This is a continuance of https://github.com/transferwise/pipelinewise/pull/919

In case of ungraceful killing of the running pipelines, PPW doesn't rename the log files to change the suffix from `.running` to `.terminated`, hence this causes the tap to never start because the existence of a log file with `.running` blocks it. 

## Proposed changes

Remove the check of logs to determine the status of the taps before running singer/fastsync sync and rely only on PID. Bear in mind that this means usage of PID in a distributed environment is not reliable, so it's up to the scheduler used to run the taps to take care not to run the same tap on different servers.  

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
