### PR TITLE
Fix typos in CLI help strings

### DIFF
--- a/pipelinewise/cli/__init__.py
+++ b/pipelinewise/cli/__init__.py
@@ -207,7 +207,7 @@ def main():
         add_help=True,
     )
     parser.add_argument('command', type=str, choices=COMMANDS)
-    parser.add_argument('--target', type=str, default='*', help='"Name of the target')
+    parser.add_argument('--target', type=str, default='*', help='Name of the target')
     parser.add_argument('--tap', type=str, default='*', help='Name of the tap')
     parser.add_argument('--taps', type=str, default='*', help='Comma separated list of tap IDs to import')
     parser.add_argument('--tables', type=str, help='List of tables to sync')
@@ -249,8 +249,8 @@ def main():
     )
     parser.add_argument('--table', type=str, default='*', help='Name of the table to partial sync')
     parser.add_argument('--column', type=str, default='*', help='Name of the column to use as sync key in partial sync')
-    parser.add_argument('--start_value', type=str, default='*', help='start value of the column to partial sync')
-    parser.add_argument('--end_value', type=str, default=None, help='end value of the column to partial sync')
+    parser.add_argument('--start_value', type=str, default='*', help='Start value of the column to partial sync')
+    parser.add_argument('--end_value', type=str, default=None, help='End value of the column to partial sync')
     parser.add_argument('--force', default=False, required=False,
                         help='Force sync_tables for full sync', action='store_true'
                         )


### PR DESCRIPTION
## Context

PipelineWise's CLI `--help` output had three small errors, reported in #1201: a stray leading quote in the `--target` help string (`"Name of the target`), and two argument help strings (`--start_value`, `--end_value`) that began with a lowercase word, out of step with the sentence case used for every other argument. A maintainer confirmed on the issue that a PR would be welcome.

This changes help text only, in `pipelinewise/cli/__init__.py`; there is no behaviour change.

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Relevant documentation is updated including usage instructions

Closes #1201.
