### PR TITLE
Prepare for Release 0.67.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.67.0 (2024-11-19)
+-------------------
+- Fix map date column to correct Postgres type
+- New argument for sync tables to select replication method
+
 0.66.1 (2024-10-31)
 -------------------
 - Bug fix for partial sync multiprocessing

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.10.*',
-      version='0.66.1',
+      version='0.67.0',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
## Context

Prepare for Release 0.67.0
- Fix map date column to correct Postgres type
- New argument for sync tables to select replication method
