### PR TITLE
[AP-1800] remove counting rows in checking for resync

### DIFF
--- a/pipelinewise/utils.py
+++ b/pipelinewise/utils.py
@@ -30,14 +30,12 @@ def get_tables_size(schema: str, tap) -> dict:
         tap.open_connections()
         result_list = tap.query(
             'select TABLE_NAME as table_name,'
-            ' TABLE_ROWS as table_rows,'
             ' (DATA_LENGTH + INDEX_LENGTH)/ 1024 / 1024 as table_size'
             f' from information_schema.TABLES where TABLE_SCHEMA = \'{schema}\';')
         tap.close_connections()
         for res in result_list:
             result.append({
                 'table_name': f'{schema}.{res["table_name"]}',
-                'table_rows': res['table_rows'],
                 'table_size': res['table_size']
             })
 
@@ -45,9 +43,6 @@ def get_tables_size(schema: str, tap) -> dict:
         tap.open_connection()
         result_list = tap.query(
             'SELECT TABLE_NAME as table_name,'
-            ' (xpath(\'/row/c/text()\','
-            ' query_to_xml(format(\'select count(*) as c from %I.%I\', table_schema, TABLE_NAME), FALSE, TRUE, \'\'))'
-            ')[1]::text::int AS table_rows,'
             ' pg_total_relation_size('
             '\'"\'||table_schema||\'"."\'||table_name||\'"\')::NUMERIC/1024::NUMERIC/1024 as table_size '
             'FROM (SELECT table_schema, TABLE_NAME FROM information_schema.tables '
@@ -56,8 +51,7 @@ def get_tables_size(schema: str, tap) -> dict:
         for res in result_list:
             result.append({
                 'table_name': f'{schema}.{res[0]}',
-                'table_rows': res[1],
-                'table_size': res[2]
+                'table_size': res[1]
             })
         tap.close_connection()
     return result

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -25,14 +25,14 @@ class MockCursor:
         """Mock fetchall method"""
         if self.type == 'mysql':
             return [
-                {'table_name': 't1', 'table_rows': 1, 'table_size': 1234},
-                {'table_name': 't2', 'table_rows': 3, 'table_size': 1234}
+                {'table_name': 't1', 'table_size': 1234},
+                {'table_name': 't2', 'table_size': 1234}
             ]
 
         if self.type == 'postgres':
             return [
-                ['t1', 1, 1234],
-                ['t2', 3, 1234],
+                ['t1', 1234],
+                ['t2', 1234],
             ]
         return None
 
@@ -119,8 +119,8 @@ class TestUtils(unittest.TestCase):
         """Test get_tables_size method works correctly"""
         test_schema = 'foo_schema'
         expected_tables_info = [
-            {'table_name': f'{test_schema}.t1', 'table_rows': 1, 'table_size': 1234},
-            {'table_name': f'{test_schema}.t2', 'table_rows': 3, 'table_size': 1234}
+            {'table_name': f'{test_schema}.t1', 'table_size': 1234},
+            {'table_name': f'{test_schema}.t2', 'table_size': 1234}
         ]
 
         connection_config = {'host': 'foo_host',
@@ -158,15 +158,15 @@ class TestUtils(unittest.TestCase):
         """Test filter_out_selected_tables method works correctly"""
         selected_tables = {'foo.t1', 'foo.t3', 'bar.t2'}
         all_schema_tables = [
-            {'table_name': 'foo.t1', 'table_rows': 1, 'table_size': 1111},
-            {'table_name': 'foo.t2', 'table_rows': 2, 'table_size': 2222},
-            {'table_name': 'foo.t3', 'table_rows': 3, 'table_size': 3333},
-            {'table_name': 'foo.something t1 Uppercase', 'table_rows': 4, 'table_size': 1234}
+            {'table_name': 'foo.t1', 'table_size': 1111},
+            {'table_name': 'foo.t2', 'table_size': 2222},
+            {'table_name': 'foo.t3', 'table_size': 3333},
+            {'table_name': 'foo.something t1 Uppercase', 'table_size': 1234}
         ]
 
         expected_output = [
-            {'table_name': 'foo.t1', 'table_rows': 1, 'table_size': 1111},
-            {'table_name': 'foo.t3', 'table_rows': 3, 'table_size': 3333},
+            {'table_name': 'foo.t1', 'table_size': 1111},
+            {'table_name': 'foo.t3', 'table_size': 3333},
         ]
 
         actual_output = utils.filter_out_selected_tables(all_schema_tables, selected_tables)


### PR DESCRIPTION
## Problem

it is running count(*) against tables which DBE is not happy about!
## Proposed changes

Remove counting row completely since it is not used at all for making decision


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions


## Details from ticket: [AP-1800](https://transferwise.atlassian.net/browse/AP-1800)

### PPW:: Remove row count from resync decision process

>h2. Context
>
>
>
>
>
>


[AP-1800]: https://transferwise.atlassian.net/browse/AP-1800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ