### PR TITLE
Prepare for release 0.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-0.67.0 (2024-11-10)
+0.68.0 (2025-01-10)
+-------------------
+- Bump `requests` from `2.20.0` to `2.32.2` in `/singer-connectors/tap-github`
+- Add `reset_state` command for PG taps
+
+0.67.0 (2024-11-19)
 -------------------
 - Fix map date column to correct Postgres type
 - New argument for sync tables to select replication method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.67.0 (2024-11-19)
+0.67.0 (2024-11-10)
 -------------------
 - Fix map date column to correct Postgres type
 - New argument for sync tables to select replication method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.68.0 (2025-01-09)
+-------------------
+- Add `reset_state` command for resetting state of PG taps
+
 0.67.0 (2024-11-19)
 -------------------
 - Fix map date column to correct Postgres type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.68.0 (2025-01-09)
 -------------------
 - Add `reset_state` command for resetting state of PG taps
+- Bump `requests` from `2.20.0` to `2.32.2` in `/singer-connectors/tap-github`
 
 0.67.0 (2024-11-19)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.10.*',
-      version='0.67.0',
+      version='0.68.0',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
## Context

Prepare for release 0.68.0

- Bump `requests` from `2.20.0` to `2.32.2` in `/singer-connectors/tap-github`
- Add `reset_state` command for PG taps