### PR TITLE
feat(tap-zendesk): bump zenpy to 2.0.57 and fix Python 3.12 compatibility

### DIFF
--- a/singer-connectors/tap-zendesk/setup.py
+++ b/singer-connectors/tap-zendesk/setup.py
@@ -16,7 +16,7 @@ setup(name='pipelinewise-tap-zendesk',
       py_modules=['tap_zendesk'],
       install_requires=[
           'pipelinewise-singer-python==3.0.2',
-          'zenpy==2.0.0',
+          'zenpy==2.0.57',
       ],
       extras_require={
           'test': [

--- a/singer-connectors/tap-zendesk/tap_zendesk/__init__.py
+++ b/singer-connectors/tap-zendesk/tap_zendesk/__init__.py
@@ -171,8 +171,11 @@ def api_token_auth(args):
     }
 
 def convert_x_rate_limit_remaining_to_int(response, *args, **kwargs):
-    if 'X-Rate-Limit-Remaining' in response.headers and isinstance(response.headers['X-Rate-Limit-Remaining'], str):
-        response.headers['X-Rate-Limit-Remaining'] = int(response.headers['X-Rate-Limit-Remaining'])
+    try:
+        if 'X-Rate-Limit-Remaining' in response.headers and isinstance(response.headers['X-Rate-Limit-Remaining'], str):
+            response.headers['X-Rate-Limit-Remaining'] = int(response.headers['X-Rate-Limit-Remaining'])
+    except (TypeError, ValueError):
+        pass
 
     return response
 

--- a/singer-connectors/tap-zendesk/tap_zendesk/__init__.py
+++ b/singer-connectors/tap-zendesk/tap_zendesk/__init__.py
@@ -171,11 +171,8 @@ def api_token_auth(args):
     }
 
 def convert_x_rate_limit_remaining_to_int(response, *args, **kwargs):
-    try:
-        if 'X-Rate-Limit-Remaining' in response.headers and isinstance(response.headers['X-Rate-Limit-Remaining'], str):
-            response.headers['X-Rate-Limit-Remaining'] = int(response.headers['X-Rate-Limit-Remaining'])
-    except (TypeError, ValueError):
-        pass
+    if 'X-Rate-Limit-Remaining' in response.headers and isinstance(response.headers['X-Rate-Limit-Remaining'], str):
+        response.headers['X-Rate-Limit-Remaining'] = int(response.headers['X-Rate-Limit-Remaining'])
 
     return response
 
@@ -237,7 +234,7 @@ def main():
     # OAuth has precedence
     creds = oauth_auth(parsed_args) or api_token_auth(parsed_args)
     session = get_session(parsed_args.config)
-    client = Zenpy(session=session, ratelimit=internal_config['rate_limit'], **creds)
+    client = Zenpy(session=session, proactive_ratelimit=internal_config['rate_limit'], **creds)
     client.internal_config = internal_config
 
     add_session_hooks(client.tickets.session)

--- a/singer-connectors/tap-zendesk/tap_zendesk/streams.py
+++ b/singer-connectors/tap-zendesk/tap_zendesk/streams.py
@@ -48,7 +48,7 @@ def process_custom_field(field):
     if zendesk_type == 'date':
         field_schema['format'] = 'datetime'
     if zendesk_type == 'dropdown':
-        field_schema['enum'] = [o['value'] for o in field.custom_field_options]
+        field_schema['enum'] = [o.value for o in field.custom_field_options]
 
     return field_schema
 

--- a/singer-connectors/tap-zendesk/test/test_do_sync.py
+++ b/singer-connectors/tap-zendesk/test/test_do_sync.py
@@ -4,7 +4,7 @@ import sys
 import unittest
 
 import json
-from io import StringIO
+from io import BytesIO
 
 import pytz
 from singer import Catalog
@@ -26,25 +26,25 @@ class DoSync(unittest.TestCase):
     def test_network_failure(self):
         client = ZenpyMock(n_tickets=10000, p_sleep=0.01, p_failure=0.1, subdomain='xyz', oauth_token=123)
 
-        self.failUnlessRaises(RuntimeError, do_sync, client, self.catalog, self.state, self.start_date)
+        self.assertRaises(RuntimeError, do_sync, client, self.catalog, self.state, self.start_date)
 
     def test_data_consistency(self):
         client = ZenpyMock(n_tickets=1000, p_sleep=0.01, subdomain='xyz', oauth_token=123)
 
+        bytes_io = BytesIO()
+
+        class BinaryStdout:
+            buffer = bytes_io
+
         saved_stdout = sys.stdout
+        sys.stdout = BinaryStdout()
 
-        string_io = StringIO()
-        sys.stdout = string_io
-
-        # Run do_sync
         do_sync(client, self.catalog, self.state, self.start_date)
         sys.stdout = saved_stdout
 
-        # Checks that every message got delivered on time
-        self._check_everything_delivered(string_io.getvalue(), client)
-
-        # Checks that STATE messages are not corrupted
-        self._check_state_consistency(string_io.getvalue())
+        output = bytes_io.getvalue().decode('utf-8')
+        self._check_everything_delivered(output, client)
+        self._check_state_consistency(output)
 
     def _parse_stdout(self, stdout):
         stdout_messages = []

--- a/singer-connectors/tap-zendesk/test/test_init.py
+++ b/singer-connectors/tap-zendesk/test/test_init.py
@@ -1,5 +1,6 @@
 import unittest
 from tap_zendesk import get_session
+import requests
 
 class TestGetSession(unittest.TestCase):
     """
@@ -8,11 +9,15 @@ class TestGetSession(unittest.TestCase):
     """
     def test_no_partner_info_returns_none(self):
         test_session = get_session({})
-        self.assertEqual(test_session, None)
+        self.assertIsInstance(test_session, requests.Session)
+        self.assertNotIn("X-Zendesk-Marketplace-Name", test_session.headers)
+
 
     def test_incomplete_partner_info_returns_none(self):
         test_session = get_session({"marketplace_name": "Hithere"})
-        self.assertEqual(test_session, None)
+        self.assertIsInstance(test_session, requests.Session)
+        self.assertNotIn("X-Zendesk-Marketplace-Name", test_session.headers)
+
 
     def test_adds_headers_when_all_present_in_config(self):
         test_session = get_session({"marketplace_name": "Hithere",

--- a/singer-connectors/tap-zendesk/test/test_init.py
+++ b/singer-connectors/tap-zendesk/test/test_init.py
@@ -7,13 +7,13 @@ class TestGetSession(unittest.TestCase):
     Confirm that partner information is added to session headers when
     present in config.
     """
-    def test_no_partner_info_returns_none(self):
+    def test_no_partner_info_returns_session_without_headers(self):
         test_session = get_session({})
         self.assertIsInstance(test_session, requests.Session)
         self.assertNotIn("X-Zendesk-Marketplace-Name", test_session.headers)
 
 
-    def test_incomplete_partner_info_returns_none(self):
+    def test_incomplete_partner_info_returns_session_without_headers(self):
         test_session = get_session({"marketplace_name": "Hithere"})
         self.assertIsInstance(test_session, requests.Session)
         self.assertNotIn("X-Zendesk-Marketplace-Name", test_session.headers)


### PR DESCRIPTION
## Context

`tap-zendesk` was broken on Python 3.12 due to an incompatible `zenpy` version. Specifically:

1. **`'CustomFieldOption' object is not subscriptable`** — `zenpy 2.0.52` changed `custom_field_options` from returning dicts to returning `CustomFieldOption` objects. The fix is to access `.value` as an attribute instead of `['value']`.
2. **`Zenpy.__init__() got an unexpected keyword argument 'ratelimit'`** — the `ratelimit` kwarg was renamed to `proactive_ratelimit` in newer zenpy versions.
3. **Test suite incompatibilities with Python 3.12** — `nose` dropped due to removal of the `imp` module; `failUnlessRaises` removed; `StringIO` stdout capture replaced with `BytesIO` for binary singer output; stale `get_session` assertions updated to reflect that a Session is always returned.

Bumps `zenpy` from `2.0.0` to `2.0.57` (latest).


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue) [optional]


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)