### PR TITLE
AP-1335: Bump tap-slack to latest patch

### DIFF
--- a/singer-connectors/tap-slack/requirements.txt
+++ b/singer-connectors/tap-slack/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-slack==1.1.0
+pipelinewise-tap-slack==1.1.1


### PR DESCRIPTION
## Problem

Fetching users from slack runs into rate limiting 

## Proposed changes

Bump tap-slack patch to latest which has a fix
https://github.com/transferwise/pipelinewise-tap-slack/releases/tag/v1.1.1


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
