### PR TITLE
Upgrade snowflake-connector-python[pandas] from 3.0.4 to 3.15.0 to fix snowflake failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.71.0 (2025-06-10)
+-------------------
+- bump snowflake-connector-python[pandas] from `3.0.4` to `3.15.0` 
+
 0.70.0 (2025-06-10)
 -------------------
 - Replace pkg_resource with importlib.metadata

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.10.*',
-      version='0.70.0',
+      version='0.71.0',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',
@@ -28,7 +28,7 @@ setup(name='pipelinewise',
           'PyMySQL==0.7.11',
           'psycopg2-binary==2.9.10',
           'numpy==1.26.4',          #  numpy 2.X is not compatible with our used pandas
-          'snowflake-connector-python[pandas]==3.0.4',
+          'snowflake-connector-python[pandas]==3.15.0',
           'pipelinewise-singer-python==1.*',
           'python-pidfile==3.0.0',
           'pymongo==4.7.*',

--- a/singer-connectors/target-snowflake/CHANGELOG.md
+++ b/singer-connectors/target-snowflake/CHANGELOG.md
@@ -1,3 +1,10 @@
+2.4.0 (2025-07-18)
+-------------------
+
+*Changes*
+- Update dependencies:
+    - snowflake-connector-python[pandas]
+
 2.3.0 (2023-08-08)
 -------------------
 

--- a/singer-connectors/target-snowflake/setup.py
+++ b/singer-connectors/target-snowflake/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name="pipelinewise-target-snowflake",
-      version="2.3.0",
+      version="2.4.0",
       description="Singer.io target for loading data to Snowflake - PipelineWise compatible",
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/singer-connectors/target-snowflake/setup.py
+++ b/singer-connectors/target-snowflake/setup.py
@@ -25,7 +25,7 @@ setup(name="pipelinewise-target-snowflake",
       install_requires=[
           'pipelinewise-singer-python==2.*',
           'numpy==1.26.4',         #  numpy 2.X is not compatible with our used pandas
-          'snowflake-connector-python[pandas]==3.0.4',
+          'snowflake-connector-python[pandas]==3.15.0',
           'inflection==0.5.1',
           'joblib==1.2.0',
           'boto3==1.28.20',


### PR DESCRIPTION
## Context
These changes:
  - upgrade snowflake-connector-python[pandas] from `3.0.4` to `3.15.0` to fix the error: "snowflake.connector.errors.OperationalError: 254007: The certificate is revoked or could not be validated: hostname=[sfc-eu-ds1-customer-stage.s3.eu-central-1.amazonaws.com](http://sfc-eu-ds1-customer-stage.s3.eu-central-1.amazonaws.com/)"


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue) [optional]
- [ ] New feature (non-breaking change which adds functionality) [optional]
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) [optional]
- [ ] Documentation Update (if none of the other choices apply) [optional]


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Relevant documentation is updated including usage instructions
