### PR TITLE
Explain basic authentication token for jira tap

### DIFF
--- a/docs/connectors/taps/jira.rst
+++ b/docs/connectors/taps/jira.rst
@@ -35,6 +35,8 @@ Example YAML for ``tap-jira``:
       # Method 1: Base authentication
       base_url: "https://<your_domain>.atlassian.net"  # the URL where your Jira installation can be found
       username: "<USERNAME>"
+      # For basic authentication the password is a token you can create as described here:
+      # https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/#Create-an-API-token
       password: "<PASSWORD>"                            # Plain string or vault encrypted
 
       # Method 2: OAuth authentication


### PR DESCRIPTION
## Problem

Basic authentication is phased out by Atlassian, except when using a token.

## Proposed changes

Clearify that a token should be used for password.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
