### PR TITLE
Migrate to modern testing interface

### DIFF
--- a/singer-connectors/tap-snowflake/tests/integration/test_tap_snowflake.py
+++ b/singer-connectors/tap-snowflake/tests/integration/test_tap_snowflake.py
@@ -265,9 +265,9 @@ class TestTypeMapping(unittest.TestCase):
                 formatted_record = singer.messages.format_message(record_message)
 
                 # Reload the generated JSON to object and assert keys
-                self.assertEquals(json.loads(formatted_record)['type'], 'RECORD')
-                self.assertEquals(json.loads(formatted_record)['stream'], 'TEST_TYPE_MAPPING')
-                self.assertEquals(json.loads(formatted_record)['record'],
+                self.assertEqual(json.loads(formatted_record)['type'], 'RECORD')
+                self.assertEqual(json.loads(formatted_record)['stream'], 'TEST_TYPE_MAPPING')
+                self.assertEqual(json.loads(formatted_record)['record'],
                                   {
                                       'C_PK': 1,
                                       'C_DECIMAL': 12345,


### PR DESCRIPTION
## Context
This small PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Relevant documentation is updated including usage instructions
