### PR TITLE
tap-postgres: discover ltree and interval columns as strings

### DIFF
--- a/singer-connectors/tap-postgres/CHANGELOG.md
+++ b/singer-connectors/tap-postgres/CHANGELOG.md
@@ -1,3 +1,8 @@
+2.3.0 (unreleased)
+-------------------
+**Changes**
+- DISCOVERY: Map `ltree` and `interval` columns to a string schema instead of leaving them untyped.
+
 2.2.0 (2026-04-07)
 -------------------
 **Changes**

--- a/singer-connectors/tap-postgres/setup.py
+++ b/singer-connectors/tap-postgres/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name='pipelinewise-tap-postgres',
-      version='2.2.0',
+      version='2.3.0',
       description='Singer.io tap for extracting data from PostgresSQL - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/singer-connectors/tap-postgres/tap_postgres/discovery_utils.py
+++ b/singer-connectors/tap-postgres/tap_postgres/discovery_utils.py
@@ -218,6 +218,10 @@ def schema_for_column_datatype(col):
         schema['type'] = nullable_column('string', col.is_primary_key)
         return schema
 
+    if data_type in {'interval', 'ltree'}:
+        schema['type'] = nullable_column('string', col.is_primary_key)
+        return schema
+
     if data_type == 'hstore':
         schema['type'] = nullable_column('object', col.is_primary_key)
         schema['properties'] = {}

--- a/singer-connectors/tap-postgres/tests/unit/test_discovery_utils.py
+++ b/singer-connectors/tap-postgres/tests/unit/test_discovery_utils.py
@@ -1,0 +1,45 @@
+import unittest
+
+from tap_postgres import discovery_utils
+
+
+def _column(sql_data_type, is_primary_key=False):
+    return discovery_utils.Column(
+        column_name='test_column',
+        is_primary_key=is_primary_key,
+        sql_data_type=sql_data_type,
+        character_maximum_length=None,
+        numeric_precision=None,
+        numeric_scale=None,
+        is_array=False,
+        is_enum=False,
+    )
+
+
+class TestSchemaForColumnDatatype(unittest.TestCase):
+    maxDiff = None
+
+    def test_ltree_maps_to_string(self):
+        """ltree columns are discovered as nullable strings"""
+        schema = discovery_utils.schema_for_column_datatype(_column('ltree'))
+        self.assertEqual(schema, {'type': ['null', 'string']})
+
+    def test_interval_maps_to_string(self):
+        """interval columns are discovered as nullable strings"""
+        schema = discovery_utils.schema_for_column_datatype(_column('interval'))
+        self.assertEqual(schema, {'type': ['null', 'string']})
+
+    def test_ltree_primary_key_is_not_nullable(self):
+        """A primary-key ltree column is a non-nullable string"""
+        schema = discovery_utils.schema_for_column_datatype(_column('ltree', is_primary_key=True))
+        self.assertEqual(schema, {'type': ['string']})
+
+    def test_interval_primary_key_is_not_nullable(self):
+        """A primary-key interval column is a non-nullable string"""
+        schema = discovery_utils.schema_for_column_datatype(_column('interval', is_primary_key=True))
+        self.assertEqual(schema, {'type': ['string']})
+
+    def test_interval_array_maps_to_string(self):
+        """Array notation is stripped, so interval[] maps the same as interval"""
+        schema = discovery_utils.schema_for_column_datatype(_column('interval[]'))
+        self.assertEqual(schema, {'type': ['null', 'string']})


### PR DESCRIPTION
## Context

We use PipelineWise's tap-postgres to replicate Postgres tables that include `ltree` (hierarchical label paths) and `interval` columns. During discovery, `schema_for_column_datatype` has no branch for either type, so it returns an empty schema and those columns reach the target untyped (effectively dropped). This adds explicit handling so they're discovered as strings.

## What

In `schema_for_column_datatype`, map `interval` and `ltree` to a nullable string schema (non-nullable for primary keys, via `nullable_column`) — consistent with how `uuid`, `citext`, and `cidr/inet/macaddr` are already handled. Array notation is stripped before matching, so `interval[]` / `ltree[]` are covered too.

## Why string

Both types have well-defined textual representations and no natural JSON-schema numeric/object form (`interval` can't satisfy RFC3339, the same reasoning already applied to `time`/`money`).

## Tests

- New `tests/unit/test_discovery_utils.py` covering `ltree`, `interval`, primary-key (non-nullable) handling for both, and array-notation stripping.
- `pytest tests/unit/test_discovery_utils.py` → 5 passed (Python 3.12).
- `pylint --rcfile .pylintrc tap_postgres/discovery_utils.py` → 10.00/10.

## Notes

- Bumps `pipelinewise-tap-postgres` to `2.3.0` with a CHANGELOG entry (marked unreleased — happy to adjust the version/date to your release flow).
- Addressed review feedback: collapsed the two type checks into a single `data_type in {...}` membership test, and added a primary-key `interval` test.
- Small, additive change, but since Postgres is a connector you use at Wise I'm glad to discuss via an issue first or adjust anything you'd prefer.