### PR TITLE
[AP-2038] implementing reset_state command

### DIFF
--- a/docs/user_guide/cli.rst
+++ b/docs/user_guide/cli.rst
@@ -135,6 +135,18 @@ Validates a project directory with YAML tap and target files.
 :--dir: relative path to the project directory with YAML taps and targets.
 
 
+reset_state
+"""""""""""
+
+Reset state file for log based tables. It works only for PostgresSQL databases!
+
+:--target: Target connector id
+
+:--tap: Tap connector id
+
+.. _cli_reset_state:
+
+
 Environment variables
 ---------------------
 

--- a/pipelinewise/cli/__init__.py
+++ b/pipelinewise/cli/__init__.py
@@ -40,7 +40,8 @@ COMMANDS = [
     'import_config',  # This is for backward compatibility; use 'import' instead
     'validate',
     'encrypt_string',
-    'partial_sync_table'
+    'partial_sync_table',
+    'reset_state'
 ]
 
 
@@ -150,7 +151,7 @@ def _validate_command_specific_arguments(args):
     if args.command == 'init' and args.name == '*':
         raise CommandSpecificArgumentsException('You must specify a project name using the argument --name')
 
-    if args.command in ['discover_tap', 'test_tap_connection', 'run_tap', 'stop_tap', 'sync_tables']:
+    if args.command in ['discover_tap', 'test_tap_connection', 'run_tap', 'stop_tap', 'sync_tables', 'reset_state']:
         if args.tap == '*':
             raise CommandSpecificArgumentsException('You must specify a source name using the argument --tap')
         if args.target == '*':

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1875,7 +1875,6 @@ class PipelineWise:
                               self.tap.get('id'), self.tap.get('type'))
             raise SystemExit(1)
 
-
     def _update_state_file(self, table_property, new_value):
         tap_state = self.tap['files']['state']
         try:
@@ -1893,9 +1892,6 @@ class PipelineWise:
         except Exception as exp:
             self.logger.error(exp)
             raise SystemExit(1) from exp
-
-
-
 
     @staticmethod
     def _remove_not_partial_synced_tables_from_properties(tap_params, not_synced_tables):

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1868,12 +1868,12 @@ class PipelineWise:
     def reset_state(self):
         """Reset state file"""
 
-        if self.tap.get("type") == 'tap-postgres':
+        if self.tap.get('type') == 'tap-postgres':
             self._update_state_file('lsn', 1)
             self.logger.info('state file is reset for log based tables!')
         else:
             self.logger.error('state reset is not supported for %s (%s)!',
-                              self.tap.get("id"), self.tap.get("type"))
+                              self.tap.get('id'), self.tap.get('type'))
             raise SystemExit(1)
 
 

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -8,7 +8,6 @@ import signal
 import sys
 import json
 import copy
-from csv import excel
 
 import psutil
 import pidfile

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1871,8 +1871,7 @@ class PipelineWise:
             self._update_state_file('lsn', 1)
             self.logger.info('state file is reset for log based tables!')
         else:
-            self.logger.error('state reset is not supported for %s (%s)!',
-                              self.tap.get('id'), self.tap.get('type'))
+            self.logger.error('state reset is available only for PostgreSQL taps!')
             raise SystemExit(1)
 
     def _update_state_file(self, table_property, new_value):

--- a/tests/units/cli/resources/test_reset_state/config.json
+++ b/tests/units/cli/resources/test_reset_state/config.json
@@ -1,0 +1,18 @@
+{
+    "targets": [
+        {
+            "id": "target_foo",
+            "type": "target-snowflake",
+            "taps": [
+                {
+                    "id": "tap_pg",
+                    "type": "tap-postgres"
+                },
+                {
+                    "id": "tap_bar",
+                    "type": "tap-bar"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/units/cli/resources/test_reset_state/target_foo/tap_pg/state.json
+++ b/tests/units/cli/resources/test_reset_state/target_foo/tap_pg/state.json
@@ -1,0 +1,10 @@
+{
+    "bookmarks": {
+        "foo_table": {
+            "lsn": 456321
+        },
+        "bar_table": {
+            "foo": "bar"
+        }
+    }
+}

--- a/tests/units/cli/test_reset_state.py
+++ b/tests/units/cli/test_reset_state.py
@@ -1,0 +1,74 @@
+import json
+import os
+
+from unittest import TestCase, mock
+
+from pipelinewise import cli
+
+
+class TestResetState(TestCase):
+    """Testcases for reset state CLI"""
+    def setUp(self):
+        resources_dir = f'{os.path.dirname(__file__)}/resources'
+        self.test_cli = cli
+        self.test_cli.CONFIG_DIR = f'{resources_dir}/test_reset_state'
+        self.test_cli.VENV_DIR = './virtualenvs-dummy'
+
+    def _run_cli(self, arguments_dict: dict) -> None:
+        """Running the test CLI application"""
+        argv_list = ['main', 'reset_state']
+        if arguments_dict.get('tap'):
+            argv_list.extend(['--tap', arguments_dict['tap']])
+        if arguments_dict.get('target'):
+            argv_list.extend(['--target', arguments_dict['target']])
+
+        with mock.patch('sys.argv', argv_list):
+            self.test_cli.main()
+
+    def test_reset_state_file_if_tap_is_pg(self):
+        """ Test reset_state command for Postgres taps"""
+        state_content = {
+                'bookmarks': {
+                    'foo_table': {
+                        'lsn': 54321
+                    },
+                    'bar_table': {
+                        'foo': 'bar'
+                    }
+                }
+        }
+        with open(f'{self.test_cli.CONFIG_DIR}/target_foo/tap_pg/state.json', 'w', encoding='utf-8') as state_file:
+            json.dump(state_content, state_file)
+
+        arguments = {
+            'tap': 'tap_pg',
+            'target': 'target_foo'
+        }
+        self._run_cli(arguments)
+
+        with open(f'{self.test_cli.CONFIG_DIR}/target_foo/tap_pg/state.json', 'r', encoding='utf-8') as state_file:
+            actual_state = json.load(state_file)
+
+        expected_state = {
+                'bookmarks': {
+                    'foo_table': {
+                        'lsn': 1
+                    },
+                    'bar_table': {
+                        'foo': 'bar'
+                    }
+                }
+        }
+        self.assertDictEqual(expected_state, actual_state)
+
+    def test_exit_with_error_1_if_tap_is_not_allowed(self):
+        """ Test reset_state command exit with error 1 if tap is not allowed for it"""
+        arguments = {
+            'tap': 'tap_bar',
+            'target': 'target_foo'
+        }
+
+        with self.assertRaises(SystemExit) as system_exit:
+            self._run_cli(arguments)
+
+        self.assertEqual(system_exit.exception.code, 1)


### PR DESCRIPTION
## Context

Added the new command `reset_state` to reset state file for log-based tables in PostgresSQL taps.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Relevant documentation is updated including usage instructions


## Details from ticket: [AP-2038](https://transferwise.atlassian.net/browse/AP-2038)

### PPW :: Command option for reseting State file

>h2. Context
>
>Please give context of the task, the problem that it solves, how impactful it is ..etc
>
>h2. Suggested Implementation(s)
>
>Any ideas on solutions or implementation


[AP-2038]: https://transferwise.atlassian.net/browse/AP-2038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ