### PR TITLE
Extend silentremove to support deleting folders

### DIFF
--- a/pipelinewise/cli/utils.py
+++ b/pipelinewise/cli/utils.py
@@ -320,13 +320,15 @@ def delete_keys_from_dict(dic, keys):
 
 def silentremove(path):
     """
-    Deleting file with no error message if the file not exists
+    Deleting file/folder with no error message if it doesn't exist
     """
-    LOGGER.debug('Removing file at %s', path)
+    LOGGER.debug('Removing folder/file at %s', path)
     try:
-        os.remove(path)
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        else:
+            os.remove(path)
     except OSError as exc:
-
         # errno.ENOENT = no such file or directory
         if exc.errno != errno.ENOENT:
             raise

--- a/pipelinewise/cli/utils.py
+++ b/pipelinewise/cli/utils.py
@@ -328,6 +328,8 @@ def silentremove(path):
             shutil.rmtree(path)
         else:
             os.remove(path)
+    except FileNotFoundError:
+        pass
     except OSError as exc:
         # errno.ENOENT = no such file or directory
         if exc.errno != errno.ENOENT:

--- a/pipelinewise/cli/utils.py
+++ b/pipelinewise/cli/utils.py
@@ -328,8 +328,6 @@ def silentremove(path):
             shutil.rmtree(path)
         else:
             os.remove(path)
-    except FileNotFoundError:
-        pass
     except OSError as exc:
         # errno.ENOENT = no such file or directory
         if exc.errno != errno.ENOENT:

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -285,11 +285,12 @@ class TestUtils:
             cli.utils.silentremove(file.name)
             assert os.path.exists(file.name) is False
 
+    # pylint: disable=consider-using-with
     def test_silentremove_successfully_removes_directory(self):
         """Test removing an existing directory works"""
-        with TemporaryDirectory() as directory:
-            cli.utils.silentremove(directory)
-            assert os.path.exists(directory) is False
+        directory = TemporaryDirectory().name
+        cli.utils.silentremove(directory)
+        assert os.path.exists(directory) is False
 
     def test_silentremove_success_if_directory_doesnt_exist(self):
         """Test removing an existing directory works"""

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -2,7 +2,7 @@ import os
 import pytest
 import re
 
-from tempfile import TemporaryDirectory, NamedTemporaryFile, TemporaryFile
+from tempfile import TemporaryDirectory, NamedTemporaryFile
 
 from pipelinewise import cli
 from pipelinewise.cli.errors import InvalidConfigException

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -1,8 +1,8 @@
 import os
-import re
 import pytest
+import re
 
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, NamedTemporaryFile
 
 from pipelinewise import cli
 from pipelinewise.cli.errors import InvalidConfigException
@@ -274,10 +274,25 @@ class TestUtils:
              {'foo3': {'nested_foo': 'nested_bar', 'nested_foo2': 'nested_bar2'}}],
             ['foo2', 'nested_foo']) == [{'foo': 'bar'}, {'foo3': {'nested_foo2': 'nested_bar2'}}]
 
-    def test_silentremove(self):
-        """Test removing functions"""
-        # Deleting non existing file should not raise exception
+    def test_silentremove_success_if_file_doesnt_exist(self):
+        """Test removing a non-existing file should not raise exception"""
         assert cli.utils.silentremove('this-file-not-exists.json') is None
+
+    def test_silentremove_successfully_removes_file(self):
+        """Test removing a file that exists"""
+        file = NamedTemporaryFile()
+        cli.utils.silentremove(file.name)
+        assert os.path.exists(file.name) is False
+
+    def test_silentremove_successfully_removes_directory(self):
+        """Test removing an existing directory works"""
+        directory = TemporaryDirectory()
+        cli.utils.silentremove(directory.name)
+        assert os.path.exists(directory.name) is False
+
+    def test_silentremove_success_if_directory_doesnt_exist(self):
+        """Test removing an existing directory works"""
+        assert cli.utils.silentremove('tmp/folder_doesnt_exist') is None
 
     def test_tap_properties(self):
         """Test tap property getter functions"""

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -2,7 +2,7 @@ import os
 import pytest
 import re
 
-from tempfile import TemporaryDirectory, NamedTemporaryFile
+from tempfile import TemporaryDirectory, NamedTemporaryFile, TemporaryFile
 
 from pipelinewise import cli
 from pipelinewise.cli.errors import InvalidConfigException
@@ -15,6 +15,7 @@ class TestUtils:
     """
     Unit Tests for PipelineWise CLI utility functions
     """
+
     def assert_json_is_invalid(self, schema, invalid_target):
         """Simple assertion to check if validate function exits with error"""
         with pytest.raises(InvalidConfigException):
@@ -278,17 +279,18 @@ class TestUtils:
         """Test removing a non-existing file should not raise exception"""
         assert cli.utils.silentremove('this-file-not-exists.json') is None
 
+    # pylint: disable=R1732
     def test_silentremove_successfully_removes_file(self):
         """Test removing a file that exists"""
-        file = NamedTemporaryFile()
-        cli.utils.silentremove(file.name)
-        assert os.path.exists(file.name) is False
+        with NamedTemporaryFile(delete=False) as file:
+            cli.utils.silentremove(file.name)
+            assert os.path.exists(file.name) is False
 
     def test_silentremove_successfully_removes_directory(self):
         """Test removing an existing directory works"""
-        directory = TemporaryDirectory()
-        cli.utils.silentremove(directory.name)
-        assert os.path.exists(directory.name) is False
+        with TemporaryDirectory() as directory:
+            cli.utils.silentremove(directory)
+            assert os.path.exists(directory) is False
 
     def test_silentremove_success_if_directory_doesnt_exist(self):
         """Test removing an existing directory works"""

--- a/tests/units/cli/test_cli_utils.py
+++ b/tests/units/cli/test_cli_utils.py
@@ -279,7 +279,6 @@ class TestUtils:
         """Test removing a non-existing file should not raise exception"""
         assert cli.utils.silentremove('this-file-not-exists.json') is None
 
-    # pylint: disable=R1732
     def test_silentremove_successfully_removes_file(self):
         """Test removing a file that exists"""
         with NamedTemporaryFile(delete=False) as file:


### PR DESCRIPTION
## Problem

A small issue was introduced by https://github.com/transferwise/pipelinewise/pull/1058
where `silentremove` function is called on a directory but this function only supports files

## Proposed changes

Extend `silentremove` to delete folders too.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
