### PR TITLE
Bump tap-kafka from 8.1.0 to 8.2.0

### DIFF
--- a/docs/connectors/taps/kafka.rst
+++ b/docs/connectors/taps/kafka.rst
@@ -92,7 +92,7 @@ Example YAML for ``tap-kafka``:
       #       int32 result_per_page = 3;
       #     }
       #proto_classess_dir:                      # (Default: current working dir) Directory where to store runtime compiled proto classes
-
+      #debug_contexts: ""                       # comma separated list of debug contexts to enable for the consumer [see librkafka](https://github.com/confluentinc/librdkafka/blob/master/INTRODUCTION.md#debug-contexts) 
 
     # ------------------------------------------------------------------------------
     # Destination (Target) - Target properties

--- a/singer-connectors/tap-kafka/requirements.txt
+++ b/singer-connectors/tap-kafka/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-kafka==8.1.0
+pipelinewise-tap-kafka==8.2.0


### PR DESCRIPTION
## Problem

Tap-kafka lacking informational and debug logs when running which hinders visibility.
 

## Proposed changes

Use https://github.com/transferwise/pipelinewise-tap-kafka/releases/tag/v8.2.0


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
