### PR TITLE
[AP-2075] reset_state for mysql type taps

### DIFF
--- a/.github/workflows/connectors.yml
+++ b/.github/workflows/connectors.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   test_install_connectors:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checking out repo

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   e2e_tests_target_pg:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: ci_tests
 
     steps:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -70,7 +70,7 @@ jobs:
           pipelinewise_dev pytest tests/end_to_end/test_target_postgres.py -vx --timer-top-n 10
 
   e2e_tests_mariadb_to_sf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: ci_tests
 
     steps:
@@ -120,7 +120,7 @@ jobs:
           pipelinewise_dev pytest tests/end_to_end/target_snowflake/tap_mariadb -vx --timer-top-n 10
 
   e2e_tests_pg_to_sf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: ci_tests
 
     steps:
@@ -170,7 +170,7 @@ jobs:
           pipelinewise_dev pytest tests/end_to_end/target_snowflake/tap_postgres -vx --timer-top-n 10
 
   e2e_tests_mg_to_sf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: ci_tests
 
     steps:
@@ -220,7 +220,7 @@ jobs:
           pipelinewise_dev pytest tests/end_to_end/target_snowflake/tap_mongodb -vx --timer-top-n 10
 
   e2e_tests_s3_to_sf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: ci_tests
 
     steps:

--- a/.github/workflows/lint_unit_tests.yml
+++ b/.github/workflows/lint_unit_tests.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   lint_and_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checking out repo

--- a/docs/user_guide/cli.rst
+++ b/docs/user_guide/cli.rst
@@ -138,7 +138,7 @@ Validates a project directory with YAML tap and target files.
 reset_state
 """""""""""
 
-Reset state file for log based tables. It works only for PostgresSQL databases!
+Reset state file for log based tables. It works only for PostgresSQL and MySQL databases!
 
 :--target: Target connector id
 
@@ -146,9 +146,35 @@ Reset state file for log based tables. It works only for PostgresSQL databases!
 
 .. _cli_reset_state:
 
+for MySQL, it needs a json file contains of switchover data same as below format:
 
-Environment variables
----------------------
+.. code-block:: JSON
+
+   {
+     "new_url_of_the_source_database": {
+       "old_identifier": "old_identifier_of_source_db",
+       "new_identifier": "new_identifier_of_source_db",
+       "old_host": "old_url_of_the_source_database",
+       "new_host": "new_url_of_the_source_database",
+       "engine": "mariadb",
+       "switchover_utc_timestamp": "2025-04-03 12:13:14+00:00",
+       "old_binlog_filename": "old_mysql-bin.000001",
+       "old_binlog_position": 1,
+       "new_binlog_filename": "new_mysql-bin.000002",
+       "new_binlog_position": 500
+     }
+   }
+
+
+.. attention::
+
+   The filename for switchover data can be added in the `config.yml`:
+
+   .. code-block:: yaml
+
+       "switch_over_data_file": "<switch over data json file>",
+
+
 
 `PIPELINEWISE_HOME`
 """""""""""""""""""

--- a/docs/user_guide/cli.rst
+++ b/docs/user_guide/cli.rst
@@ -172,7 +172,7 @@ for MySQL, it needs a json file contains of switchover data same as below format
 
    .. code-block:: yaml
 
-       "switch_over_data_file": "<switch over data json file>",
+       "switch_over_data_file": "switch_over_data_json_file"
 
 
 

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1898,7 +1898,7 @@ class PipelineWise:
         if new_log_file and new_log_pos:
             return [('log_file', new_log_file), ('log_pos', int(new_log_pos))]
 
-        self.logger.error('There is no data for switchover %s!', self.tap["id"])
+        self.logger.error('There is no data for switchover %s!', self.tap['id'])
         raise SystemExit(1)
 
     def _update_state_file(self, table_property, new_value):

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1866,12 +1866,39 @@ class PipelineWise:
 
     def reset_state(self):
         """Reset state file"""
-
         if self.tap.get('type') == 'tap-postgres':
-            self._update_state_file('lsn', 1)
-            self.logger.info('state file is reset for log based tables!')
+            state_items_to_update = [('lsn', 1),]
+        elif self.tap.get('type') == 'tap-mysql':
+            state_items_to_update = self._get_data_from_switchover_file()
         else:
             self.logger.error('state reset is available only for PostgreSQL taps!')
+            raise SystemExit(1)
+
+        for state_item in state_items_to_update:
+            self._update_state_file(state_item[0], state_item[1])
+            self.logger.info('state file is reset for log based tables!')
+
+    def _get_data_from_switchover_file(self):
+        new_log_file = None
+        new_log_pos = None
+        database_url = None
+        try:
+            with open(self.tap['files']['config'], 'r', encoding='utf-8') as tap_config_file:
+                tap_config_content = json.load(tap_config_file)
+                database_url = tap_config_content['host']
+
+            with open(self.config.get('switch_over_data_file'), 'r', encoding='utf-8') as switchover_file:
+                switchover_content = json.load(switchover_file)
+                new_log_file = switchover_content.get(database_url, {}).get('new_binlog_filename')
+                new_log_pos = switchover_content.get(database_url, {}).get('new_binlog_position')
+
+        except Exception as exp:
+            self.logger.error(str(exp))
+
+        if new_log_file and new_log_pos:
+            return [('log_file', new_log_file), ('log_pos', int(new_log_pos))]
+        else:
+            self.logger.error(f'There is no data for switchover {self.tap["id"]}!')
             raise SystemExit(1)
 
     def _update_state_file(self, table_property, new_value):

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1897,9 +1897,9 @@ class PipelineWise:
 
         if new_log_file and new_log_pos:
             return [('log_file', new_log_file), ('log_pos', int(new_log_pos))]
-        else:
-            self.logger.error(f'There is no data for switchover {self.tap["id"]}!')
-            raise SystemExit(1)
+
+        self.logger.error('There is no data for switchover %s!', self.tap["id"])
+        raise SystemExit(1)
 
     def _update_state_file(self, table_property, new_value):
         tap_state = self.tap['files']['state']

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1867,7 +1867,7 @@ class PipelineWise:
     def reset_state(self):
         """Reset state file"""
         if self.tap.get('type') == 'tap-postgres':
-            state_items_to_update = [('lsn', 1),]
+            state_items_to_update = [('lsn', 1), ]
         elif self.tap.get('type') == 'tap-mysql':
             state_items_to_update = self._get_data_from_switchover_file()
         else:

--- a/pipelinewise/cli/schemas/config.json
+++ b/pipelinewise/cli/schemas/config.json
@@ -51,6 +51,9 @@
         }
       },
       "required": ["table_mb"]
+    },
+    "switch_over_data_File": {
+      "type": "string"
     }
   },
   "required": [],

--- a/tests/units/cli/resources/test_reset_state/config.json
+++ b/tests/units/cli/resources/test_reset_state/config.json
@@ -1,4 +1,4 @@
-{
+{   "switch_over_data_file": "/tmp/switch_over_test.json",
     "targets": [
         {
             "id": "target_foo",
@@ -11,6 +11,10 @@
                 {
                     "id": "tap_bar",
                     "type": "tap-bar"
+                },
+                {
+                    "id": "tap_mysql",
+                    "type": "tap-mysql"
                 }
             ]
         }

--- a/tests/units/cli/resources/test_reset_state/target_foo/tap_mysql/config.json
+++ b/tests/units/cli/resources/test_reset_state/target_foo/tap_mysql/config.json
@@ -1,0 +1,3 @@
+{
+    "host": "new_database_url"
+}

--- a/tests/units/cli/resources/test_reset_state/target_foo/tap_mysql/state.json
+++ b/tests/units/cli/resources/test_reset_state/target_foo/tap_mysql/state.json
@@ -1,0 +1,1 @@
+{"bookmarks": {"foo_table": {"log_file": "mysql-bin.000001", "log_pos": 1, "version": 1}, "bar_table": {"foo": "bar"}}}

--- a/tests/units/cli/test_reset_state.py
+++ b/tests/units/cli/test_reset_state.py
@@ -71,10 +71,10 @@ class TestResetState(TestCase):
         new_bin = ''.join(random.choice(string.ascii_letters) for _ in range(10))
         state_content = {
             'bookmarks': {
-                "foo_table": {
-                    "log_file": "mysql-bin.000001",
-                    "log_pos": old_pos,
-                    "version": 1
+                'foo_table': {
+                    'log_fil': 'mysql-bin.000001',
+                    'log_pos': old_pos,
+                    'version': 1
                 },
                 'bar_table': {
                     'foo': 'bar'
@@ -115,9 +115,9 @@ class TestResetState(TestCase):
         expected_state = {
             'bookmarks': {
                 'foo_table': {
-                    "log_file": new_bin,
-                    "log_pos": new_pos,
-                    "version": 1
+                    'log_file': new_bin,
+                    'log_pos': new_pos,
+                    'version': 1
                 },
                 'bar_table': {
                     'foo': 'bar'
@@ -145,10 +145,10 @@ class TestResetState(TestCase):
 
         state_content = {
             'bookmarks': {
-                "foo_table": {
-                    "log_file": "mysql-bin.000001",
-                    "log_pos": 1,
-                    "version": 1
+                'foo_table': {
+                    'log_file': 'mysql-bin.000001',
+                    'log_pos': 1,
+                    'version': 1
                 },
                 'bar_table': {
                     'foo': 'bar'

--- a/tests/units/cli/test_reset_state.py
+++ b/tests/units/cli/test_reset_state.py
@@ -100,7 +100,7 @@ class TestResetState(TestCase):
         with open(f'{self.test_cli.CONFIG_DIR}/target_foo/tap_mysql/state.json', 'w', encoding='utf-8') as state_file:
             json.dump(state_content, state_file)
 
-        with open(f'/tmp/switch_over_test.json', 'w', encoding='utf-8') as switchover_file:
+        with open('/tmp/switch_over_test.json', 'w', encoding='utf-8') as switchover_file:
             json.dump(switchover_data, switchover_file)
 
         arguments = {
@@ -127,6 +127,7 @@ class TestResetState(TestCase):
         self.assertDictEqual(expected_state, actual_state)
 
     def test_exit_with_error_1_if_tap_is_mysql_but_no_record_in_switchover(self):
+        """Test reset_state command returns error 1 if there is no record in json file for the tap"""
         switchover_data = {
             'bar_new_database_url': {
                 'old_identifier': '',
@@ -158,7 +159,7 @@ class TestResetState(TestCase):
         with open(f'{self.test_cli.CONFIG_DIR}/target_foo/tap_mysql/state.json', 'w', encoding='utf-8') as state_file:
             json.dump(state_content, state_file)
 
-        with open(f'/tmp/switch_over_test.json', 'w', encoding='utf-8') as switchover_file:
+        with open('/tmp/switch_over_test.json', 'w', encoding='utf-8') as switchover_file:
             json.dump(switchover_data, switchover_file)
 
         arguments = {

--- a/tests/units/cli/test_reset_state.py
+++ b/tests/units/cli/test_reset_state.py
@@ -72,7 +72,7 @@ class TestResetState(TestCase):
         state_content = {
             'bookmarks': {
                 'foo_table': {
-                    'log_fil': 'mysql-bin.000001',
+                    'log_file': 'mysql-bin.000001',
                     'log_pos': old_pos,
                     'version': 1
                 },

--- a/tests/units/cli/test_reset_state.py
+++ b/tests/units/cli/test_reset_state.py
@@ -1,5 +1,7 @@
 import json
 import os
+import random
+import string
 
 from unittest import TestCase, mock
 
@@ -60,6 +62,115 @@ class TestResetState(TestCase):
                 }
         }
         self.assertDictEqual(expected_state, actual_state)
+
+    def test_reset_state_file_if_tap_is_mysql(self):
+        """ Test reset_state command for MySQL taps"""
+        old_pos = random.randint(1, 100)
+        new_pos = random.randint(1, 100)
+        old_bin = ''.join(random.choice(string.ascii_letters) for _ in range(10))
+        new_bin = ''.join(random.choice(string.ascii_letters) for _ in range(10))
+        state_content = {
+            'bookmarks': {
+                "foo_table": {
+                    "log_file": "mysql-bin.000001",
+                    "log_pos": old_pos,
+                    "version": 1
+                },
+                'bar_table': {
+                    'foo': 'bar'
+                }
+            }
+        }
+
+        switchover_data = {
+            'new_database_url': {
+                'old_identifier': '',
+                'new_identifier': '',
+                'old_host': 'foo_database',
+                'new_host': 'new_database_url',
+                'old_binlog_filename': old_bin,
+                'old_binlog_position': old_pos,
+                'new_binlog_filename': new_bin,
+                'new_binlog_position': new_pos,
+                'switchover_utc_timestamp': '2025-04-04T15:15:45+00:00',
+                'engine': 'mariadb'
+            }
+        }
+
+        with open(f'{self.test_cli.CONFIG_DIR}/target_foo/tap_mysql/state.json', 'w', encoding='utf-8') as state_file:
+            json.dump(state_content, state_file)
+
+        with open(f'/tmp/switch_over_test.json', 'w', encoding='utf-8') as switchover_file:
+            json.dump(switchover_data, switchover_file)
+
+        arguments = {
+            'tap': 'tap_mysql',
+            'target': 'target_foo'
+        }
+        self._run_cli(arguments)
+
+        with open(f'{self.test_cli.CONFIG_DIR}/target_foo/tap_mysql/state.json', 'r', encoding='utf-8') as state_file:
+            actual_state = json.load(state_file)
+
+        expected_state = {
+            'bookmarks': {
+                'foo_table': {
+                    "log_file": new_bin,
+                    "log_pos": new_pos,
+                    "version": 1
+                },
+                'bar_table': {
+                    'foo': 'bar'
+                }
+            }
+        }
+        self.assertDictEqual(expected_state, actual_state)
+
+    def test_exit_with_error_1_if_tap_is_mysql_but_no_record_in_switchover(self):
+        switchover_data = {
+            'bar_new_database_url': {
+                'old_identifier': '',
+                'new_identifier': '',
+                'old_host': 'foo_database',
+                'new_host': 'new_database_url',
+                'old_binlog_filename': 'foo',
+                'old_binlog_position': 1,
+                'new_binlog_filename': 'bar',
+                'new_binlog_position': 2,
+                'switchover_utc_timestamp': '2025-04-04T15:15:45+00:00',
+                'engine': 'mariadb'
+            }
+        }
+
+        state_content = {
+            'bookmarks': {
+                "foo_table": {
+                    "log_file": "mysql-bin.000001",
+                    "log_pos": 1,
+                    "version": 1
+                },
+                'bar_table': {
+                    'foo': 'bar'
+                }
+            }
+        }
+
+        with open(f'{self.test_cli.CONFIG_DIR}/target_foo/tap_mysql/state.json', 'w', encoding='utf-8') as state_file:
+            json.dump(state_content, state_file)
+
+        with open(f'/tmp/switch_over_test.json', 'w', encoding='utf-8') as switchover_file:
+            json.dump(switchover_data, switchover_file)
+
+        arguments = {
+            'tap': 'tap_mysql',
+            'target': 'target_foo'
+        }
+
+        with self.assertRaises(SystemExit) as system_exit:
+            self._run_cli(arguments)
+
+        self.assertEqual(system_exit.exception.code, 1)
+
 
     def test_exit_with_error_1_if_tap_is_not_allowed(self):
         """ Test reset_state command exit with error 1 if tap is not allowed for it"""


### PR DESCRIPTION
## Context

support reset_state command for mysql taps 
https://transferwise.atlassian.net/browse/AP-2075

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Relevant documentation is updated including usage instructions
