### PR TITLE
Revert zenpy to 2.0.0 in tap-zendesk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.76.6 (2026-06-08)
+-------------------
+- Revert `zenpy` in `tap-zendesk` to `2.0.0`
+
 0.76.5 (2026-05-20)
 -------------------
 - Update zendesk retry strategy

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.12.*',
-      version='0.76.5',
+      version='0.76.6',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',

--- a/singer-connectors/tap-zendesk/setup.py
+++ b/singer-connectors/tap-zendesk/setup.py
@@ -16,7 +16,7 @@ setup(name='pipelinewise-tap-zendesk',
       py_modules=['tap_zendesk'],
       install_requires=[
           'pipelinewise-singer-python==3.0.2',
-          'zenpy==2.0.52',
+          'zenpy==2.0.0',
       ],
       extras_require={
           'test': [

--- a/singer-connectors/tap-zendesk/tap_zendesk/__init__.py
+++ b/singer-connectors/tap-zendesk/tap_zendesk/__init__.py
@@ -234,7 +234,7 @@ def main():
     # OAuth has precedence
     creds = oauth_auth(parsed_args) or api_token_auth(parsed_args)
     session = get_session(parsed_args.config)
-    client = Zenpy(session=session, proactive_ratelimit=internal_config['rate_limit'], **creds)
+    client = Zenpy(session=session, ratelimit=internal_config['rate_limit'], **creds)
     client.internal_config = internal_config
 
     add_session_hooks(client.tickets.session)


### PR DESCRIPTION
## Context

Reverting `zenpy` from `2.0.52` back to `2.0.0` in `tap-zendesk`. The upgrade to `2.0.52` (done in #1183 for AP-1840) introduced the `proactive_ratelimit` parameter and cursor pagination support, but has caused instability with the retry strategy. This reverts the dependency and restores the original `ratelimit` parameter used by zenpy 2.0.0.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Relevant documentation is updated including usage instructions