### PR TITLE
Update Dockerfile and requirements to support building on Apple Silicon on Mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get -qq update \
 
 # Add Mongodb ppa
 RUN wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add - \
-    && echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb.list \
+    && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb.list \
     && apt-get -qq update \
     && apt-get -qqy --no-install-recommends install \
         mongodb-database-tools \

--- a/singer-connectors/target-postgres/requirements.txt
+++ b/singer-connectors/target-postgres/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-postgres==2.1.1
+pipelinewise-target-postgres==2.1.2


### PR DESCRIPTION
## Problem

Build docker image fails when running on Apple Silicon Mac

## Proposed changes

All this PR does is add the arm64 option to the apt sources mongodb repository list in addition to the amd64 one. This allows containers built on Apple Silicon to compile correctly. Otherwise the docker build script fails when trying to install the mongodb tools. It also bumps target-postgres from 2.1.1 to 2.1.2 since otherwise it won't find the correct postgres-binary package.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [X ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ X] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ X] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
