### PR TITLE
[AP-1485] fix for unwanted sync trigger for tables

### DIFF
--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -358,7 +358,6 @@ class PipelineWise:
                 dir=self.get_temp_dir(), prefix='properties_', suffix='.json'
             )[1]
             utils.save_json(properties, temp_properties_path)
-
             return temp_properties_path, filtered_tap_stream_ids
 
         except Exception as exc:
@@ -1190,7 +1189,7 @@ class PipelineWise:
         current_time = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
 
         # Create fastsync and singer specific filtered tap properties that contains only
-        # the the tables that needs to be synced by the specific command
+        # the tables that needs to be synced by the specific command
         (
             tap_properties_fastsync,
             fastsync_stream_ids,
@@ -2074,10 +2073,11 @@ TAP RUN SUMMARY
         selection = utils.load_json(self.tap['files']['selection'])
         selection = selection.get('selection')
         all_tables = {'full_sync': [], 'partial_sync': {}}
+        tables_list = tables.split(',') if tables else tables
         if selection:
             for table in selection:
                 table_name = self._get_fixed_name_of_table(table['tap_stream_id'])
-                if tables is None or table_name in tables:
+                if tables_list is None or table_name in tables_list:
                     if table.get('sync_start_from'):
                         all_tables['partial_sync'][table_name] = table['sync_start_from']
                     else:

--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -1054,7 +1054,7 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
             }
             assert actual_selected_tables == expected_selected_tables
 
-    def test_get_sync_tables_setting_from_selection_file_if_tables_parameter_in_none(self):
+    def test_get_sync_tables_setting_from_selection_file_if_tables_parameter_is_none(self):
         """Test if the method for getting list of tables for syncing works as expected while input parameter is None"""
         tables = None
         with patch('pipelinewise.cli.pipelinewise.utils.load_json') as mocked_load_json:


### PR DESCRIPTION
## Problem

Resync triggered unnecessarily for an existing table

## Proposed changes

fixed the method which is used to select the list of tables need to be synced.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
