### PR TITLE
Mention official Docker images in install guide

### DIFF
--- a/docs/installation_guide/installation.rst
+++ b/docs/installation_guide/installation.rst
@@ -48,7 +48,7 @@ your host system. First you need to install docker on your computer:
 * `Install Docker on MacOS <https://runnable.com/docker/install-docker-on-macos>`_
 
 Once Docker is installed you need to clone the PipelineWise git repository and build the
-executable docker image:
+executable Docker image:
 
 .. code-block:: bash
 
@@ -58,8 +58,10 @@ executable docker image:
 
 
 Building the image may take 5-10 minutes depending on your network connection. The output image will
-contain every supporter singer connectors. At the moment there is no official, pre-built image available
-to download on DockerHub. Once the image is ready, create an alias to the docker wrapper script so you can
+contain every supported Singer connector. Alternatively, see [Official Docker Images](https://github.com/transferwise/pipelinewise?tab=readme-ov-file#official-docker-images)
+to pull a pre-built image. 
+
+Once the image is ready, create an alias to the Docker wrapper script so you can
 use the ``pipelinewise`` executable commands everywhere on your system:
 
 .. code-block:: bash


### PR DESCRIPTION
## Context

Documentation is outdated and fails to mentioned the official Docker images published to DockerHub. PR addresses that. 

Closes https://github.com/transferwise/pipelinewise/issues/1202

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue) [optional]
- [ ] New feature (non-breaking change which adds functionality) [optional]
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) [optional]
- [x] Documentation Update (if none of the other choices apply) [optional]


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Relevant documentation is updated including usage instructions
