### PR TITLE
[AP-2830] Slice 1/6: Harden shared FastSync and Snowflake target behaviour

### DIFF
--- a/.github/workflows/connectors.yml
+++ b/.github/workflows/connectors.yml
@@ -23,6 +23,7 @@ jobs:
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -40,6 +40,7 @@ jobs:
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python config
@@ -89,6 +90,7 @@ jobs:
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python config
@@ -148,6 +150,7 @@ jobs:
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python config
@@ -207,6 +210,7 @@ jobs:
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python config
@@ -263,6 +267,7 @@ jobs:
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python config

--- a/.github/workflows/lint_unit_tests.yml
+++ b/.github/workflows/lint_unit_tests.yml
@@ -22,6 +22,7 @@ jobs:
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python config

--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -33,6 +33,7 @@ jobs:
         id: check
         env:
           GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,93 @@
+0.79.0-slice1 (TBD)
+-------------------
+
+**Fixes**
+
+- Make MariaDB/PostgreSQL Snowflake PartialSync publication atomic by staging, copying, and transforming before one mark/merge/delete transaction
+- Correct the Snowflake PartialSync `_SDC_DELETED_AT` hard-delete filter
+- Preserve live Snowflake data when PartialSync fails
+- Preserve replication state when PartialSync fails
+- Publish explicit empty PartialSync ranges
+- Preserve zero-valued PartialSync boundaries
+- Treat an unresolved dynamic PartialSync boundary as a successful no-op
+- Upload every Snowflake FullSync part before deleting local files
+- Roll back Snowflake FullSync staging failures
+- Clean encrypted FullSync temporary files
+- Preserve the live Snowflake table until FullSync cutover
+- Normalize primary keys only when FullSync creates a table
+- Retry FullSync cleanup
+- Retry FullSync grant application
+- Withhold FullSync state until publication completes
+- Grant each published Snowflake table explicitly instead of exposing a concurrent raw `_TEMP` table through `ALL TABLES IN SCHEMA`
+- Serialize FastSync state updates across sibling processes
+- Persist FastSync state with atomic replacement
+- Apply file and directory `fsync` to FastSync state writes
+- Preserve original FastSync state-file permissions
+- Close PostgreSQL FullSync source connections after failure
+- Close PostgreSQL primary-host bookmark connections after FullSync failure
+- Close MariaDB PartialSync source connections after failure
+- Close PostgreSQL PartialSync source connections after failure
+
+**Test hardening**
+
+**New tests added; runtime code was correct**
+
+- Confirm existing type mappings
+- Confirm failure short-circuiting
+- Confirm lock release
+- Confirm bookmark handling
+- Confirm state-error handling
+- Confirm first-upload preservation
+- Confirm MariaDB FullSync cleanup
+- Confirm single-part cleanup
+
+**New tests added; runtime code needed fixing**
+
+- Cover atomic FullSync publication
+- Cover atomic PartialSync publication
+- Cover staging rollback
+- Cover crash-safe state persistence
+- Cover source cleanup
+- Cover boundary values
+- Cover changed-file pagination
+- Cover changed-file detection failures
+
+**Existing tests needed fixing; runtime code was correct**
+
+- Repair PartialSync arguments
+- Repair retry assertions
+- Repair engine assertions
+- Repair log assertions
+- Repair source reset
+- Repair schema isolation
+- Repair temporary-file cleanup
+- Repair log-file cleanup
+- Repair route names
+- Repair profiling expectations
+- Repair optional-credential handling
+
+**Existing tests and runtime code needed fixing**
+
+- Correct publication-order assertions and behavior
+- Correct soft-delete assertions and behavior
+- Correct hard-delete assertions and behavior
+- Correct boundary assertions and behavior
+- Correct COPY SQL assertions and behavior
+- Correct grant SQL assertions and behavior
+- Correct FullSync lifecycle expectations and behavior
+- Correct complete-row comparisons and behavior
+- Correct exact-state assertions and behavior
+
+**CI and development**
+
+- Authenticate changed-file detection
+- Paginate changed-file detection so large pull requests cannot silently skip tests
+- Fail closed when changed-file detection is unavailable
+- Fail closed when changed-file responses are invalid
+- Run lint checks when changed-file detection fails
+- Run unit tests when changed-file detection fails
+- Run E2E tests when changed-file detection fails
+
 0.78.0 (2026-08-05)
 -------------------
 

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -2024,12 +2024,11 @@ class PipelineWise:
                     table_columns.append(sync_settings['column'])
                     static_value = sync_settings.get('static_value')
                     dynamic_value = sync_settings.get('dynamic_value')
-                    if static_value and dynamic_value:
+                    if static_value is not None and dynamic_value is not None:
                         raise Exception('It is not allowed to have both dynamic and static values!')
-                    if static_value:
+                    if static_value is not None:
                         table_values.append(f'<S>{str(static_value)}')
-
-                    if dynamic_value:
+                    elif dynamic_value is not None:
                         table_values.append(f'<D>{str(dynamic_value)}')
 
                     table_drop_targets.append(sync_settings.get('drop_target_table'))

--- a/pipelinewise/fastsync/commons/tap_mysql.py
+++ b/pipelinewise/fastsync/commons/tap_mysql.py
@@ -158,15 +158,24 @@ class FastSyncTapMySql:
 
     def close_connections(self, silent=False):
         """
-        Close connection
+        Close and clear both buffered and unbuffered connections.
         """
-        try:
-            self.conn.close()
-            self.conn_unbuffered.close()
-        except Exception as exc:
-            if not silent:
-                LOGGER.exception(exc)
-                LOGGER.info('Connections seem to be already closed.')
+        connections = (
+            ('buffered', self.conn),
+            ('unbuffered', self.conn_unbuffered),
+        )
+        self.conn = None
+        self.conn_unbuffered = None
+
+        for connection_name, connection in connections:
+            if connection is None:
+                continue
+            try:
+                connection.close()
+            except Exception as exc:
+                if not silent:
+                    LOGGER.exception(exc)
+                    LOGGER.info('%s connection seems to be already closed.', connection_name.capitalize())
 
     # pylint: disable=too-many-arguments
     def query(self, query, conn=None, params=None, return_as_cursor=False, n_retry=1):

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -189,11 +189,41 @@ class FastSyncTapPostgres:
         )
         self.curr = self.conn.cursor()
 
-    def close_connection(self):
+    def close_connection(self, silent=False):
         """
-        Close connection
+        Close source connections
         """
-        self.conn.close()
+        connection = self.conn
+        self.conn = None
+        self.curr = None
+
+        self._close_primary_host_connection(silent=silent)
+
+        if connection is None:
+            return
+
+        try:
+            connection.close()
+        except Exception as exc:
+            if not silent:
+                LOGGER.exception(exc)
+                LOGGER.info('Connection seems to be already closed.')
+
+    def _close_primary_host_connection(self, silent=False):
+        """Close and clear the dedicated primary-host connection."""
+        connection = self.primary_host_conn
+        self.primary_host_conn = None
+        self.primary_host_curr = None
+
+        if connection is None:
+            return
+
+        try:
+            connection.close()
+        except Exception as exc:
+            if not silent:
+                LOGGER.exception(exc)
+                LOGGER.info('Primary host connection seems to be already closed.')
 
     def query(self, query, params=None):
         """
@@ -268,35 +298,35 @@ class FastSyncTapPostgres:
         self.primary_host_conn = self.get_connection(
             self.connection_config, prioritize_primary=True
         )
-        self.primary_host_curr = self.primary_host_conn.cursor()
+        try:
+            self.primary_host_curr = self.primary_host_conn.cursor()
 
-        # Make sure PostgreSQL version is 9.4 or higher
-        # pylint: disable=assignment-from-no-return
-        result = self.primary_host_query(
-            "SELECT setting::int AS version FROM pg_settings WHERE name='server_version_num'"
-        )
-        # pylint: disable=unsubscriptable-object
-        version = result[0].get('version')
+            # Make sure PostgreSQL version is 9.4 or higher
+            # pylint: disable=assignment-from-no-return
+            result = self.primary_host_query(
+                "SELECT setting::int AS version FROM pg_settings WHERE name='server_version_num'"
+            )
+            # pylint: disable=unsubscriptable-object
+            version = result[0].get('version')
 
-        # Do not allow minor versions with PostgreSQL BUG #15114
-        if (version >= 110000) and (version < 110002):
-            raise Exception('PostgreSQL upgrade required to minor version 11.2')
-        if (version >= 100000) and (version < 100007):
-            raise Exception('PostgreSQL upgrade required to minor version 10.7')
-        if (version >= 90600) and (version < 90612):
-            raise Exception('PostgreSQL upgrade required to minor version 9.6.12')
-        if (version >= 90500) and (version < 90516):
-            raise Exception('PostgreSQL upgrade required to minor version 9.5.16')
-        if (version >= 90400) and (version < 90421):
-            raise Exception('PostgreSQL upgrade required to minor version 9.4.21')
-        if version < 90400:
-            raise Exception('Logical replication not supported before PostgreSQL 9.4')
+            # Do not allow minor versions with PostgreSQL BUG #15114
+            if (version >= 110000) and (version < 110002):
+                raise Exception('PostgreSQL upgrade required to minor version 11.2')
+            if (version >= 100000) and (version < 100007):
+                raise Exception('PostgreSQL upgrade required to minor version 10.7')
+            if (version >= 90600) and (version < 90612):
+                raise Exception('PostgreSQL upgrade required to minor version 9.6.12')
+            if (version >= 90500) and (version < 90516):
+                raise Exception('PostgreSQL upgrade required to minor version 9.5.16')
+            if (version >= 90400) and (version < 90421):
+                raise Exception('PostgreSQL upgrade required to minor version 9.4.21')
+            if version < 90400:
+                raise Exception('Logical replication not supported before PostgreSQL 9.4')
 
-        # Create replication slot
-        self.create_replication_slot()
-
-        # Close replication slot dedicated connection
-        self.primary_host_conn.close()
+            # Create replication slot
+            self.create_replication_slot()
+        finally:
+            self._close_primary_host_connection()
 
         # is replica_host set ?
         if self.connection_config.get('replica_host'):

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -79,7 +79,7 @@ class FastSyncTargetSnowflake:
             }
         )
 
-    def open_connection(self, query_tag_props=None):
+    def open_connection(self, query_tag_props=None, autocommit=True):
         return snowflake.connector.connect(
             user=self.connection_config['user'],
             private_key=pem2der(self.connection_config['private_key']),
@@ -87,7 +87,7 @@ class FastSyncTargetSnowflake:
             database=self.connection_config['dbname'],
             warehouse=self.connection_config['warehouse'],
             authenticator='SNOWFLAKE_JWT',
-            autocommit=True,
+            autocommit=autocommit,
             session_parameters={
                 # Quoted identifiers should be case sensitive
                 'QUOTED_IDENTIFIERS_IGNORE_CASE': 'FALSE',
@@ -106,11 +106,44 @@ class FastSyncTargetSnowflake:
 
                 return []
 
+    def execute_transaction(self, queries, query_tag_props=None):
+        """Execute a sequence of statements atomically on one connection."""
+        connection = self.open_connection(query_tag_props, autocommit=False)
+        try:
+            with connection.cursor() as cur:
+                for query in queries:
+                    LOGGER.debug('Running transaction query: %s', query)
+                    cur.execute(query)
+            connection.commit()
+        except Exception:
+            try:
+                connection.rollback()
+            except Exception:  # pragma: no cover - driver-specific cleanup failure
+                LOGGER.warning(
+                    'Failed to roll back Snowflake publication transaction',
+                    exc_info=True,
+                )
+            raise
+        finally:
+            try:
+                connection.close()
+            except Exception:  # pragma: no cover - driver-specific cleanup failure
+                # Publication may already be committed, so a close failure must not
+                # turn a successful sync into an ambiguous retry.
+                LOGGER.warning(
+                    'Failed to close Snowflake publication connection',
+                    exc_info=True,
+                )
+
+    def _get_s3_key(self, file):
+        """Return the deterministic staging key before an upload is attempted."""
+        s3_key_prefix = self.connection_config.get('s3_key_prefix', '')
+        return '{}{}'.format(s3_key_prefix, os.path.basename(file))
+
     def upload_to_s3(self, file, tmp_dir=None):
         bucket = self.connection_config['s3_bucket']
         s3_acl = self.connection_config.get('s3_acl')
-        s3_key_prefix = self.connection_config.get('s3_key_prefix', '')
-        s3_key = '{}{}'.format(s3_key_prefix, os.path.basename(file))
+        s3_key = self._get_s3_key(file)
 
         LOGGER.info(
             'Uploading to S3 bucket: %s, local file: %s, S3 key: %s',
@@ -139,10 +172,19 @@ class FastSyncTargetSnowflake:
                 'x-amz-key': encryption_metadata.key,
                 'x-amz-iv': encryption_metadata.iv,
             }
-            self.s3.upload_file(encrypted_file, bucket, s3_key, ExtraArgs=extra_args)
-
-            # Remove the uploaded encrypted file
-            os.remove(encrypted_file)
+            try:
+                self.s3.upload_file(encrypted_file, bucket, s3_key, ExtraArgs=extra_args)
+            finally:
+                try:
+                    os.remove(encrypted_file)
+                except OSError:
+                    # Once upload succeeds the caller needs the key so it can either
+                    # publish or roll the object back; local cleanup is best-effort.
+                    LOGGER.warning(
+                        'Failed to remove encrypted staging file %s',
+                        encrypted_file,
+                        exc_info=True,
+                    )
 
         # Upload to S3 without encrypting
         else:
@@ -203,7 +245,13 @@ class FastSyncTargetSnowflake:
         sql = 'CREATE SCHEMA IF NOT EXISTS {}'.format(schema)
         self.query(sql, query_tag_props={'schema': schema})
 
-    def drop_table(self, target_schema, table_name, is_temporary=False):
+    def drop_table(
+        self,
+        target_schema,
+        table_name,
+        is_temporary=False,
+        max_attempts=1,
+    ):
         table_dict = utils.tablename_to_dict(table_name)
         target_table = (
             table_dict.get('table_name')
@@ -212,7 +260,24 @@ class FastSyncTargetSnowflake:
         )
 
         sql = 'DROP TABLE IF EXISTS {}."{}"'.format(target_schema, target_table.upper())
-        self.query(sql, query_tag_props={'schema': target_schema, 'table': table_name})
+        for attempt in range(1, max_attempts + 1):
+            try:
+                self.query(
+                    sql,
+                    query_tag_props={'schema': target_schema, 'table': table_name},
+                )
+                return
+            except Exception as exc:
+                if attempt == max_attempts:
+                    raise
+                LOGGER.warning(
+                    'Snowflake staging cleanup retry %s/%s failed for %s.%s: %s',
+                    attempt,
+                    max_attempts,
+                    target_schema,
+                    target_table,
+                    exc,
+                )
 
     # pylint: disable=too-many-positional-arguments
     def create_table(
@@ -223,7 +288,8 @@ class FastSyncTargetSnowflake:
         primary_key: Optional[List[str]],
         is_temporary: bool = False,
         sort_columns=False,
-        allow_replace_table=True
+        allow_replace_table=True,
+        normalize_primary_keys=True,
     ):
 
         table_dict = utils.tablename_to_dict(table_name)
@@ -231,6 +297,11 @@ class FastSyncTargetSnowflake:
             table_dict.get('table_name')
             if not is_temporary
             else table_dict.get('temp_table_name')
+        )
+        target_existed = (
+            self.table_exists(target_schema, table_name, is_temporary)
+            if normalize_primary_keys == 'if_created'
+            else False
         )
 
         # skip the EXTRACTED, BATCHED and DELETED columns in case they exist because they gonna be added later
@@ -259,19 +330,39 @@ class FastSyncTargetSnowflake:
         full_table_name = self._get_full_qualified_table_name(target_schema, target_table)
 
         sql_columns = ','.join(columns)
-        sql_primary_keys = ','.join(primary_key) if primary_key else None
-        create_sql = 'OR REPLACE TABLE' if allow_replace_table else 'TABLE IF NOT EXISTS'
-
         sql = (
-            f'CREATE {create_sql} {full_table_name} ({sql_columns}'
-            f'{f", PRIMARY KEY ({sql_primary_keys}))" if primary_key else ")"}'
+            f'CREATE '
+            f'{"OR REPLACE TABLE" if allow_replace_table else "TABLE IF NOT EXISTS"} '
+            f'{full_table_name} ({sql_columns}'
+            f'{f", PRIMARY KEY ({",".join(primary_key)}))" if primary_key else ")"}'
         )
 
         self.query(
             sql, query_tag_props={'schema': target_schema, 'table': target_table}
         )
 
-        self._drop_pk_non_nullability(target_schema, target_table, primary_key)
+        if normalize_primary_keys and not target_existed:
+            self._drop_pk_non_nullability(target_schema, target_table, primary_key)
+
+    def table_exists(self, target_schema, table_name, is_temporary=False):
+        """Return whether the exact standard or staging table already exists."""
+        table_dict = utils.tablename_to_dict(table_name)
+        target_table = (
+            table_dict.get('temp_table_name')
+            if is_temporary
+            else table_dict.get('table_name')
+        ).upper()
+        quoted_schema = target_schema.upper().replace('"', '""')
+        table_prefix = target_table.replace("'", "''")
+        rows = self.query(
+            f'SHOW TABLES IN SCHEMA "{quoted_schema}" '
+            f"STARTS WITH '{table_prefix}'",
+            query_tag_props={'schema': target_schema, 'table': table_name},
+        )
+        return any(
+            row.get('name', row.get('NAME')) == target_table
+            for row in rows
+        )
 
     def _drop_pk_non_nullability(self, target_schema: str, target_table: str, primary_keys: Optional[List[str]]):
         """
@@ -323,10 +414,13 @@ class FastSyncTargetSnowflake:
         inserts = 0
 
         stage = self.connection_config['stage']
+        # Keep Snowflake's default explicit: unquoted empty fields are NULL, while
+        # quoted empty fields remain empty strings.
         sql = (
             f'COPY INTO {target_schema}."{target_table.upper()}" FROM \'@{stage}/{s3_key}\''
             f' FILE_FORMAT = (type=CSV escape=NONE escape_unenclosed_field=\'\\x1e\''
-            f' field_optionally_enclosed_by=\'\"\' skip_header={int(skip_csv_header)}'
+            f' field_optionally_enclosed_by=\'\"\' empty_field_as_null=TRUE'
+            f' skip_header={int(skip_csv_header)}'
             f' compression=GZIP binary_format=HEX)'
         )
 
@@ -365,7 +459,7 @@ class FastSyncTargetSnowflake:
                 if not is_temporary
                 else table_dict.get('temp_table_name')
             )
-            sql = 'GRANT SELECT ON {}."{}" TO ROLE {}'.format(
+            sql = 'GRANT SELECT ON TABLE {}."{}" TO ROLE {}'.format(
                 target_schema, target_table.upper(), role
             )
             self.query(
@@ -422,7 +516,8 @@ class FastSyncTargetSnowflake:
 
         LOGGER.info('Obfuscation rules applied.')
 
-    def merge_tables(self, schema, source_table, target_table, columns, primary_keys):
+    @staticmethod
+    def _merge_tables_query(schema, source_table, target_table, columns, primary_keys):
         on_clause = ' AND '.join(
             [f'"{source_table.upper()}".{p.upper()} = "{target_table.upper()}".{p.upper()}' for p in primary_keys]
         )
@@ -432,19 +527,44 @@ class FastSyncTargetSnowflake:
         columns_for_insert = ', '.join([f'{c.upper()}' for c in columns])
         values = ', '.join([f'"{source_table.upper()}".{c.upper()}' for c in columns])
 
-        query = f'MERGE INTO {schema}."{target_table.upper()}" USING {schema}."{source_table.upper()}"'  \
-                f' ON {on_clause}'  \
-                f' WHEN MATCHED THEN UPDATE SET {update_clause}'  \
-                f' WHEN NOT MATCHED THEN INSERT ({columns_for_insert})'  \
-                f' VALUES ({values})'
-        self.query(query)
+        return f'MERGE INTO {schema}."{target_table.upper()}" USING {schema}."{source_table.upper()}"' \
+               f' ON {on_clause}' \
+               f' WHEN MATCHED THEN UPDATE SET {update_clause}' \
+               f' WHEN NOT MATCHED THEN INSERT ({columns_for_insert})' \
+               f' VALUES ({values})'
+
+    def merge_tables(self, schema, source_table, target_table, columns, primary_keys):
+        self.query(self._merge_tables_query(schema, source_table, target_table, columns, primary_keys))
+
+    @staticmethod
+    def _partial_hard_delete_query(schema, table, where_clause_sql):
+        return f'DELETE FROM {schema}."{table.upper()}"{where_clause_sql} AND _SDC_DELETED_AT IS NOT NULL'
 
     def partial_hard_delete(self, schema, table, where_clause_sql):
-        self.query(
-            f'DELETE FROM {schema}."{table.upper()}"{where_clause_sql} AND _SDC_DELETEd_AT IS NOT NULL'
-        )
+        self.query(self._partial_hard_delete_query(schema, table, where_clause_sql))
 
-    def swap_tables(self, schema, table_name) -> None:
+    def publish_partial_sync(
+        self,
+        schema,
+        source_table,
+        target_table,
+        columns,
+        primary_keys,
+        where_clause_sql,
+        hard_delete,
+    ):
+        """Atomically mark, merge, and optionally delete one partial range."""
+        queries = [
+            f'UPDATE {schema}."{target_table.upper()}" SET _SDC_DELETED_AT = CURRENT_TIMESTAMP()'
+            f'{where_clause_sql} AND _SDC_DELETED_AT IS NULL',
+            self._merge_tables_query(schema, source_table, target_table, columns, primary_keys),
+        ]
+        if hard_delete:
+            queries.append(self._partial_hard_delete_query(schema, target_table, where_clause_sql))
+
+        self.execute_transaction(queries, query_tag_props={'schema': schema, 'table': target_table})
+
+    def swap_tables(self, schema, table_name, cleanup_old_table=True) -> None:
         """
         Swaps given target table with its temp version and drops the latter
         Args:
@@ -456,16 +576,21 @@ class FastSyncTargetSnowflake:
         target_table = table_dict.get('table_name')
         temp_table = table_dict.get('temp_table_name')
 
-        # Swap tables and drop the temp tamp
+        # Swap tables and drop the old target now held under the temp name.
         self.query(
             f'ALTER TABLE {schema}."{temp_table.upper()}" SWAP WITH {schema}."{target_table.upper()}"',
             query_tag_props={'schema': schema, 'table': target_table},
         )
 
-        self.query(
-            f'DROP TABLE IF EXISTS {schema}."{temp_table.upper()}"',
-            query_tag_props={'schema': schema, 'table': temp_table},
-        )
+        if cleanup_old_table:
+            # Cleanup is part of successful publication. If it cannot complete,
+            # the caller withholds state and retries this idempotent range.
+            self.drop_table(
+                schema,
+                table_name,
+                is_temporary=True,
+                max_attempts=3,
+            )
 
     def add_columns(self, schema: str, table_name: str, adding_columns: dict) -> None:
         if adding_columns:

--- a/pipelinewise/fastsync/commons/utils.py
+++ b/pipelinewise/fastsync/commons/utils.py
@@ -1,11 +1,16 @@
 import argparse
+from contextlib import contextmanager
+import fcntl
 import json
 import multiprocessing
 import os
 import logging
 import datetime
+import re
+import stat
+import tempfile
 
-from typing import Dict
+from typing import Callable, Dict, List, Tuple
 from pipelinewise.cli.utils import generate_random_string
 
 LOGGER = logging.getLogger(__name__)
@@ -13,6 +18,330 @@ LOGGER = logging.getLogger(__name__)
 SDC_EXTRACTED_AT = '_SDC_EXTRACTED_AT'
 SDC_BATCHED_AT = '_SDC_BATCHED_AT'
 SDC_DELETED_AT = '_SDC_DELETED_AT'
+
+
+class StagingUploadError(RuntimeError):
+    """An upload failed and its successfully uploaded parts still need cleanup."""
+
+    def __init__(self, upload_error, cleanup_error, s3_keys):
+        super().__init__(
+            f'{upload_error}; staging upload rollback failed: {cleanup_error}'
+        )
+        self.s3_keys = list(s3_keys)
+
+
+def delete_s3_objects(
+    snowflake,
+    s3_keys: List[str],
+    bucket: str,
+    cleanup_context='FastSync staging cleanup',
+    max_attempts=3,
+) -> None:
+    """Delete every staging object with bounded retries and report any debt."""
+    failures = []
+    for s3_key in s3_keys:
+        for attempt in range(1, max_attempts + 1):
+            try:
+                snowflake.s3.delete_object(Bucket=bucket, Key=s3_key)
+                break
+            except Exception as exc:
+                if attempt == max_attempts:
+                    failures.append((s3_key, exc))
+                else:
+                    LOGGER.warning(
+                        '%s retry %s/%s failed for s3://%s/%s: %s',
+                        cleanup_context,
+                        attempt,
+                        max_attempts,
+                        bucket,
+                        s3_key,
+                        exc,
+                    )
+
+    if failures:
+        details = '; '.join(
+            f's3://{bucket}/{s3_key}: {exc}' for s3_key, exc in failures
+        )
+        raise RuntimeError(f'{cleanup_context} failed after {max_attempts} attempts: {details}')
+
+
+def cleanup_staging(
+    snowflake,
+    s3_keys,
+    bucket,
+    target_schema=None,
+    table=None,
+    temp_created=False,
+) -> None:
+    """Attempt all S3 and Snowflake staging cleanup before reporting failures."""
+    failures = []
+    if s3_keys:
+        try:
+            delete_s3_objects(
+                snowflake,
+                s3_keys,
+                bucket,
+                cleanup_context='Failed FastSync rollback',
+            )
+        except Exception as exc:
+            failures.append(f'S3 objects: {exc}')
+
+    if temp_created and target_schema and table:
+        try:
+            snowflake.drop_table(
+                target_schema,
+                table,
+                is_temporary=True,
+                max_attempts=3,
+            )
+        except Exception as exc:
+            failures.append(f'Snowflake staging table: {exc}')
+
+    if failures:
+        raise RuntimeError('; '.join(failures))
+
+
+def apply_snowflake_table_grants(
+    snowflake,
+    target_config,
+    target_schema,
+    table,
+    is_temporary=False,
+) -> None:
+    """Grant schema usage and SELECT on one obfuscated staging or live table."""
+    grantees = get_grantees(target_config, table)
+
+    def grant_select_on_live_table(schema, role, to_group=False):
+        snowflake.grant_select_on_table(
+            schema,
+            table,
+            role,
+            is_temporary=is_temporary,
+            to_group=to_group,
+        )
+
+    run_post_publication_actions([
+        (
+            'schema usage grant',
+            lambda: grant_privilege(
+                target_schema, grantees, snowflake.grant_usage_on_schema
+            ),
+        ),
+        (
+            'live table select grant',
+            lambda: grant_privilege(
+                target_schema, grantees, grant_select_on_live_table
+            ),
+        ),
+    ])
+
+
+def retry_snowflake_table_grants(
+    snowflake,
+    target_config,
+    target_schema,
+    table,
+    is_temporary=False,
+    max_attempts=3,
+) -> None:
+    """Retry idempotent grants so a transient failure does not force republish."""
+    for attempt in range(1, max_attempts + 1):
+        try:
+            apply_snowflake_table_grants(
+                snowflake,
+                target_config,
+                target_schema,
+                table,
+                is_temporary=is_temporary,
+            )
+            return
+        except Exception as exc:
+            if attempt == max_attempts:
+                raise
+            LOGGER.warning(
+                'Snowflake grant retry %s/%s failed for %s.%s: %s',
+                attempt,
+                max_attempts,
+                target_schema,
+                table,
+                exc,
+            )
+
+
+def finalize_snowflake_fullsync(
+    snowflake,
+    s3_keys,
+    bucket,
+    target_config,
+    target_schema,
+    table,
+    publication_error=None,
+) -> None:
+    """Attempt finalization without masking an earlier publication failure."""
+    try:
+        run_post_publication_actions([
+            (
+                'grant application',
+                lambda: apply_snowflake_table_grants(
+                    snowflake, target_config, target_schema, table
+                ),
+            ),
+            (
+                'S3 staging cleanup',
+                lambda: delete_s3_objects(
+                    snowflake,
+                    s3_keys,
+                    bucket,
+                    cleanup_context='Successful FullSync staging cleanup',
+                ),
+            ),
+            (
+                'Snowflake staging cleanup',
+                lambda: snowflake.drop_table(
+                    target_schema,
+                    table,
+                    is_temporary=True,
+                    max_attempts=3,
+                ),
+            ),
+        ])
+    except Exception as finalization_error:
+        if publication_error is not None:
+            raise RuntimeError(
+                f'{publication_error}; post-publication finalization failed: '
+                f'{finalization_error}'
+            ) from publication_error
+        raise
+
+
+def staging_failure_result(
+    snowflake,
+    s3_keys,
+    bucket,
+    target_schema,
+    table,
+    temp_created,
+    operation_error,
+) -> str:
+    """Roll back staging and preserve both the operation and cleanup errors."""
+    result = f'{table}: {operation_error}'
+    if not s3_keys and not temp_created:
+        return result
+
+    try:
+        cleanup_staging(
+            snowflake,
+            s3_keys,
+            bucket,
+            target_schema=target_schema,
+            table=table,
+            temp_created=temp_created,
+        )
+    except Exception as cleanup_error:
+        LOGGER.exception('Failed to clean up FastSync staging')
+        result = f'{result}; staging cleanup failed: {cleanup_error}'
+    return result
+
+
+def partial_sync_failure_result(
+    snowflake,
+    target_config,
+    source_table,
+    target_schema,
+    target_table,
+    staging,
+    operation_error,
+) -> str:
+    """Repair published grants, roll back staging, and preserve every error."""
+    if staging['publication_attempted'] and not staging['grants_attempted']:
+        try:
+            retry_snowflake_table_grants(
+                snowflake, target_config, target_schema, source_table
+            )
+        except Exception as grant_error:
+            LOGGER.exception('Failed to repair PartialSync grants')
+            operation_error = RuntimeError(
+                f'{operation_error}; grant application failed: {grant_error}'
+            )
+
+    return staging_failure_result(
+        snowflake,
+        staging['s3_keys'],
+        target_config.get('s3_bucket'),
+        target_schema,
+        target_table or source_table,
+        staging['temp_created'],
+        operation_error,
+    )
+
+
+def get_expected_s3_key(snowflake, file_part):
+    """Resolve a deterministic key so ambiguous upload outcomes can be cleaned."""
+    key_resolver = getattr(snowflake, '_get_s3_key', None)
+    if not callable(key_resolver):
+        return None
+    expected_key = key_resolver(file_part)
+    return expected_key if isinstance(expected_key, str) else None
+
+
+def upload_files_to_s3(
+    snowflake,
+    file_parts: List[str],
+    temp_dir: str,
+    bucket: str,
+) -> Tuple[List[str], str]:
+    """Upload every part before removing local files and roll back failed staging."""
+    s3_keys = []
+    try:
+        for file_part in file_parts:
+            expected_key = get_expected_s3_key(snowflake, file_part)
+            if expected_key:
+                s3_keys.append(expected_key)
+            uploaded_key = snowflake.upload_to_s3(file_part, tmp_dir=temp_dir)
+            if expected_key:
+                s3_keys[-1] = uploaded_key
+            else:
+                s3_keys.append(uploaded_key)
+        for file_part in file_parts:
+            os.remove(file_part)
+    except Exception as upload_error:
+        try:
+            delete_s3_objects(
+                snowflake,
+                s3_keys,
+                bucket,
+                cleanup_context='Failed FastSync upload rollback',
+            )
+        except Exception as cleanup_error:
+            LOGGER.exception('Failed to fully roll back uploaded FastSync staging objects')
+            raise StagingUploadError(
+                upload_error, cleanup_error, s3_keys
+            ) from upload_error
+        raise
+
+    s3_key_pattern = (
+        re.sub(r'\.part\d*$', '', s3_keys[0])
+        if s3_keys
+        else 'NO_FILES_TO_LOAD'
+    )
+    return s3_keys, s3_key_pattern
+
+
+def run_post_publication_actions(
+    actions: List[Tuple[str, Callable[[], None]]],
+) -> None:
+    """Attempt every required post-publication action before reporting failures."""
+    failures = []
+    for action_name, action in actions:
+        try:
+            action()
+        except Exception as exc:
+            LOGGER.exception('Post-publication %s failed', action_name)
+            failures.append((action_name, exc))
+
+    if failures:
+        details = '; '.join(f'{action_name}: {exc}' for action_name, exc in failures)
+        raise RuntimeError(f'Post-publication actions failed: {details}') from failures[0][1]
 
 
 class NotSelectedTableException(Exception):
@@ -40,10 +369,53 @@ def load_json(path):
         return json.load(fil)
 
 
+def _fsync_directory(path):
+    """Persist a renamed state-file directory entry across host crashes."""
+    directory_descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(directory_descriptor)
+    finally:
+        os.close(directory_descriptor)
+
+
 def save_dict_to_json(path, data):
     LOGGER.info('Saving new state file to %s', path)
-    with open(path, 'w', encoding='utf-8') as fil:
-        fil.write(json.dumps(data, indent=4, sort_keys=True))
+    path = os.path.realpath(path)
+    directory = os.path.dirname(path)
+    file_mode = stat.S_IMODE(os.stat(path).st_mode) if os.path.exists(path) else None
+    file_descriptor, temp_path = tempfile.mkstemp(
+        dir=directory,
+        prefix=f'.{os.path.basename(path)}.',
+        suffix='.tmp',
+    )
+
+    try:
+        with os.fdopen(file_descriptor, 'w', encoding='utf-8') as fil:
+            json.dump(data, fil, indent=4, sort_keys=True)
+            fil.flush()
+            os.fsync(fil.fileno())
+        if file_mode is not None:
+            os.chmod(temp_path, file_mode)
+        os.replace(temp_path, path)
+        _fsync_directory(directory)
+    except Exception:
+        try:
+            os.remove(temp_path)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+@contextmanager
+def _state_file_lock(path):
+    """Serialize state updates across independently started FastSync processes."""
+    state_path = os.path.realpath(path)
+    with open(f'{state_path}.lock', 'a', encoding='utf-8') as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield state_path
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def check_config(config, required_keys):
@@ -254,18 +626,32 @@ def get_grantees(target_config, table):
     return grantees
 
 
-def grant_privilege(schema, grantees, grant_method, to_group=False):
+def _grantee_entries(grantees, to_group=False):
+    """Normalize configured grantees while preserving user/group semantics."""
+    if isinstance(grantees, str):
+        return [(grantees, to_group)]
     if isinstance(grantees, list):
-        for grantee in grantees:
-            grant_method(schema, grantee, to_group)
-    elif isinstance(grantees, str):
-        grant_method(schema, grantees, to_group)
-    elif isinstance(grantees, dict):
-        users = grantees.get('users')
-        groups = grantees.get('groups')
+        return [(grantee, to_group) for grantee in grantees]
+    if isinstance(grantees, dict):
+        return (
+            _grantee_entries(grantees.get('users'))
+            + _grantee_entries(grantees.get('groups'), to_group=True)
+        )
+    return []
 
-        grant_privilege(schema, users, grant_method)
-        grant_privilege(schema, groups, grant_method, to_group=True)
+
+def grant_privilege(schema, grantees, grant_method, to_group=False):
+    """Attempt a privilege grant for every configured grantee."""
+    failures = []
+    for grantee, grantee_is_group in _grantee_entries(grantees, to_group):
+        try:
+            grant_method(schema, grantee, grantee_is_group)
+        except Exception as exc:
+            failures.append((grantee, exc))
+
+    if failures:
+        details = '; '.join(f'{grantee}: {exc}' for grantee, exc in failures)
+        raise RuntimeError(f'Privilege grants failed: {details}') from failures[0][1]
 
 
 def save_state_file(path, table, bookmark, dbname=None):
@@ -285,21 +671,23 @@ def save_state_file(path, table, bookmark, dbname=None):
     if not path:
         return
 
-    # Load the current state file
-    state = {}
-    if os.path.exists(path):
-        state = load_json(path)
+    with _state_file_lock(path) as state_path:
+        # Load the current state file
+        state = {}
+        if os.path.exists(state_path):
+            state = load_json(state_path)
 
-    # Find the current table position
-    bookmarks = state.get('bookmarks', {})
+        # Find the current table position
+        bookmarks = state.get('bookmarks', {})
 
-    # Update the state file with the new values at the right place
-    state['currently_syncing'] = None
-    state['bookmarks'] = bookmarks
-    state['bookmarks'][stream_id] = bookmark
+        # Update the state file with the new values at the right place
+        state['currently_syncing'] = None
+        state['bookmarks'] = bookmarks
+        state['bookmarks'][stream_id] = bookmark
 
-    # Save the new state file
-    save_dict_to_json(path, state)
+        # Save the new state file
+        save_dict_to_json(state_path, state)
+        LOGGER.info('FastSync state updated for stream: %s', stream_id)
 
 
 def parse_args(required_config_keys: Dict) -> argparse.Namespace:

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -2,7 +2,6 @@
 import os
 import sys
 import glob
-import re
 from functools import partial
 from argparse import Namespace
 import multiprocessing
@@ -32,8 +31,6 @@ REQUIRED_CONFIG_KEYS = {
         'file_format',
     ],
 }
-
-LOCK = multiprocessing.Lock()
 
 
 def tap_type_to_target_type(mysql_type, mysql_column_type):
@@ -88,6 +85,9 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     snowflake = FastSyncTargetSnowflake(args.target, args.transform)
     tap_id = args.target.get('tap_id')
     archive_load_files = args.target.get('archive_load_files', False)
+    s3_keys = []
+    target_schema = None
+    temp_created = False
 
     try:
         filename = utils.gen_export_filename(tap_id=tap_id, table=table)
@@ -121,21 +121,16 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         snowflake_columns = snowflake_types.get('columns', [])
         primary_key = snowflake_types.get('primary_key')
 
-        # Uploading to S3
-        s3_keys = []
-        for file_part in file_parts:
-            s3_keys.append(snowflake.upload_to_s3(file_part, tmp_dir=args.temp_dir))
-            os.remove(file_part)
-
-        # Create a pattern that match all file parts by removing multipart suffix
-        s3_key_pattern = (
-            re.sub(r'\.part\d*$', '', s3_keys[0])
-            if len(s3_keys) > 0
-            else 'NO_FILES_TO_LOAD'
+        s3_keys, s3_key_pattern = utils.upload_files_to_s3(
+            snowflake,
+            file_parts,
+            args.temp_dir,
+            args.target.get('s3_bucket'),
         )
 
         # Creating temp table in Snowflake
         snowflake.create_schema(target_schema)
+        temp_created = True
         snowflake.create_table(
             target_schema, table, snowflake_columns, primary_key, is_temporary=True
         )
@@ -150,34 +145,63 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
                 # Copy load file to archive
                 snowflake.copy_to_archive(s3_key, tap_id, table)
 
-            # Delete all file parts from s3
-            snowflake.s3.delete_object(Bucket=args.target.get('s3_bucket'), Key=s3_key)
-
         # Obfuscate columns
         snowflake.obfuscate_columns(target_schema, table)
 
         # Create target table and swap with the temp table in Snowflake
-        snowflake.create_table(target_schema, table, snowflake_columns, primary_key)
-        snowflake.swap_tables(target_schema, table)
-
-        # Save bookmark to singer state file
-        # Lock to ensure that only one process writes the same state file at a time
-        LOCK.acquire()
+        snowflake.create_table(
+            target_schema,
+            table,
+            snowflake_columns,
+            primary_key,
+            allow_replace_table=False,
+            normalize_primary_keys=False,
+        )
+        utils.apply_snowflake_table_grants(
+            snowflake,
+            args.target,
+            target_schema,
+            table,
+            is_temporary=True,
+        )
+        publication_error = None
         try:
-            utils.save_state_file(args.state, table, bookmark)
-        finally:
-            LOCK.release()
+            snowflake.swap_tables(
+                target_schema, table, cleanup_old_table=False
+            )
+        except Exception as exc:
+            publication_error = exc
 
-        # Table loaded, grant select on all tables in target schema
-        grantees = utils.get_grantees(args.target, table)
-        utils.grant_privilege(target_schema, grantees, snowflake.grant_usage_on_schema)
-        utils.grant_privilege(target_schema, grantees, snowflake.grant_select_on_schema)
+        utils.finalize_snowflake_fullsync(
+            snowflake,
+            s3_keys,
+            args.target.get('s3_bucket'),
+            args.target,
+            target_schema,
+            table,
+            publication_error=publication_error,
+        )
+        s3_keys = []
+        temp_created = False
+
+        if publication_error:
+            raise publication_error
+
+        utils.save_state_file(args.state, table, bookmark)
 
         return True
 
     except Exception as exc:
         LOGGER.exception(exc)
-        return '{}: {}'.format(table, exc)
+        return utils.staging_failure_result(
+            snowflake,
+            getattr(exc, 's3_keys', s3_keys),
+            args.target.get('s3_bucket'),
+            target_schema,
+            table,
+            temp_created,
+            exc,
+        )
 
     finally:
         # try closing connections again just in case, silence errors

--- a/pipelinewise/fastsync/partialsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/partialsync/mysql_to_snowflake.py
@@ -25,88 +25,102 @@ def partial_sync_table(table: tuple, args: Namespace) -> Union[bool, str]:
     """Partial sync table for MySQL to Snowflake"""
     snowflake = FastSyncTargetSnowflake(args.target, args.transform)
     tap_id = args.target.get('tap_id')
+    table_name = table[0]
+    s3_keys = []
+    target_schema = None
+    target_table = None
+    temp_created = False
+    publication_status = {'attempted': False}
+    grants_attempted = False
 
     try:
-        table_name = table[0]
-
         column_name = table[1]['column']
 
-        drop_target_table = table[1]['drop_target_table']
-        args.drop_target_table = drop_target_table
-        args.table = table_name
+        args.drop_target_table, args.table = (
+            table[1]['drop_target_table'],
+            table_name,
+        )
 
         mysql = FastSyncTapMySql(args.tap, tap_type_to_target_type)
+        try:
+            mysql.open_connections()
 
-        mysql.open_connections()
+            start_value = utils.validate_boundary_value(mysql.query, table[1]['start_value'])
+            end_value = utils.validate_boundary_value(mysql.query, table[1]['end_value'])
 
-        start_value = utils.validate_boundary_value(mysql.query, table[1]['start_value'])
-        end_value = utils.validate_boundary_value(mysql.query, table[1]['end_value'])
+            if (
+                start_value is utils.DYNAMIC_BOUNDARY_NOT_READY
+                or end_value is utils.DYNAMIC_BOUNDARY_NOT_READY
+            ):
+                LOGGER.info('Dynamic boundary returned no value for %s; skipping PartialSync', table_name)
+                return True
 
-        # Get bookmark - Binlog position or Incremental Key value
-        bookmark = common_utils.get_bookmark_for_table(table_name, args.properties, mysql)
+            bookmark = common_utils.get_bookmark_for_table(table_name, args.properties, mysql)
+            snowflake_types = mysql.map_column_types_to_target(table_name)
+
+            start_value_for_query = start_value if start_value == 'NULL' else f'\'{start_value}\''
+            where_clause_sql = f' WHERE {column_name} >= {start_value_for_query}'
+            if end_value is not None:
+                where_clause_sql += f' AND {column_name} <= \'{end_value}\''
+
+            file_parts = mysql.export_source_table_data(args, tap_id, where_clause_sql)
+        finally:
+            mysql.close_connections(silent=True)
 
         target_schema = common_utils.get_target_schema(args.target, table_name)
         table_dict = common_utils.tablename_to_dict(table_name)
         target_table = table_dict.get('table_name')
-
         target_sf = {
             'sf_object': snowflake,
             'schema': target_schema,
             'table': target_table,
-            'temp': table_dict.get('temp_table_name')
+            'temp': table_dict.get('temp_table_name'),
+            'publication_status': publication_status,
         }
-
-        snowflake_types = mysql.map_column_types_to_target(table_name)
-
-        # making target table if not exists
-        snowflake.create_schema(target_schema)
-        snowflake.create_table(
-            target_schema=target_schema,
-            table_name=target_table,
-            columns=snowflake_types['columns'],
-            primary_key=snowflake_types.get('primary_key'),
-            is_temporary=False,
-            sort_columns=False,
-            allow_replace_table=False
-        )
-
         source_columns = snowflake_types.get('columns', [])
-        columns_diff = utils.diff_source_target_columns(target_sf, source_columns=source_columns)
 
-        start_value_for_query = start_value if start_value == 'NULL' else f'\'{start_value}\''
-        where_clause_sql = f' WHERE {column_name} >= {start_value_for_query}'
-        if end_value:
-            where_clause_sql += f' AND {column_name} <= \'{end_value}\''
-
-        # export data from source
-        file_parts = mysql.export_source_table_data(args, tap_id, where_clause_sql)
-
-        # mark partial data as deleted in the target
-        snowflake.query(f'UPDATE {target_schema}."{target_table.upper()}"'
-                        f' SET _SDC_DELETEd_AT = CURRENT_TIMESTAMP(){where_clause_sql} AND _SDC_DELETED_AT IS NULL')
-
-        # Creating temp table in Snowflake
         primary_keys = snowflake_types.get('primary_key')
         snowflake.create_schema(target_schema)
+        temp_created = True
         snowflake.create_table(
             target_schema, target_table, source_columns, primary_keys, is_temporary=True
         )
 
-        mysql.close_connections()
-
         size_bytes = sum([os.path.getsize(file_part) for file_part in file_parts])
-        _, s3_key_pattern = utils.upload_to_s3(snowflake, file_parts, args.temp_dir)
+        s3_keys, s3_key_pattern = utils.upload_to_s3(snowflake, file_parts, args.temp_dir)
 
         utils.load_into_snowflake(
-            target_sf, args, columns_diff, primary_keys, s3_key_pattern, size_bytes, where_clause_sql)
+            target_sf, args, source_columns, primary_keys, s3_key_pattern,
+            size_bytes, where_clause_sql,
+        )
+        publication_status['attempted'] = True
+        temp_created = False
 
-        if file_parts:
-            utils.update_state_file(args, bookmark)
+        grants_attempted = True
+        common_utils.retry_snowflake_table_grants(
+            snowflake, args.target, target_schema, table_name
+        )
+        utils.delete_s3_objects(snowflake, s3_keys, args.target.get('s3_bucket'))
+        s3_keys = []
+        utils.update_state_file(args, bookmark)
 
         return True
     except Exception as exc:
         LOGGER.exception(exc)
-        return f'{table_name}: {exc}'
+        return common_utils.partial_sync_failure_result(
+            snowflake,
+            args.target,
+            table_name,
+            target_schema,
+            target_table,
+            {
+                's3_keys': getattr(exc, 's3_keys', s3_keys),
+                'temp_created': temp_created,
+                'publication_attempted': publication_status['attempted'],
+                'grants_attempted': grants_attempted,
+            },
+            exc,
+        )
 
 
 def main_impl():
@@ -137,18 +151,14 @@ def main_impl():
     )
 
     sync_tables = utils.get_sync_tables(args)
-
     pool_size = len(sync_tables) if len(sync_tables) < pool_size else pool_size
     with multiprocessing.Pool(pool_size) as proc:
-        sync_excs = list(
-            filter(
-                lambda x: not isinstance(x, bool),
-                proc.map(partial(partial_sync_table, args=args), sync_tables.items())
-            )
+        sync_results = proc.map(
+            partial(partial_sync_table, args=args),
+            sync_tables.items(),
         )
 
-    if isinstance(sync_excs, bool):
-        sync_excs = None
+    sync_excs = [result for result in sync_results if result is not True]
 
     # Log summary
     end_time = datetime.now()

--- a/pipelinewise/fastsync/partialsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/partialsync/postgres_to_snowflake.py
@@ -23,89 +23,103 @@ def partial_sync_table(table: tuple, args: Namespace) -> Union[bool, str]:
     snowflake = FastSyncTargetSnowflake(args.target, args.transform)
     tap_id = args.target.get('tap_id')
     dbname = args.tap.get('dbname')
+    table_name = table[0]
+    s3_keys = []
+    target_schema = None
+    target_table = None
+    temp_created = False
+    publication_status = {'attempted': False}
+    grants_attempted = False
     try:
-        table_name = table[0]
-
         column_name = table[1]['column']
 
-        drop_target_table = table[1]['drop_target_table']
-        args.drop_target_table = drop_target_table
-        args.table = table_name
+        args.drop_target_table, args.table = (
+            table[1]['drop_target_table'],
+            table_name,
+        )
 
         postgres = FastSyncTapPostgres(args.tap, tap_type_to_target_type)
+        try:
+            postgres.open_connection()
 
-        # Open connection
-        postgres.open_connection()
+            start_value = utils.validate_boundary_value(postgres.query, table[1]['start_value'])
+            end_value = utils.validate_boundary_value(postgres.query, table[1]['end_value'])
 
-        start_value = utils.validate_boundary_value(postgres.query, table[1]['start_value'])
-        end_value = utils.validate_boundary_value(postgres.query, table[1]['end_value'])
+            if (
+                start_value is utils.DYNAMIC_BOUNDARY_NOT_READY
+                or end_value is utils.DYNAMIC_BOUNDARY_NOT_READY
+            ):
+                LOGGER.info('Dynamic boundary returned no value for %s; skipping PartialSync', table_name)
+                return True
 
-        # Get bookmark - Binlog position or Incremental Key value
-        bookmark = common_utils.get_bookmark_for_table(table_name, args.properties, postgres, dbname=dbname)
+            bookmark = common_utils.get_bookmark_for_table(
+                table_name, args.properties, postgres, dbname=dbname
+            )
+            snowflake_types = postgres.map_column_types_to_target(table_name)
 
-        # Get column differences
+            start_value_for_query = start_value if start_value == 'NULL' else f'\'{start_value}\''
+            where_clause_sql = f' WHERE {column_name} >= {start_value_for_query}'
+            if end_value is not None:
+                where_clause_sql += f' AND {column_name} <= \'{end_value}\''
+
+            file_parts = postgres.export_source_table_data(args, tap_id, where_clause_sql)
+        finally:
+            postgres.close_connection()
+
         target_schema = common_utils.get_target_schema(args.target, table_name)
         table_dict = common_utils.tablename_to_dict(table_name)
         target_table = table_dict.get('table_name')
-
         target_sf = {
             'sf_object': snowflake,
             'schema': target_schema,
             'table': target_table,
-            'temp': table_dict.get('temp_table_name')
+            'temp': table_dict.get('temp_table_name'),
+            'publication_status': publication_status,
         }
-
-        snowflake_types = postgres.map_column_types_to_target(table_name)
-
-        # making target table if not exists
-        snowflake.create_schema(target_schema)
-        snowflake.create_table(
-            target_schema=target_schema,
-            table_name=target_table,
-            columns=snowflake_types['columns'],
-            primary_key=snowflake_types.get('primary_key'),
-            is_temporary=False,
-            sort_columns=False,
-            allow_replace_table=False
-        )
-
         source_columns = snowflake_types.get('columns', [])
-        columns_diff = utils.diff_source_target_columns(target_sf, source_columns=source_columns)
 
-        start_value_for_query = start_value if start_value == 'NULL' else f'\'{start_value}\''
-        where_clause_sql = f' WHERE {column_name} >= {start_value_for_query}'
-        if args.end_value:
-            where_clause_sql += f' AND {column_name} <= \'{end_value}\''
-
-        file_parts = postgres.export_source_table_data(args, tap_id, where_clause_sql)
-
-        # mark partial data as deleted in the target
-        snowflake.query(
-            f'UPDATE {target_schema}."{target_table.upper()}"'
-            f' SET _SDC_DELETEd_AT = CURRENT_TIMESTAMP(){where_clause_sql} AND _SDC_DELETED_AT IS NULL')
-
-        # Creating temp table in Snowflake
         primary_keys = snowflake_types.get('primary_key')
         snowflake.create_schema(target_schema)
+        temp_created = True
         snowflake.create_table(
             target_schema, target_table, source_columns, primary_keys, is_temporary=True
         )
 
-        postgres.close_connection()
-
         size_bytes = sum([os.path.getsize(file_part) for file_part in file_parts])
-        _, s3_key_pattern = utils.upload_to_s3(snowflake, file_parts, args.temp_dir)
+        s3_keys, s3_key_pattern = utils.upload_to_s3(snowflake, file_parts, args.temp_dir)
 
         utils.load_into_snowflake(
-            target_sf, args, columns_diff, primary_keys, s3_key_pattern, size_bytes, where_clause_sql)
+            target_sf, args, source_columns, primary_keys, s3_key_pattern,
+            size_bytes, where_clause_sql,
+        )
+        publication_status['attempted'] = True
+        temp_created = False
 
-        if file_parts:
-            utils.update_state_file(args, bookmark)
+        grants_attempted = True
+        common_utils.retry_snowflake_table_grants(
+            snowflake, args.target, target_schema, table_name
+        )
+        utils.delete_s3_objects(snowflake, s3_keys, args.target.get('s3_bucket'))
+        s3_keys = []
+        utils.update_state_file(args, bookmark)
 
         return True
     except Exception as exc:
         LOGGER.exception(exc)
-        return f'{table_name}: {exc}'
+        return common_utils.partial_sync_failure_result(
+            snowflake,
+            args.target,
+            table_name,
+            target_schema,
+            target_table,
+            {
+                's3_keys': getattr(exc, 's3_keys', s3_keys),
+                'temp_created': temp_created,
+                'publication_attempted': publication_status['attempted'],
+                'grants_attempted': grants_attempted,
+            },
+            exc,
+        )
 
 
 def main_impl():
@@ -134,18 +148,14 @@ def main_impl():
     )
 
     sync_tables = utils.get_sync_tables(args)
-
     pool_size = len(sync_tables) if len(sync_tables) < pool_size else pool_size
     with multiprocessing.Pool(pool_size) as proc:
-        sync_excs = list(
-            filter(
-                lambda x: not isinstance(x, bool),
-                proc.map(partial(partial_sync_table, args=args), sync_tables.items())
-            )
+        sync_results = proc.map(
+            partial(partial_sync_table, args=args),
+            sync_tables.items(),
         )
 
-    if isinstance(sync_excs, bool):
-        sync_excs = None
+    sync_excs = [result for result in sync_results if result is not True]
 
     # Log summary
     end_time = datetime.now()

--- a/pipelinewise/fastsync/partialsync/utils.py
+++ b/pipelinewise/fastsync/partialsync/utils.py
@@ -16,21 +16,33 @@ from pipelinewise.fastsync.commons import utils as common_utils
 from pipelinewise.fastsync.commons.target_snowflake import FastSyncTargetSnowflake
 
 
+# A dynamic boundary query with no usable scalar is a successful no-op.
+DYNAMIC_BOUNDARY_NOT_READY = object()
+
+
 def upload_to_s3(snowflake: FastSyncTargetSnowflake, file_parts: List, temp_dir: str) -> Tuple[List, str]:
-    """Upload exported data into S3"""
-
-    s3_keys = []
-    for file_part in file_parts:
-        s3_keys.append(snowflake.upload_to_s3(file_part, tmp_dir=temp_dir))
-        os.remove(file_part)
-
-    # Create a pattern that match all file parts by removing multipart suffix
-    s3_key_pattern = (
-        re.sub(r'\.part\d*$', '', s3_keys[0])
-        if len(s3_keys) > 0
-        else 'NO_FILES_TO_LOAD'
+    """Upload PartialSync staging through the shared FastSync implementation."""
+    return common_utils.upload_files_to_s3(
+        snowflake,
+        file_parts,
+        temp_dir,
+        snowflake.connection_config.get('s3_bucket'),
     )
-    return s3_keys, s3_key_pattern
+
+
+def delete_s3_objects(
+    snowflake: FastSyncTargetSnowflake,
+    s3_keys: List,
+    bucket: str,
+    cleanup_context='PartialSync staging cleanup after successful publication',
+) -> None:
+    """Delete every staged object before state can advance."""
+    common_utils.delete_s3_objects(
+        snowflake,
+        s3_keys,
+        bucket,
+        cleanup_context=cleanup_context,
+    )
 
 
 def diff_source_target_columns(target_sf: dict, source_columns: list) -> dict:
@@ -52,34 +64,71 @@ def diff_source_target_columns(target_sf: dict, source_columns: list) -> dict:
     }
 
 
-def load_into_snowflake(target, args, columns_diff, primary_keys, s3_key_pattern, size_bytes,
+def load_into_snowflake(target, args, source_columns, primary_keys, s3_key_pattern, size_bytes,
                         where_clause_sql):
-    """Loading data from S3 to the temp table in snowflake and then merge it with the target table"""
+    """Load staging data before creating or modifying the live target table."""
 
     snowflake = target['sf_object']
-    # Load into Snowflake temp table
     snowflake.copy_to_table(
         s3_key_pattern, target['schema'], args.table, size_bytes, is_temporary=True
     )
-    # Obfuscate columns
     snowflake.obfuscate_columns(target['schema'], args.table)
 
-    snowflake.add_columns(target['schema'], target['table'], columns_diff['added_columns'])
-    added_metadata_columns = ['_SDC_EXTRACTED_AT', '_SDC_BATCHED_AT', '_SDC_DELETED_AT']
+    if args.drop_target_table:
+        common_utils.apply_snowflake_table_grants(
+            snowflake,
+            args.target,
+            target['schema'],
+            args.table,
+            is_temporary=True,
+        )
+
+    publication_status = target.get('publication_status')
+    if publication_status is not None:
+        publication_status['attempted'] = True
+    snowflake.create_table(
+        target_schema=target['schema'],
+        table_name=target['table'],
+        columns=source_columns,
+        primary_key=primary_keys,
+        is_temporary=False,
+        sort_columns=False,
+        allow_replace_table=False,
+        normalize_primary_keys=(
+            False if args.drop_target_table else 'if_created'
+        ),
+    )
     if args.drop_target_table:
         snowflake.swap_tables(target['schema'], target['table'])
     else:
-        snowflake.merge_tables(
-            target['schema'], target['temp'], target['table'],
-            list(columns_diff['source_columns'].keys()) + added_metadata_columns, primary_keys)
+        columns_diff = diff_source_target_columns(target, source_columns=source_columns)
+        # Snowflake DDL implicitly commits, so schema evolution must finish before atomic DML publication.
+        snowflake.add_columns(target['schema'], target['table'], columns_diff['added_columns'])
+        added_metadata_columns = ['_SDC_EXTRACTED_AT', '_SDC_BATCHED_AT', '_SDC_DELETED_AT']
+        snowflake.publish_partial_sync(
+            target['schema'],
+            target['temp'],
+            target['table'],
+            list(columns_diff['source_columns'].keys()) + added_metadata_columns,
+            primary_keys,
+            where_clause_sql,
+            hard_delete=args.target['hard_delete'] is True,
+        )
+        snowflake.drop_table(
+            target['schema'],
+            target['table'],
+            is_temporary=True,
+            max_attempts=3,
+        )
 
-        if args.target['hard_delete'] is True:
-            snowflake.partial_hard_delete(target['schema'], target['table'], where_clause_sql)
-        snowflake.drop_table(target['schema'], target['temp'])
 
-
-def update_state_file(args: argparse.Namespace, bookmark: Dict) -> None:
-    """Update state file"""
+def update_state_file(
+    args: argparse.Namespace,
+    bookmark: Dict,
+    state_lock=None,
+) -> None:
+    """Update state after an unbounded sync; the legacy lock argument is ignored."""
+    del state_lock
     # Save bookmark to singer state file
     if not args.end_value:
         common_utils.save_state_file(args.state, args.table, bookmark)
@@ -141,15 +190,13 @@ def _validate_static_boundary_value(string_to_check: str) -> str:
     return string_to_check
 
 
-def _validate_dynamic_boundary_value(query_object, string_to_check: str) -> str:
+def _validate_dynamic_boundary_value(query_object, string_to_check: str) -> object:
     """Validating if the dynamic boundary values are valid and there is no injection"""
     try:
         _check_for_allowed_query(string_to_check)
         return_value = query_object(string_to_check)
         if return_value == []:
-            # in this case it returns NULL and this NULL will be used in generating where clause later and
-            # partial sync can be selected again next time until this dynamic value returns something from the source!
-            return 'NULL'
+            return DYNAMIC_BOUNDARY_NOT_READY
         if len(return_value) > 1 or len(return_value[0]) != 1:
             raise Exception
 
@@ -157,12 +204,14 @@ def _validate_dynamic_boundary_value(query_object, string_to_check: str) -> str:
             boundary_value = list(return_value[0].values())[0]
         else:
             boundary_value = return_value[0][0]
+        if boundary_value is None:
+            return DYNAMIC_BOUNDARY_NOT_READY
     except Exception:
         raise (InvalidConfigException(f'Invalid query for boundary value: {string_to_check}')) from Exception
     return boundary_value
 
 
-def validate_boundary_value(query_object: object, string_to_check: Union[str, None]) -> Union[str, None]:
+def validate_boundary_value(query_object: object, string_to_check: Union[str, None]) -> object:
     """Validate and finding the boundary value"""
     if string_to_check:
         if string_to_check.startswith('<S>'):

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -2,7 +2,6 @@
 import os
 import sys
 import glob
-import re
 import multiprocessing
 
 from argparse import Namespace
@@ -41,8 +40,6 @@ REQUIRED_CONFIG_KEYS = {
         'file_format',
     ],
 }
-
-LOCK = multiprocessing.Lock()
 
 
 def tap_type_to_target_type(pg_type, *_):
@@ -89,6 +86,9 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     snowflake = FastSyncTargetSnowflake(args.target, args.transform)
     tap_id = args.target.get('tap_id')
     archive_load_files = args.target.get('archive_load_files', False)
+    s3_keys = []
+    target_schema = None
+    temp_created = False
 
     try:
         dbname = args.tap.get('dbname')
@@ -123,21 +123,16 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
         primary_key = snowflake_types.get('primary_key')
         postgres.close_connection()
 
-        # Uploading to S3
-        s3_keys = []
-        for file_part in file_parts:
-            s3_keys.append(snowflake.upload_to_s3(file_part, tmp_dir=args.temp_dir))
-            os.remove(file_part)
-
-        # Create a pattern that match all file parts by removing multipart suffix
-        s3_key_pattern = (
-            re.sub(r'\.part\d*$', '', s3_keys[0])
-            if len(s3_keys) > 0
-            else 'NO_FILES_TO_LOAD'
+        s3_keys, s3_key_pattern = utils.upload_files_to_s3(
+            snowflake,
+            file_parts,
+            args.temp_dir,
+            args.target.get('s3_bucket'),
         )
 
         # Creating temp table in Snowflake
         snowflake.create_schema(target_schema)
+        temp_created = True
         snowflake.create_table(
             target_schema, table, snowflake_columns, primary_key, is_temporary=True
         )
@@ -152,34 +147,66 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
                 # Copy load file to archive
                 snowflake.copy_to_archive(s3_key, tap_id, table)
 
-            # Delete all file parts from s3
-            snowflake.s3.delete_object(Bucket=args.target.get('s3_bucket'), Key=s3_key)
-
         # Obfuscate columns
         snowflake.obfuscate_columns(target_schema, table)
 
         # Create target table and swap with the temp table in Snowflake
-        snowflake.create_table(target_schema, table, snowflake_columns, primary_key)
-        snowflake.swap_tables(target_schema, table)
-
-        # Save bookmark to singer state file
-        # Lock to ensure that only one process writes the same state file at a time
-        LOCK.acquire()
+        snowflake.create_table(
+            target_schema,
+            table,
+            snowflake_columns,
+            primary_key,
+            allow_replace_table=False,
+            normalize_primary_keys=False,
+        )
+        utils.apply_snowflake_table_grants(
+            snowflake,
+            args.target,
+            target_schema,
+            table,
+            is_temporary=True,
+        )
+        publication_error = None
         try:
-            utils.save_state_file(args.state, table, bookmark)
-        finally:
-            LOCK.release()
+            snowflake.swap_tables(
+                target_schema, table, cleanup_old_table=False
+            )
+        except Exception as exc:
+            publication_error = exc
 
-        # Table loaded, grant select on all tables in target schema
-        grantees = utils.get_grantees(args.target, table)
-        utils.grant_privilege(target_schema, grantees, snowflake.grant_usage_on_schema)
-        utils.grant_privilege(target_schema, grantees, snowflake.grant_select_on_schema)
+        utils.finalize_snowflake_fullsync(
+            snowflake,
+            s3_keys,
+            args.target.get('s3_bucket'),
+            args.target,
+            target_schema,
+            table,
+            publication_error=publication_error,
+        )
+        s3_keys = []
+        temp_created = False
+
+        if publication_error:
+            raise publication_error
+
+        utils.save_state_file(args.state, table, bookmark)
 
         return True
 
     except Exception as exc:
         LOGGER.exception(exc)
-        return '{}: {}'.format(table, exc)
+        return utils.staging_failure_result(
+            snowflake,
+            getattr(exc, 's3_keys', s3_keys),
+            args.target.get('s3_bucket'),
+            target_schema,
+            table,
+            temp_created,
+            exc,
+        )
+
+    finally:
+        postgres.close_connection(silent=True)
 
 
 def main_impl():

--- a/scripts/ci_check_no_file_changes.sh
+++ b/scripts/ci_check_no_file_changes.sh
@@ -37,13 +37,64 @@ URL="https://api.github.com/repos/${GITHUB_REPO}/pulls/${PR_NUMBER}/files"
 
 echo "PR URL:${URL}"
 
-FILES=$(curl -s -X GET -G "${URL}" | jq -r '.[] | .filename')
+fetch_changed_files() {
+  local page=1
+  local page_size
+  local response
+  local -a curl_args=(
+    --fail
+    --silent
+    --show-error
+    --get
+    --header "Accept: application/vnd.github+json"
+    --header "X-GitHub-Api-Version: 2022-11-28"
+  )
+
+  if [[ -n ${GITHUB_TOKEN:-} ]]; then
+    curl_args+=(--header "Authorization: Bearer ${GITHUB_TOKEN}")
+  fi
+
+  while true; do
+    if ! response=$(curl "${curl_args[@]}" \
+      --data-urlencode "per_page=100" \
+      --data-urlencode "page=${page}" \
+      "${URL}"); then
+      echo "Failed to fetch changed files from GitHub" >&2
+      return 1
+    fi
+
+    if ! jq -e 'type == "array" and all(.[]; (.filename | type) == "string")' \
+      >/dev/null <<< "${response}"; then
+      echo "GitHub changed-files response is invalid" >&2
+      return 1
+    fi
+
+    if ! page_size=$(jq -r 'length' <<< "${response}"); then
+      echo "Failed to read GitHub changed-files page size" >&2
+      return 1
+    fi
+    if ! jq -r '.[].filename' <<< "${response}"; then
+      echo "Failed to read filenames from GitHub response" >&2
+      return 1
+    fi
+
+    if (( page_size < 100 )); then
+      break
+    fi
+    ((page += 1))
+  done
+}
+
+if ! FILES=$(fetch_changed_files); then
+  echo "Unable to determine changed files; Exiting with FAILURE code"
+  exit 1
+fi
 
 REGEXES=()
 for CHECK in "$@"
 do
   if [[ ${CHECK} == "python" ]]; then
-    REGEX="(^tests\/|^pipelinewise\/|^singer-connectors\/|^setup\.py|^Makefile)"
+    REGEX="(^tests\/|^pipelinewise\/|^singer-connectors\/|^scripts\/ci_check_no_file_changes\.sh$|^setup\.py|^Makefile)"
     echo "Searching for changes in python files"
 
   elif [[ ${CHECK} == "doc" ]]; then
@@ -70,8 +121,11 @@ $FILES
 
 EOF
 
-for FILE in ${FILES}
+while IFS= read -r FILE
 do
+  if [[ -z ${FILE} ]]; then
+    continue
+  fi
   for REGEX in "${REGEXES[@]}"
   do
     if [[ "${FILE}" =~ ${REGEX} ]]; then
@@ -80,6 +134,6 @@ do
       exit 1
     fi
   done
-done
+done <<< "${FILES}"
 echo "No changes detected... Exiting with SUCCESS code"
 exit 0

--- a/singer-connectors/target-snowflake/tests/integration/test_target_snowflake.py
+++ b/singer-connectors/target-snowflake/tests/integration/test_target_snowflake.py
@@ -347,6 +347,10 @@ class TestIntegration(unittest.TestCase):
 
         self.assert_three_streams_are_into_snowflake()
 
+    @unittest.skipUnless(
+        os.environ.get('CLIENT_SIDE_ENCRYPTION_MASTER_KEY'),
+        'CLIENT_SIDE_ENCRYPTION_MASTER_KEY is required to test encrypted loading',
+    )
     def test_loading_tables_with_client_side_encryption(self):
         """Loading multiple tables from the same input tap with various columns types"""
         tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
@@ -1164,23 +1168,15 @@ class TestIntegration(unittest.TestCase):
 
         target_db = self.config['dbname']
         target_schema = self.config['default_target_schema']
-        self.assertEqual(result, [{
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}..',
-            'QUERIES': 4
-        },
-            {
-                'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_ONE',
-                'QUERIES': 10
-            },
-            {
-                'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_THREE',
-                'QUERIES': 9
-            },
-            {
-                'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_TWO',
-                'QUERIES': 9
-            }
-        ])
+        expected_minimum_queries = {
+            f'PPW test tap run at {current_time}. Loading into {target_db}..': 4,
+            f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_ONE': 10,
+            f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_THREE': 9,
+            f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_TWO': 9,
+        }
+        self.assertEqual({row['QUERY_TAG'] for row in result}, set(expected_minimum_queries))
+        for row in result:
+            self.assertGreaterEqual(row['QUERIES'], expected_minimum_queries[row['QUERY_TAG']])
 
         # Detecting file format type should run only once
         result = snowflake.query(f"""SELECT count(*) show_file_format_queries

--- a/tests/end_to_end/helpers/assertions.py
+++ b/tests/end_to_end/helpers/assertions.py
@@ -1,7 +1,11 @@
 import glob
+import hashlib
+import json
 import os
 import re
 
+from collections import Counter
+from datetime import datetime
 from typing import List, Set, Union
 from pathlib import Path
 from unittest import TestCase
@@ -11,7 +15,9 @@ from . import tasks
 from . import db
 
 
-def assert_run_tap_success(tap, target, sync_engines, profiling=False):
+def assert_run_tap_success(
+        tap, target, sync_engines, profiling=False,
+        expected_state_streams=None):
     """Run a specific tap and make sure that it's using the correct sync engine,
     finished successfully and state file created with the right content"""
 
@@ -21,11 +27,29 @@ def assert_run_tap_success(tap, target, sync_engines, profiling=False):
         command = f'{command} --profiler'
 
     [return_code, stdout, stderr] = tasks.run_command(command)
+    tasks.assert_run_tap_log_engines(stdout, sync_engines)
 
     for sync_engine in sync_engines:
         log_file = tasks.find_run_tap_log_file(stdout, sync_engine)
         assert_command_success(return_code, stdout, stderr, log_file)
-        assert_state_file_valid(target, tap, log_file)
+        if sync_engine == 'singer':
+            assert_state_file_valid(
+                target, tap, log_file, require_emitted_state=True
+            )
+            continue
+
+        expected_streams, progress_streams = _state_expectations_for_engine(
+            expected_state_streams, sync_engine
+        )
+        if sync_engine in ('fastsync', 'partialsync'):
+            assert_fastsync_state_persisted(log_file, expected_streams)
+        assert_state_file_valid(
+            target,
+            tap,
+            log_file,
+            expected_streams=expected_streams,
+            expected_progress_streams=progress_streams,
+        )
 
     if profiling:
         assert_profiling_stats_files_created(
@@ -33,37 +57,255 @@ def assert_run_tap_success(tap, target, sync_engines, profiling=False):
         )
 
 
-def assert_resync_tables_success(tap, target, profiling=False):
+def assert_resync_tables_success(
+        tap, target, profiling=False, expected_streams=None, tables=None,
+        sync_engines=('fastsync',), expected_state_streams=None):
     """Resync a specific tap and make sure that it's using the correct sync engine,
     finished successfully and state file created with the right content"""
 
     command = f'pipelinewise fast_sync --tap {tap} --target {target}'
 
+    if tables:
+        command += ' --tables ' + (
+            tables if isinstance(tables, str) else ','.join(tables)
+        )
+
     if profiling:
         command = f'{command} --profiler'
 
     [return_code, stdout, stderr] = tasks.run_command(command)
+    tasks.assert_run_tap_log_engines(stdout, sync_engines)
 
-    log_file = tasks.find_run_tap_log_file(stdout, 'fastsync')
-    assert_command_success(return_code, stdout, stderr, log_file)
-    assert_state_file_valid(target, tap, log_file)
+    if expected_state_streams is None and expected_streams is not None:
+        expected_state_streams = {'fastsync': set(expected_streams)}
+
+    for sync_engine in sync_engines:
+        log_file = tasks.find_run_tap_log_file(stdout, sync_engine)
+        assert_command_success(return_code, stdout, stderr, log_file)
+        engine_streams, progress_streams = _state_expectations_for_engine(
+            expected_state_streams, sync_engine
+        )
+        assert_fastsync_state_persisted(log_file, engine_streams)
+        assert_state_file_valid(
+            target,
+            tap,
+            log_file,
+            expected_streams=engine_streams,
+            expected_progress_streams=progress_streams,
+        )
 
     if profiling:
         assert_profiling_stats_files_created(
-            stdout, 'fast_sync', ['fastsync'], tap, target
+            stdout, 'fast_sync', sync_engines, tap, target
         )
 
 
+def assert_resync_populates_target(tap_parameters, primary_key):
+    """Run FastSync once and prove the target contains the complete fixture."""
+    source_table = tap_parameters.get('source_table', tap_parameters['table'])
+    qualified_table = f'{tap_parameters["source_db"]}.{source_table}'
+    assert_resync_tables_success(
+        tap_parameters['tap'],
+        tap_parameters['target'],
+        expected_streams={_expected_fastsync_state_stream(tap_parameters)},
+        tables=qualified_table,
+    )
+
+    return assert_source_target_rows_equal(
+        tap_parameters,
+        primary_key,
+        operation='FastSync',
+    )
+
+
+def assert_source_target_rows_equal(
+        tap_parameters, primary_key, where_clause=None, operation='sync'):
+    """Prove selected deterministic source and Snowflake rows are identical."""
+
+    comparison_columns = tap_parameters['comparison_columns']
+    source_expressions = [
+        column['source_expression'] for column in comparison_columns
+    ]
+    target_expressions = [
+        column['target_expression'] for column in comparison_columns
+    ]
+    source_query = {
+        'tap_type': tap_parameters['tap_type'],
+        'source_db': tap_parameters['source_db'],
+        'table': tap_parameters.get('source_table', tap_parameters['table']),
+        'columns': source_expressions,
+        'primary_key': primary_key,
+    }
+    target_query = {
+        'tap_type': tap_parameters['tap_type'],
+        'table': tap_parameters.get('target_table', tap_parameters['table']),
+        'columns': target_expressions,
+        'primary_key': primary_key,
+    }
+    if where_clause:
+        source_query['where_clause'] = where_clause
+        target_query['where_clause'] = where_clause
+
+    expected_records = tap_parameters['env'].get_rows_from_source(
+        **source_query
+    )
+    actual_records = tap_parameters['env'].get_rows_from_target_snowflake(
+        **target_query
+    )
+
+    assert expected_records, (
+        f'Source fixture {tap_parameters["source_db"]}.'
+        f'{tap_parameters["table"]} is empty'
+    )
+    normalized_expected = _normalize_fixture_rows(
+        expected_records, comparison_columns, 'source'
+    )
+    normalized_actual = _normalize_fixture_rows(
+        actual_records, comparison_columns, 'target'
+    )
+    _assert_fixture_rows_equal(
+        normalized_actual,
+        normalized_expected,
+        operation,
+        tap_parameters['source_db'],
+        tap_parameters['table'],
+    )
+    return normalized_actual
+
+
+def _assert_fixture_rows_equal(actual_rows, expected_rows, operation, source_db, table):
+    """Report one actionable mismatch without dumping an entire fixture."""
+    if actual_rows == expected_rows:
+        return
+
+    mismatch_index = next(
+        (
+            index
+            for index, (expected, actual) in enumerate(
+                zip(expected_rows, actual_rows)
+            )
+            if expected != actual
+        ),
+        min(len(expected_rows), len(actual_rows)),
+    )
+    expected_row = (
+        expected_rows[mismatch_index]
+        if mismatch_index < len(expected_rows)
+        else '<missing>'
+    )
+    actual_row = (
+        actual_rows[mismatch_index]
+        if mismatch_index < len(actual_rows)
+        else '<missing>'
+    )
+    raise AssertionError(
+        f'{operation} did not reproduce {source_db}.{table} in the Snowflake '
+        f'target: first mismatch at ordered row {mismatch_index + 1}; '
+        f'expected {expected_row!r}, got {actual_row!r}; '
+        f'expected {len(expected_rows)} rows, got {len(actual_rows)}'
+    )
+
+
+def _normalize_fixture_rows(records, comparison_columns, side):
+    """Normalize source/target driver values without weakening comparisons."""
+    normalized_records = []
+    for row_number, record in enumerate(records, start=1):
+        if len(record) != len(comparison_columns):
+            raise AssertionError(
+                f'{side} fixture row {row_number} has {len(record)} values; '
+                f'expected {len(comparison_columns)}'
+            )
+
+        normalized_records.append(tuple(
+            _normalize_fixture_value(
+                value,
+                column.get(f'{side}_normalizer', column['normalizer']),
+            )
+            for value, column in zip(record, comparison_columns)
+        ))
+
+    return normalized_records
+
+
+def _normalize_fixture_value(value, normalizer):
+    """Apply one explicit normalization used by a FastSync fixture column."""
+    if value is None:
+        return None
+
+    if normalizer.startswith('hash_skip_first_'):
+        return _normalize_hashed_fixture_value(value, normalizer)
+
+    normalizers = {
+        'integer': int,
+        'boolean': _normalize_boolean_fixture_value,
+        'datetime': _normalize_datetime_fixture_value,
+        'json': _normalize_json_fixture_value,
+        'text': str,
+    }
+    try:
+        normalize = normalizers[normalizer]
+    except KeyError as exc:
+        raise ValueError(f'Unsupported fixture normalizer: {normalizer}') from exc
+    return normalize(value)
+
+
+def _normalize_boolean_fixture_value(value):
+    """Normalize boolean values returned differently by database drivers."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    normalized = str(value).strip().lower()
+    if normalized in ('true', '1'):
+        return True
+    if normalized in ('false', '0'):
+        return False
+    raise ValueError(f'Cannot normalize {value!r} as boolean')
+
+
+def _normalize_datetime_fixture_value(value):
+    """Normalize datetime objects and ISO text to the same representation."""
+    if isinstance(value, datetime):
+        return value.isoformat(sep=' ')
+    return str(value).replace('T', ' ')
+
+
+def _normalize_json_fixture_value(value):
+    """Normalize JSON objects and serialized Snowflake VARIANT values."""
+    parsed_value = json.loads(value) if isinstance(value, str) else value
+    return json.dumps(parsed_value, sort_keys=True, separators=(',', ':'))
+
+
+def _normalize_hashed_fixture_value(value, normalizer):
+    """Apply the configured HASH-SKIP-FIRST transform to source text."""
+    if not isinstance(value, str):
+        raise TypeError(f'Cannot hash non-string fixture value {value!r}')
+    skip_first = int(normalizer.rsplit('_', 1)[-1])
+    digest = hashlib.sha256(value[skip_first:].encode('utf-8')).hexdigest()
+    return f'{value[:skip_first]}{digest}'
+
+
 # pylint: disable=invalid-name
-def assert_partial_sync_table_success(tap_parameters, start_value, end_value):
+def assert_partial_sync_table_success(
+        tap_parameters, start_value, end_value=None):
     """Partial sync a specific tap and make sure that it finished successfully and state file is created
     with the right content"""
 
+    state_before = _load_persisted_state(
+        tap_parameters['target'], tap_parameters['tap']
+    )
     command = _get_command_for_partial_sync(tap_parameters, start_value, end_value)
 
     [return_code, stdout, stderr] = tasks.run_command(command)
+    tasks.assert_run_tap_log_engines(stdout, ('partialsync',))
     log_file = tasks.find_run_tap_log_file(stdout, 'partialsync')
     assert_command_success(return_code, stdout, stderr, log_file)
+    _assert_partial_sync_state(
+        tap_parameters,
+        end_value,
+        state_before,
+        log_file,
+    )
 
 
 def assert_partial_sync_table_with_target_additional_columns(
@@ -78,11 +320,21 @@ def assert_partial_sync_table_with_target_additional_columns(
         new_column=additional_column
     )
 
+    state_before = _load_persisted_state(
+        tap_parameters['target'], tap_parameters['tap']
+    )
     command = _get_command_for_partial_sync(tap_parameters, start_value, end_value)
 
     [return_code, stdout, stderr] = tasks.run_command(command)
+    tasks.assert_run_tap_log_engines(stdout, ('partialsync',))
     log_file = tasks.find_run_tap_log_file(stdout, 'partialsync')
     assert_command_success(return_code, stdout, stderr, log_file)
+    _assert_partial_sync_state(
+        tap_parameters,
+        end_value,
+        state_before,
+        log_file,
+    )
 
 
 def assert_partial_sync_table_with_source_additional_columns(
@@ -97,11 +349,21 @@ def assert_partial_sync_table_with_source_additional_columns(
         new_column=additional_column
     )
 
+    state_before = _load_persisted_state(
+        tap_parameters['target'], tap_parameters['tap']
+    )
     command = _get_command_for_partial_sync(tap_parameters, start_value, end_value)
 
     [return_code, stdout, stderr] = tasks.run_command(command)
+    tasks.assert_run_tap_log_engines(stdout, ('partialsync',))
     log_file = tasks.find_run_tap_log_file(stdout, 'partialsync')
     assert_command_success(return_code, stdout, stderr, log_file)
+    _assert_partial_sync_state(
+        tap_parameters,
+        end_value,
+        state_before,
+        log_file,
+    )
 
 
 def assert_partial_sync_rows_in_target(env, tap_type, table, column, primary_key, expected_column_values):
@@ -136,30 +398,165 @@ def assert_command_success(return_code, stdout, stderr, log_path=None):
         assert True
 
 
-def assert_state_file_valid(target_name, tap_name, log_path=None):
-    """Assert helper function to check if state file exists for
-    a certain tap for a certain target"""
-    state_file = Path(
+def _expected_fastsync_state_stream(tap_parameters):
+    """Return the state stream id written by FastSync for one source table."""
+    table = tap_parameters.get('source_table', tap_parameters['table'])
+    return f'{tap_parameters["source_db"]}-{table.strip(chr(34))}'
+
+
+def _state_expectations_for_engine(expected_state_streams, sync_engine):
+    """Return exact stream markers and the subset that require progress."""
+    if expected_state_streams is None or sync_engine not in expected_state_streams:
+        return None, None
+
+    expectations = expected_state_streams[sync_engine]
+    if isinstance(expectations, dict):
+        return (
+            set(expectations),
+            {
+                stream_id
+                for stream_id, requires_progress in expectations.items()
+                if requires_progress
+            },
+        )
+    streams = set(expectations)
+    return streams, streams
+
+
+def _has_fastsync_progress(bookmark):
+    """Recognize a usable log-based or incremental FastSync bookmark."""
+    if not isinstance(bookmark, dict):
+        return False
+    if bookmark.get('gtid') or bookmark.get('lsn') or bookmark.get('modified_since'):
+        return True
+    if bookmark.get('log_file') and bookmark.get('log_pos') is not None:
+        return True
+    if bookmark.get('replication_key') and 'replication_key_value' in bookmark:
+        return True
+    token = bookmark.get('token')
+    return isinstance(token, dict) and bool(token.get('_data'))
+
+
+def assert_fastsync_state_persisted(log_path, expected_streams=None):
+    """Prove this FastSync process completed its own atomic state write."""
+    with open(f'{log_path}.success', encoding='utf-8') as log_file:
+        persisted_streams = re.findall(
+            r'^(?:INFO |.* log_level=INFO message=)'
+            r'FastSync state updated for stream: (.+)$',
+            log_file.read(),
+            flags=re.MULTILINE,
+        )
+
+    assert persisted_streams
+    persisted_counts = Counter(persisted_streams)
+    if expected_streams is not None:
+        assert persisted_counts == Counter({stream: 1 for stream in expected_streams})
+    else:
+        assert all(count == 1 for count in persisted_counts.values())
+
+
+def _state_file_path(target_name, tap_name):
+    return Path(
         f'{Path.home()}/.pipelinewise/{target_name}/{tap_name}/state.json'
     ).resolve()
+
+
+def _load_persisted_state(target_name, tap_name):
+    state_file = _state_file_path(target_name, tap_name)
+    if not state_file.is_file():
+        return None
+    with state_file.open(encoding='utf-8') as state_handle:
+        return json.load(state_handle)
+
+
+def _last_emitted_state(log_path):
+    """Parse the last real target state from bare JSON or legacy log text."""
+    with open(f'{log_path}.success', 'r', encoding='utf-8') as log_file:
+        log_content = log_file.read()
+
+    parsed_states = []
+    for line in log_content.splitlines():
+        try:
+            candidate = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(candidate, dict) and (
+            'bookmarks' in candidate or 'currently_syncing' in candidate
+        ):
+            parsed_states.append(candidate)
+    if parsed_states:
+        return parsed_states[-1]
+
+    emitted_states = re.findall(
+        r'^(?:INFO |.* log_level=INFO message=)'
+        r'STATE emitted from target: (.+)$',
+        log_content,
+        flags=re.MULTILINE,
+    )
+    return json.loads(emitted_states[-1]) if emitted_states else None
+
+
+def _assert_partial_sync_state(
+    tap_parameters,
+    end_value,
+    state_before,
+    log_path,
+):
+    """Require an unbounded bookmark write or an unchanged bounded state."""
+    target = tap_parameters['target']
+    tap = tap_parameters['tap']
+    if end_value is not None:
+        assert _load_persisted_state(target, tap) == state_before
+        return
+
+    expected_streams = {_expected_fastsync_state_stream(tap_parameters)}
+    assert_fastsync_state_persisted(log_path, expected_streams)
+    assert_state_file_valid(
+        target,
+        tap,
+        expected_streams=expected_streams,
+        expected_progress_streams=expected_streams,
+    )
+
+
+def assert_state_file_valid(
+        target_name, tap_name, log_path=None, expected_streams=None,
+        expected_progress_streams=None, require_emitted_state=False):
+    """Assert the persisted state is valid and matches emitted Singer state."""
+    state_file = _state_file_path(target_name, tap_name)
     assert os.path.isfile(state_file)
 
-    # Check if state file content equals to last emitted state in log
-    if log_path:
-        success_log_path = f'{log_path}.success'
-        state_in_log = None
-        with open(success_log_path, 'r', encoding='utf-8') as log_f:
-            state_log_pattern = re.search(
-                r'\nINFO STATE emitted from target: (.+\n)',
-                '\n'.join(log_f.readlines()),
-            )
-            if state_log_pattern:
-                state_in_log = state_log_pattern.groups()[-1]
+    with open(state_file, encoding='utf-8') as state_f:
+        persisted_state = json.load(state_f)
 
-        # If the emitted state message exists in the log then compare it to the actual state file
-        if state_in_log:
-            with open(state_file, 'r', encoding='utf-8') as state_f:
-                assert state_in_log == ''.join(state_f.readlines())
+    assert isinstance(persisted_state, dict)
+
+    # Check if state file content equals to last emitted state in log.
+    # Targets emit state as a bare JSON line; retain the prefixed parser for
+    # compatibility with older/custom targets.
+    state_in_log = _last_emitted_state(log_path) if log_path else None
+
+    if require_emitted_state:
+        assert state_in_log is not None
+
+    if state_in_log is not None:
+        assert persisted_state == state_in_log
+
+    bookmarks = persisted_state.get('bookmarks')
+    assert isinstance(bookmarks, dict) and bookmarks
+    assert all(
+        isinstance(stream_id, str)
+        and stream_id
+        and isinstance(bookmark, dict)
+        for stream_id, bookmark in bookmarks.items()
+    )
+    if expected_streams is not None:
+        assert set(expected_streams).issubset(bookmarks)
+    if expected_progress_streams:
+        assert all(
+            _has_fastsync_progress(bookmarks[stream_id])
+            for stream_id in expected_progress_streams
+        )
 
 
 def assert_cols_in_table(
@@ -488,9 +885,11 @@ def assert_record_count_in_sf(env, tap_type, table, expected_records, where_clau
 
 
 def _get_command_for_partial_sync(tap_parameters, start_value, end_value=None):
-    end_value_command = f' --end_value {end_value}' if end_value else ''
     command = f'pipelinewise partial_sync_table --tap {tap_parameters["tap"]} --target {tap_parameters["target"]}' \
               f' --table {tap_parameters["source_db"]}.{tap_parameters["table"]} --column {tap_parameters["column"]}' \
-              f' --start_value {start_value} --end_value {end_value}{end_value_command}'
+              f' --start_value {start_value}'
+
+    if end_value is not None:
+        command += f' --end_value {end_value}'
 
     return command

--- a/tests/end_to_end/helpers/db.py
+++ b/tests/end_to_end/helpers/db.py
@@ -11,7 +11,7 @@ from pymongo.database import Database
 from pipelinewise.utils import pem2der
 
 # pylint: disable=too-many-arguments
-def run_query_postgres(query, host, port, user, password, database):
+def run_query_postgres(query, host, port, user, password, database, params=None):
     """Run and SQL query in a postgres database"""
     result_rows = []
     with psycopg2.connect(
@@ -19,13 +19,13 @@ def run_query_postgres(query, host, port, user, password, database):
     ) as conn:
         conn.set_session(autocommit=True)
         with conn.cursor() as cur:
-            cur.execute(query)
+            cur.execute(query, params)
             if cur.rowcount > 0 and cur.description:
                 result_rows = cur.fetchall()
     return result_rows
 
 
-def run_query_mysql(query, host, port, user, password, database):
+def run_query_mysql(query, host, port, user, password, database, params=None):
     """Run and SQL query in a mysql database"""
     result_rows = []
     with pymysql.connect(
@@ -39,7 +39,7 @@ def run_query_mysql(query, host, port, user, password, database):
         ssl={'': True}
     ) as conn:
         with conn.cursor() as cur:
-            cur.execute(query)
+            cur.execute(query, params)
             if cur.rowcount > 0:
                 result_rows = cur.fetchall()
     return result_rows

--- a/tests/end_to_end/helpers/env.py
+++ b/tests/end_to_end/helpers/env.py
@@ -51,6 +51,9 @@ class E2EEnv:
         load_dotenv(
             dotenv_path=os.path.join(DIR, '..', '..', '..', 'dev-project', '.env')
         )
+        schema_postfix_override = os.environ.get('TARGET_SNOWFLAKE_SCHEMA_POSTFIX')
+        self.sf_schema_postfix_is_override = bool(schema_postfix_override)
+        self.sf_schema_postfix = schema_postfix_override or self.sf_schema_postfix
         self.env = {
             # ------------------------------------------------------------------
             # Tap Postgres is a REQUIRED test connector and test database with test data available
@@ -244,7 +247,7 @@ class E2EEnv:
                         'optional': True,
                     },
                     'SCHEMA_POSTFIX': {
-                        'value': os.environ.get('TARGET_SNOWFLAKE_SCHEMA_POSTFIX', self.sf_schema_postfix),
+                        'value': self.sf_schema_postfix,
                         'optional': True,
                     }
                 },
@@ -384,7 +387,7 @@ class E2EEnv:
                 else:
                     try:
                         os.remove(yaml_path)
-                    except OSError:
+                    except FileNotFoundError:
                         pass
 
     @staticmethod
@@ -396,7 +399,7 @@ class E2EEnv:
     # Database functions to run queries in source and target databases
     # -------------------------------------------------------------------------
 
-    def run_query_tap_postgres(self, query):
+    def run_query_tap_postgres(self, query, params=None):
         """Run and SQL query in tap postgres database"""
         return db.run_query_postgres(
             query,
@@ -405,6 +408,7 @@ class E2EEnv:
             user=self.get_conn_env_var('TAP_POSTGRES', 'USER'),
             password=self.get_conn_env_var('TAP_POSTGRES', 'PASSWORD'),
             database=self.get_conn_env_var('TAP_POSTGRES', 'DB'),
+            params=params,
         )
 
     def get_tap_mongodb_connection(self):
@@ -461,7 +465,7 @@ class E2EEnv:
         This function is not yet implemented"""
         pass
 
-    def run_query_tap_mysql(self, query):
+    def run_query_tap_mysql(self, query, params=None):
         """Run and SQL query in tap mysql database"""
         return db.run_query_mysql(
             query,
@@ -470,6 +474,7 @@ class E2EEnv:
             user=self.get_conn_env_var('TAP_MYSQL', 'USER'),
             password=self.get_conn_env_var('TAP_MYSQL', 'PASSWORD'),
             database=self.get_conn_env_var('TAP_MYSQL', 'DB'),
+            params=params,
         )
 
     def run_query_tap_mysql_2(self, query):
@@ -567,8 +572,7 @@ class E2EEnv:
             'DROP SCHEMA IF EXISTS ppw_e2e_tap_mongodb CASCADE'
         )
 
-        # Clean config directory
-        shutil.rmtree(os.path.join(CONFIG_DIR, 'postgres_dwh'), ignore_errors=True)
+        self.remove_dir_from_config_dir('postgres_dwh')
 
     def setup_pipelinewise_backend(self):
         """Remove data-diff control-plane state without touching target data."""
@@ -615,28 +619,37 @@ class E2EEnv:
                 f'DROP SCHEMA IF EXISTS ppw_e2e_tap_mongodb{self.sf_schema_postfix} CASCADE'
             )
 
-        # Clean config directory
-        shutil.rmtree(os.path.join(CONFIG_DIR, 'snowflake'), ignore_errors=True)
+        self.remove_dir_from_config_dir('snowflake')
+
+    @staticmethod
+    def remove_dir_from_config_dir(dir_path):
+        """Remove generated config while surfacing failures other than absence."""
+        try:
+            shutil.rmtree(os.path.join(CONFIG_DIR, dir_path))
+        except FileNotFoundError:
+            pass
 
     def delete_record_from_target_snowflake(self, tap_type, table, where_clause):
         """Delete all records except the first one from the snowflake target"""
+        source_type = E2EEnv._normalize_tap_type(tap_type)
         self.run_query_target_snowflake(
-            f'DELETE from ppw_e2e_tap_{tap_type}{self.sf_schema_postfix}.{table} {where_clause}'
+            f'DELETE from ppw_e2e_tap_{source_type}{self.sf_schema_postfix}.{table} {where_clause}'
         )
 
     def add_column_into_target_sf(self, tap_type, table, new_column):
         """Add a record into the target"""
+        source_type = E2EEnv._normalize_tap_type(tap_type)
         self.run_query_target_snowflake(
-            f'ALTER TABLE ppw_e2e_tap_{tap_type}{self.sf_schema_postfix}.{table} ADD {new_column["name"]} int'
+            f'ALTER TABLE ppw_e2e_tap_{source_type}{self.sf_schema_postfix}.{table} ADD {new_column["name"]} int'
         )
         self.run_query_target_snowflake(
-            f'UPDATE ppw_e2e_tap_{tap_type}{self.sf_schema_postfix}.{table}'
+            f'UPDATE ppw_e2e_tap_{source_type}{self.sf_schema_postfix}.{table}'
             f' SET {new_column["name"]}={new_column["value"]} WHERE 1=1'
         )
 
     def add_column_into_source(self, tap_type, table, new_column):
         """Add a column into the source table"""
-        run_query_method = getattr(self, f'run_query_tap_{tap_type}')
+        run_query_method = E2EEnv._get_source_query_method(self, tap_type)
         run_query_method(
             f'ALTER TABLE {table} ADD {new_column["name"]} int'
         )
@@ -646,24 +659,58 @@ class E2EEnv:
 
     def delete_record_from_source(self, tap_type, table, where_clause):
         """Delete a record from the source"""
-        run_query_method = getattr(self, f'run_query_tap_{tap_type}')
+        run_query_method = E2EEnv._get_source_query_method(self, tap_type)
         run_query_method(
             f'DELETE FROM {table} {where_clause}'
         )
 
+    def _get_source_query_method(self, tap_type):
+        """Resolve lowercase and canonical TAP_* source route identifiers."""
+        source_type = E2EEnv._normalize_tap_type(tap_type)
+        return getattr(self, f'run_query_tap_{source_type}')
+
+    @staticmethod
+    def _normalize_tap_type(tap_type):
+        """Return the source suffix used in E2E method and schema names."""
+        source_type = str(tap_type).lower()
+        return source_type[4:] if source_type.startswith('tap_') else source_type
+
     def get_source_records_count(self, tap_type, table):
         """Getting count of records from the source"""
-        run_query_method = getattr(self, f'run_query_{tap_type.lower()}')
+        run_query_method = E2EEnv._get_source_query_method(self, tap_type)
         result = run_query_method(f'SELECT count(1) FROM {table}')
         return result[0][0]
 
+    def get_rows_from_source(
+            self, tap_type, source_db, table, columns, primary_key,
+            where_clause=None):
+        """Get representative ordered rows from a source fixture table."""
+        run_query_method = E2EEnv._get_source_query_method(self, tap_type)
+        filter_sql = f' {where_clause.strip()}' if where_clause else ''
+        return run_query_method(
+            f'SELECT {", ".join(columns)} FROM {source_db}.{table}'
+            f'{filter_sql} ORDER BY {primary_key}'
+        )
+
+    def get_rows_from_target_snowflake(
+            self, tap_type, table, columns, primary_key, where_clause=None):
+        """Get representative ordered rows from a Snowflake target table."""
+        source_type = E2EEnv._normalize_tap_type(tap_type)
+        filter_sql = f' {where_clause.strip()}' if where_clause else ''
+        return self.run_query_target_snowflake(
+            f'SELECT {", ".join(columns)} '
+            f'FROM ppw_e2e_tap_{source_type}{self.sf_schema_postfix}.{table}'
+            f'{filter_sql} ORDER BY "{primary_key.upper()}"'
+        )
+
     def get_records_from_target_snowflake(self, tap_type, table, column, primary_key):
         """"Getting all records from a specific table of snowflake target"""
-        records = self.run_query_target_snowflake(
-            f'SELECT {column} FROM ppw_e2e_tap_{tap_type}{self.sf_schema_postfix}.{table}'
-            f' ORDER BY "{primary_key.upper()}"'
+        return self.get_rows_from_target_snowflake(
+            tap_type=tap_type,
+            table=table,
+            columns=[column],
+            primary_key=primary_key,
         )
-        return records
 
     @staticmethod
     def remove_all_state_files():
@@ -673,10 +720,13 @@ class E2EEnv:
 
     @staticmethod
     def clean_up_temp_dir():
-        """Clean up temp folder to ensure tests behave the same every time"""
-        files = glob.glob(f'{CONFIG_DIR}/tmp/*')
-        for f in files:
+        """Remove temporary files and directories between E2E runs."""
+        entries = glob.glob(f'{CONFIG_DIR}/tmp/*')
+        for entry in entries:
             try:
-                os.remove(f)
-            except Exception:
+                if os.path.islink(entry) or not os.path.isdir(entry):
+                    os.remove(entry)
+                else:
+                    shutil.rmtree(entry)
+            except FileNotFoundError:
                 pass

--- a/tests/end_to_end/helpers/tasks.py
+++ b/tests/end_to_end/helpers/tasks.py
@@ -1,6 +1,10 @@
 import re
 import shlex
 import subprocess
+from collections import Counter
+
+
+SYNC_ENGINES = ('fastsync', 'partialsync', 'singer')
 
 
 def run_command(command):
@@ -29,7 +33,29 @@ def find_run_tap_log_file(stdout, sync_engine=None):
     else:
         pattern = re.compile(r'Writing output into (.+\.log)')
 
-    return pattern.search(stdout).group(1)
+    log_files = pattern.findall(stdout)
+    assert len(log_files) == 1, (
+        f'Expected exactly one {sync_engine or "sync"} log file, '
+        f'found {len(log_files)}'
+    )
+    return log_files[0]
+
+
+def assert_run_tap_log_engines(stdout, expected_engines):
+    """Require exactly the requested engine logs and reject hidden extra runs."""
+    actual_engines = Counter()
+    for sync_engine in SYNC_ENGINES:
+        pattern = re.compile(
+            r'Writing output into (.+\.{}\.log)'.format(sync_engine)
+        )
+        actual_engines[sync_engine] = len(pattern.findall(stdout))
+
+    actual_engines = +actual_engines
+    expected_engines = Counter(expected_engines)
+    assert actual_engines == expected_engines, (
+        f'Expected sync engine logs {dict(expected_engines)}, '
+        f'found {dict(actual_engines)}'
+    )
 
 
 def find_profiling_folder(stdout):

--- a/tests/end_to_end/target_snowflake/__init__.py
+++ b/tests/end_to_end/target_snowflake/__init__.py
@@ -27,23 +27,40 @@ class TargetSnowflake(unittest.TestCase):
         if self.e2e_env.env[tap_type]['is_configured'] is False:
             self.skipTest(f'{tap_type} is not configured properly')
 
-        self.remove_dir_from_config_dir(f'{self.target_id}/{self.tap_id}')
+        # import_config processes every Snowflake tap in the E2E project. Reset
+        # the whole generated target tree so stale sibling files cannot make
+        # discovery depend on a previous test's outcome.
+        self.remove_dir_from_config_dir(self.target_id)
 
         self.check_snowflake_credentials_provided()
-        self._cleanup_stale_sf_schemas(tap_type)
-        self.drop_sf_schema_if_exists(f'{self.tap_id}{self.e2e_env.sf_schema_postfix}')
+        self.tap_type = tap_type
+        self.addCleanup(
+            self.remove_dir_from_config_dir,
+            f'{self.target_id}/{self.tap_id}',
+        )
+        current_run_schemas = self._current_run_schemas()
+        for schema in current_run_schemas:
+            self.addCleanup(self.drop_sf_schema_if_exists, schema)
+        if self.e2e_env.sf_schema_postfix_is_override:
+            for schema in current_run_schemas:
+                self.drop_sf_schema_if_exists(schema)
 
+        self.prepare_source()
         self.check_validate_taps()
         self.check_import_config()
-        self.tap_type = tap_type
 
-    def tearDown(self):
-        self.remove_dir_from_config_dir(f'{self.target_id}/{self.tap_id}')
-        self.drop_sf_schema_if_exists(f'ppw_e2e_{self.tap_type}{self.e2e_env.sf_schema_postfix}'.upper())
-        self.drop_sf_schema_if_exists(f'ppw_e2e_{self.tap_type}_public2{self.e2e_env.sf_schema_postfix}'.upper())
-        # The replica taps load into a _2 schema; without this it leaks every run.
-        self.drop_sf_schema_if_exists(f'ppw_e2e_{self.tap_type}_2{self.e2e_env.sf_schema_postfix}'.upper())
-        super().tearDown()
+    def prepare_source(self):
+        """Prepare a source fixture before validation and discovery."""
+
+    def _current_run_schemas(self):
+        """Return only the schemas rendered for this test environment."""
+        schema_prefix = f'ppw_e2e_{self.tap_type}'
+        schema_postfix = self.e2e_env.sf_schema_postfix
+        return [
+            f'{schema_prefix}{schema_postfix}'.upper(),
+            f'{schema_prefix}_public2{schema_postfix}'.upper(),
+            f'{schema_prefix}_2{schema_postfix}'.upper(),
+        ]
 
     def get_e2e_env(self) -> E2EEnv:
         """
@@ -87,28 +104,11 @@ class TargetSnowflake(unittest.TestCase):
             f'DROP SCHEMA IF EXISTS {schema} CASCADE'
         )
 
-    def _cleanup_stale_sf_schemas(self, tap_type):
-        """Drop leftover PPW_E2E_* schemas for this tap type from previous test
-        runs that crashed or timed out before tearDown could clean up.
-        Only drops schemas matching the current tap type to avoid interfering
-        with other tap suites running in the same session."""
-        # tap_type is already 'TAP_MYSQL'/'TAP_POSTGRES', so no TAP_ prefix here.
-        pattern = f'PPW_E2E_{tap_type.upper()}_%'
-        try:
-            rows = self.e2e_env.run_query_target_snowflake(
-                f"SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA"
-                f" WHERE SCHEMA_NAME LIKE '{pattern}'"
-            )
-            for row in rows:
-                schema_name = row[0]
-                self.e2e_env.run_query_target_snowflake(
-                    f'DROP SCHEMA IF EXISTS {schema_name} CASCADE'
-                )
-        except Exception:
-            pass
-
     def remove_dir_from_config_dir(self, dir_path: str):
         """
         remove directory from config directory
         """
-        shutil.rmtree(os.path.join(CONFIG_DIR, dir_path), ignore_errors=True)
+        try:
+            shutil.rmtree(os.path.join(CONFIG_DIR, dir_path))
+        except FileNotFoundError:
+            pass

--- a/tests/end_to_end/target_snowflake/tap_mariadb/__init__.py
+++ b/tests/end_to_end/target_snowflake/tap_mariadb/__init__.py
@@ -9,4 +9,7 @@ class TapMariaDB(TargetSnowflake):
     # pylint: disable=arguments-differ
     def setUp(self, tap_id: str, target_id: str):
         super().setUp(tap_id=tap_id, target_id=target_id, tap_type='TAP_MYSQL')
+
+    def prepare_source(self):
+        """Reset MariaDB before validate/import discovers its schema."""
         self.e2e_env.setup_tap_mysql()

--- a/tests/end_to_end/target_snowflake/tap_mariadb/test_defined_partial_sync_mariadb_to_sf.py
+++ b/tests/end_to_end/target_snowflake/tap_mariadb/test_defined_partial_sync_mariadb_to_sf.py
@@ -44,7 +44,7 @@ class TestDefinedPartialSyncMariaDBToSF(TapMariaDB):
         from_value_address = 400
         # run-tap command
         assertions.assert_run_tap_success(
-            self.tap_id, self.target_id, ['fastsync', 'singer']
+            self.tap_id, self.target_id, ['fastsync', 'partialsync', 'singer']
 
         )
 
@@ -73,7 +73,9 @@ class TestDefinedPartialSyncMariaDBToSF(TapMariaDB):
         self._manipulate_target_tables()
 
         # sync-tables command
-        assertions.assert_resync_tables_success(self.tap_id, self.target_id)
+        assertions.assert_resync_tables_success(
+            self.tap_id, self.target_id, sync_engines=('fastsync', 'partialsync')
+        )
 
         expected_records = source_records_weight - from_value_weight + 1
         assertions.assert_record_count_in_sf(self.e2e_env, self.tap_type, 'weight_unit', expected_records)

--- a/tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_soft_delete.py
+++ b/tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_soft_delete.py
@@ -15,7 +15,9 @@ class TestReplicateMariaDBToSFSoftDelete(TapMariaDB):
 
         self.e2e_env.delete_record_from_source('mysql', 'weight_unit', 'WHERE weight_unit_id=25')
 
-        assertions.assert_run_tap_success(self.tap_id, self.target_id, ['singer'])
+        assertions.assert_run_tap_success(
+            self.tap_id, self.target_id, ['fastsync', 'singer']
+        )
 
         records = self.e2e_env.run_query_target_snowflake(
             f'SELECT "_SDC_DELETED_AT", "DATE_CREATED" '

--- a/tests/end_to_end/target_snowflake/tap_postgres/__init__.py
+++ b/tests/end_to_end/target_snowflake/tap_postgres/__init__.py
@@ -9,5 +9,8 @@ class TapPostgres(TargetSnowflake):
     # pylint: disable=arguments-differ
     def setUp(self, tap_id: str, target_id: str):
         super().setUp(tap_id=tap_id, target_id=target_id, tap_type='TAP_POSTGRES')
+
+    def prepare_source(self):
+        """Reset PostgreSQL before validate/import discovers its schema."""
         self.e2e_env.clean_up_temp_dir()
         self.e2e_env.setup_tap_postgres()

--- a/tests/end_to_end/target_snowflake/tap_postgres/test_defined_partial_sync_pg_to_sf.py
+++ b/tests/end_to_end/target_snowflake/tap_postgres/test_defined_partial_sync_pg_to_sf.py
@@ -44,7 +44,7 @@ class TestDefinedPartialSyncPGToSF(TapPostgres):
         from_value_order = 5
         # run-tap command
         assertions.assert_run_tap_success(
-            self.tap_id, self.target_id, ['fastsync', 'singer']
+            self.tap_id, self.target_id, ['fastsync', 'partialsync', 'singer']
 
         )
 
@@ -72,7 +72,9 @@ class TestDefinedPartialSyncPGToSF(TapPostgres):
         self._manipulate_target_tables()
 
         # sync-tables command
-        assertions.assert_resync_tables_success(self.tap_id, self.target_id)
+        assertions.assert_resync_tables_success(
+            self.tap_id, self.target_id, sync_engines=('fastsync', 'partialsync')
+        )
 
         expected_records = source_records_order - from_value_order + 1
         assertions.assert_record_count_in_sf(self.e2e_env, self.tap_type, 'order', expected_records)

--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -696,18 +696,20 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
         assert pytest_wrapped_e.type == SystemExit
         assert pytest_wrapped_e.value.code == 1
 
-    def test_command_stop_tap(self):
+    def test_command_stop_tap(self, tmp_path):
         """Test stop tap command"""
         args = CliArgs(target='target_one', tap='tap_one')
         pipelinewise = PipelineWise(args, CONFIG_DIR, VIRTUALENVS_DIR)
-        pipelinewise.tap_run_log_file = 'test-tap-run-dummy.log'
-        Path(f'{pipelinewise.tap_run_log_file}.running').touch()
+        pipelinewise.tap_run_log_file = str(tmp_path / 'test-tap-run-dummy.log')
+        pipelinewise.tap['files']['pidfile'] = str(tmp_path / 'pipelinewise.pid')
 
         # Tap is not running, pid file not exist, should exit with error
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             pipelinewise.stop_tap()
         assert pytest_wrapped_e.type == SystemExit
         assert pytest_wrapped_e.value.code == 1
+
+        Path(f'{pipelinewise.tap_run_log_file}.running').touch()
 
         # Stop tap command should stop all the child processes
         # 1. Start the pipelinewise mock executable that's running
@@ -732,9 +734,6 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
 
         # Graceful exit should rename log file from running status to terminated
         assert os.path.isfile(f'{pipelinewise.tap_run_log_file}.terminated')
-
-        # Delete test log file
-        os.remove(f'{pipelinewise.tap_run_log_file}.terminated')
 
     def test_command_run_tap_exit_with_error_1_if_fastsync_exception(self):
         """Test if run_tap command returns error 1 if exception in fastsync"""
@@ -845,6 +844,36 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
         with open(test_state_file, 'a', encoding='UTF-8'):
             pass
         self._assert_calling_sync_tables(pipelinewise)
+
+    def test_defined_partial_sync_preserves_zero_static_boundary(self):
+        """A YAML numeric zero must remain aligned with its selected table."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        pipelinewise.args.table = '*'
+        defined_tables = {
+            'db_test_mysql.table_one': {
+                'column': 'id',
+                'static_value': 0,
+                'drop_target_table': False,
+            }
+        }
+
+        with patch.object(
+            pipelinewise, '_check_if_complete_tap_configuration'
+        ), patch.object(
+            pipelinewise,
+            'create_consumable_target_config',
+            return_value=pipelinewise.target['files']['config'],
+        ), patch.object(
+            pipelinewise, 'get_tap_log_dir', return_value='/tmp'
+        ), patch.object(
+            pipelinewise, 'run_tap_partialsync'
+        ) as run_partial_sync, patch(
+            'pipelinewise.cli.pipelinewise.utils.silentremove'
+        ):
+            pipelinewise.sync_tables_partial_sync(defined_tables)
+
+        assert pipelinewise.args.start_value == '<S>0'
+        run_partial_sync.assert_called_once()
 
     def test_validate_command_1(self):
         """Test validate command should fail because of missing replication key for incremental"""

--- a/tests/units/fastsync/assertions.py
+++ b/tests/units/fastsync/assertions.py
@@ -2,8 +2,12 @@ import pytest
 import collections
 import multiprocessing
 
-from unittest.mock import patch, Mock
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import call, patch, Mock
 from argparse import Namespace
+
+from pipelinewise.fastsync.commons import utils as fastsync_utils
 
 
 FASTSYNC_NS = Namespace(
@@ -15,6 +19,23 @@ FASTSYNC_NS = Namespace(
         'temp_dir': '',
         'state': '',
     }
+)
+
+
+SNOWFLAKE_FASTSYNC_NS = Namespace(
+    tap={'dbname': 'source_db'},
+    properties={'schema': 'source properties'},
+    target={
+        'archive_load_files': False,
+        's3_bucket': 'staging-bucket',
+        'split_file_chunk_size_mb': 64,
+        'split_file_max_chunks': 4,
+        'split_large_files': True,
+        'tap_id': 'tap-id',
+    },
+    transform={'transformations': []},
+    temp_dir='/tmp',
+    state='/tmp/state.json',
 )
 
 
@@ -101,26 +122,352 @@ def assert_sync_table_returns_true_on_success(
                         assert res
 
 
-# pylint: disable=missing-function-docstring,unused-variable,invalid-name
+# pylint: disable=missing-function-docstring,unused-variable,invalid-name,no-member
 def assert_sync_table_exception_on_failed_copy(
-    sync_table: callable, package_nm: str, tap_class_nm: str, target_class_nm: str
+    sync_table: callable,
+    package_nm: str,
+    tap_class_nm: str,
+    target_class_nm: str,
+    expected_cleanup=None,
 ) -> None:
     objects_to_mock = _create_object_names_to_mock(
         package_nm, tap_class_nm, target_class_nm
     )
 
     with patch(objects_to_mock.full_tap_class_nm) as tap_mock:
-        with patch(objects_to_mock.full_target_class_nm):
+        with patch(objects_to_mock.full_target_class_nm) as target_mock:
             with patch(objects_to_mock.utils_module_nm) as utils_mock:
-                with patch(objects_to_mock.multiproc_module_nm):
-                    utils_mock.get_target_schema.return_value = 'my-target-schema'
-                    utils_mock.gen_export_filename.return_value = 'my-export-file'
-                    tap_mock.return_value.copy_table.side_effect = Exception('Boooom')
+                utils_mock.get_target_schema.return_value = 'my-target-schema'
+                utils_mock.gen_export_filename.return_value = 'my-export-file'
+                utils_mock.staging_failure_result.return_value = (
+                    'table_1: Boooom'
+                )
+                tap_mock.return_value.copy_table.side_effect = Exception('Boooom')
 
-                    assert sync_table('table_1', FASTSYNC_NS) == 'table_1: Boooom'
+                assert sync_table('table_1', FASTSYNC_NS) == 'table_1: Boooom'
 
-                    assert utils_mock.get_target_schema.call_count == 1
-                    assert tap_mock.return_value.copy_table.call_count == 1
+                utils_mock.get_target_schema.assert_called_once_with(FASTSYNC_NS.target, 'table_1')
+                tap_mock.return_value.copy_table.assert_called_once()
+                utils_mock.save_state_file.assert_not_called()
+                assert target_mock.return_value.method_calls == []
+                if expected_cleanup is not None:
+                    assert tap_mock.return_value.method_calls[-1] == expected_cleanup
+
+
+def assert_snowflake_sync_table_native_workflow(
+    sync_table: callable,
+    package_nm: str,
+    tap_class_nm: str,
+    source_type: str,
+    type_mapper: callable,
+    publish_error: Exception = None,
+    state_error: Exception = None,
+    grant_error: Exception = None,
+) -> None:
+    """Assert the native Snowflake staging, publication, and state workflow."""
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    # pylint: disable=too-many-locals,too-many-statements,no-member
+    objects_to_mock = _create_object_names_to_mock(
+        package_nm, tap_class_nm, 'FastSyncTargetSnowflake'
+    )
+    args = SNOWFLAKE_FASTSYNC_NS
+    table = 'source.table'
+    export_path = '/tmp/export.csv.gz'
+    file_parts = [f'{export_path}.part0', f'{export_path}.part1']
+    s3_keys = ['loads/export.csv.gz.part0', 'loads/export.csv.gz.part1']
+    columns = ['"ID" NUMBER', '"VALUE" VARCHAR']
+    primary_key = ['"ID"']
+    bookmark = {'version': 1, 'position': 42}
+    timeline = []
+
+    if publish_error and state_error:
+        raise AssertionError('State persistence cannot be reached after publication fails')
+
+    finalization_error = grant_error
+    if publish_error and grant_error:
+        finalization_error = RuntimeError(
+            f'{publish_error}; post-publication finalization failed: {grant_error}'
+        )
+
+    def record(name, result=None, error=None):
+        def side_effect(*_args, **_kwargs):
+            timeline.append(name)
+            if error:
+                raise error
+            return result
+
+        return side_effect
+
+    file_sizes = iter([10, 20])
+
+    def getsize(*_args):
+        timeline.append('getsize')
+        return next(file_sizes)
+
+    with patch(objects_to_mock.full_tap_class_nm) as tap_class_mock, \
+            patch(objects_to_mock.full_target_class_nm) as target_class_mock, \
+            patch(objects_to_mock.utils_module_nm) as utils_mock, \
+            patch(f'{package_nm}.glob.glob', return_value=file_parts) as glob_mock, \
+            patch(f'{package_nm}.os.path.exists', return_value=True) as exists_mock, \
+            patch(f'{package_nm}.os.path.getsize', side_effect=getsize) as getsize_mock:
+        tap = tap_class_mock.return_value
+        target = target_class_mock.return_value
+        utils_mock.gen_export_filename.return_value = 'export.csv.gz'
+        utils_mock.get_target_schema.return_value = 'TARGET_SCHEMA'
+        utils_mock.get_bookmark_for_table.side_effect = record('bookmark', bookmark)
+        utils_mock.upload_files_to_s3.side_effect = record(
+            'upload_all', (s3_keys, 'loads/export.csv.gz')
+        )
+        utils_mock.apply_snowflake_table_grants.side_effect = record('pregrant')
+        utils_mock.finalize_snowflake_fullsync.side_effect = record(
+            'finalize', error=finalization_error
+        )
+        tap.map_column_types_to_target.side_effect = record(
+            'source.map',
+            {'columns': columns, 'primary_key': primary_key},
+        )
+        source_open_method = tap.open_connections if source_type == 'mysql' else tap.open_connection
+        source_close_method = tap.close_connections if source_type == 'mysql' else tap.close_connection
+        source_open_method.side_effect = record('source.open')
+        tap.copy_table.side_effect = record('source.copy')
+        source_close_method.side_effect = record('source.close')
+
+        target.copy_to_table.side_effect = record('target.copy')
+        target.obfuscate_columns.side_effect = record('obfuscate')
+
+        def publish(*_args, **_kwargs):
+            timeline.append('publish')
+            if publish_error:
+                raise publish_error
+
+        target.swap_tables.side_effect = publish
+        utils_mock.save_state_file.side_effect = record('state', error=state_error)
+
+        def staging_failure(
+            _target,
+            _s3_keys,
+            _bucket,
+            _target_schema,
+            failed_table,
+            _temp_created,
+            operation_error,
+        ):
+            timeline.append('rollback')
+            return f'{failed_table}: {operation_error}'
+
+        utils_mock.staging_failure_result.side_effect = staging_failure
+
+        result = sync_table(table, args)
+
+    expected_error = finalization_error or publish_error or state_error
+    expected_result = f'{table}: {expected_error}' if expected_error else True
+    assert result == expected_result
+    tap_class_mock.assert_called_once_with(args.tap, type_mapper)
+    target_class_mock.assert_called_once_with(args.target, args.transform)
+    exists_mock.assert_called_once_with(export_path)
+    glob_mock.assert_called_once_with(f'{export_path}*')
+    assert getsize_mock.call_args_list == [call(file_parts[0]), call(file_parts[1])]
+
+    expected_copy_call = call.copy_table(
+        table,
+        export_path,
+        split_large_files=True,
+        split_file_chunk_size_mb=64,
+        split_file_max_chunks=4,
+    )
+    if source_type == 'mysql':
+        assert tap.method_calls == [
+            call.open_connections(),
+            expected_copy_call,
+            call.map_column_types_to_target(table),
+            call.close_connections(),
+            call.close_connections(silent=True),
+        ]
+        source_timeline = [
+            'source.open', 'bookmark', 'source.copy', 'source.map', 'source.close',
+            'getsize', 'getsize',
+        ]
+        expected_bookmark_call = call.get_bookmark_for_table(table, args.properties, tap)
+    elif source_type == 'postgres':
+        assert tap.method_calls == [
+            call.open_connection(),
+            expected_copy_call,
+            call.map_column_types_to_target(table),
+            call.close_connection(),
+            call.close_connection(silent=True),
+        ]
+        source_timeline = [
+            'source.open', 'bookmark', 'source.copy', 'getsize', 'getsize',
+            'source.map', 'source.close',
+        ]
+        expected_bookmark_call = call.get_bookmark_for_table(
+            table, args.properties, tap, dbname='source_db'
+        )
+    else:
+        raise AssertionError(f'Unsupported source type: {source_type}')
+
+    expected_target_calls = [
+        call.create_schema('TARGET_SCHEMA'),
+        call.create_table('TARGET_SCHEMA', table, columns, primary_key, is_temporary=True),
+        call.copy_to_table('loads/export.csv.gz', 'TARGET_SCHEMA', table, 30, is_temporary=True),
+        call.obfuscate_columns('TARGET_SCHEMA', table),
+        call.create_table(
+            'TARGET_SCHEMA',
+            table,
+            columns,
+            primary_key,
+            allow_replace_table=False,
+            normalize_primary_keys=False,
+        ),
+        call.swap_tables('TARGET_SCHEMA', table, cleanup_old_table=False),
+    ]
+    assert target.method_calls == expected_target_calls
+
+    expected_utils_calls = [
+        call.gen_export_filename(tap_id='tap-id', table=table),
+        call.get_target_schema(args.target, table),
+        expected_bookmark_call,
+        call.upload_files_to_s3(target, file_parts, args.temp_dir, 'staging-bucket'),
+        call.apply_snowflake_table_grants(
+            target,
+            args.target,
+            'TARGET_SCHEMA',
+            table,
+            is_temporary=True,
+        ),
+    ]
+    expected_utils_calls.append(call.finalize_snowflake_fullsync(
+        target,
+        s3_keys,
+        'staging-bucket',
+        args.target,
+        'TARGET_SCHEMA',
+        table,
+        publication_error=publish_error,
+    ))
+    expected_timeline = source_timeline + [
+        'upload_all', 'target.copy', 'obfuscate', 'pregrant', 'publish', 'finalize',
+    ]
+
+    if publish_error or grant_error:
+        expected_utils_calls.append(call.staging_failure_result(
+            target,
+            s3_keys if grant_error else [],
+            'staging-bucket',
+            'TARGET_SCHEMA',
+            table,
+            bool(grant_error),
+            finalization_error or publish_error,
+        ))
+        expected_timeline.extend(['rollback', 'source.close'])
+    else:
+        expected_utils_calls.append(
+            call.save_state_file(args.state, table, bookmark)
+        )
+        expected_timeline.append('state')
+        if state_error:
+            expected_utils_calls.append(call.staging_failure_result(
+                target,
+                [],
+                'staging-bucket',
+                'TARGET_SCHEMA',
+                table,
+                False,
+                state_error,
+            ))
+            expected_timeline.append('rollback')
+        expected_timeline.append('source.close')
+
+    assert timeline == expected_timeline
+    assert utils_mock.method_calls == expected_utils_calls
+
+
+def assert_snowflake_sync_table_rolls_back_later_upload_failure(
+    sync_table: callable,
+    package_nm: str,
+    tap_class_nm: str,
+    source_type: str,
+    rollback_cleanup_error: Exception = None,
+) -> None:
+    """A failed later part upload must retain local files and remove earlier S3 parts."""
+    # pylint: disable=too-many-locals
+    objects_to_mock = _create_object_names_to_mock(
+        package_nm, tap_class_nm, 'FastSyncTargetSnowflake'
+    )
+    table = 'source.table'
+
+    with TemporaryDirectory() as temp_directory:
+        args = Namespace(**{
+            **vars(SNOWFLAKE_FASTSYNC_NS),
+            'temp_dir': temp_directory,
+        })
+        export_path = Path(temp_directory, 'export.csv.gz')
+        file_parts = [f'{export_path}.part0', f'{export_path}.part1']
+        for file_part in file_parts:
+            Path(file_part).write_text('data', encoding='utf8')
+
+        with patch(objects_to_mock.full_tap_class_nm) as tap_class_mock, \
+                patch(objects_to_mock.full_target_class_nm) as target_class_mock, \
+                patch.object(fastsync_utils, 'gen_export_filename', return_value=export_path.name), \
+                patch.object(fastsync_utils, 'get_target_schema', return_value='TARGET_SCHEMA'), \
+                patch.object(fastsync_utils, 'get_bookmark_for_table', return_value={'position': 42}), \
+                patch.object(fastsync_utils, 'save_state_file') as save_state_file_mock, \
+                patch.object(fastsync_utils, 'get_grantees') as get_grantees_mock:
+            tap = tap_class_mock.return_value
+            tap.map_column_types_to_target.return_value = {
+                'columns': ['"ID" NUMBER'],
+                'primary_key': ['"ID"'],
+            }
+            target = target_class_mock.return_value
+            target.upload_to_s3.side_effect = [
+                'loads/export.csv.gz.part0',
+                RuntimeError('second upload failed'),
+            ]
+            target.s3.delete_object.side_effect = rollback_cleanup_error
+
+            result = sync_table(table, args)
+
+        if rollback_cleanup_error:
+            assert result.startswith(f'{table}: second upload failed')
+            assert 'staging upload rollback failed' in result
+            assert 'staging cleanup failed' in result
+        else:
+            assert result == f'{table}: second upload failed'
+        upload_calls = target.upload_to_s3.call_args_list
+        assert len(upload_calls) == 2
+        assert {upload_call.args[0] for upload_call in upload_calls} == set(file_parts)
+        assert all(
+            upload_call.kwargs == {'tmp_dir': temp_directory}
+            for upload_call in upload_calls
+        )
+        assert target.s3.delete_object.call_count == (
+            6 if rollback_cleanup_error else 1
+        )
+        assert all(
+            delete_call == call(
+                Bucket='staging-bucket', Key='loads/export.csv.gz.part0'
+            )
+            for delete_call in target.s3.delete_object.call_args_list
+        )
+        target.create_schema.assert_not_called()
+        target.copy_to_table.assert_not_called()
+        target.swap_tables.assert_not_called()
+        assert all(Path(file_part).exists() for file_part in file_parts)
+        save_state_file_mock.assert_not_called()
+        get_grantees_mock.assert_not_called()
+
+        if source_type == 'mysql':
+            assert tap.method_calls[-2:] == [
+                call.close_connections(),
+                call.close_connections(silent=True),
+            ]
+        elif source_type == 'postgres':
+            assert tap.method_calls[-2:] == [
+                call.close_connection(),
+                call.close_connection(silent=True),
+            ]
+        else:
+            raise AssertionError(f'Unsupported source type: {source_type}')
 
 
 # pylint: disable=missing-function-docstring,unused-variable,invalid-name

--- a/tests/units/fastsync/commons/test_fastsync_tap_mysql.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_mysql.py
@@ -32,7 +32,7 @@ class FastSyncTapMySqlMock(FastSyncTapMySql):
         return []
 
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,too-many-public-methods
 class TestFastSyncTapMySql(TestCase):
     """
     Unit tests for fastsync tap mysql
@@ -59,6 +59,51 @@ class TestFastSyncTapMySql(TestCase):
         # Test if session variables applied on both connections
         self.assertListEqual(self.mysql.executed_queries, tap_mysql.DEFAULT_SESSION_SQLS)
         self.assertListEqual(self.mysql.executed_queries_unbuffered, self.mysql.executed_queries)
+
+    def test_close_connections_is_idempotent(self):
+        """Each MySQL connection is closed once and its reference is cleared."""
+        self.mysql = FastSyncTapMySql(self.connection_config, lambda value: value)
+        buffered_connection = Mock()
+        unbuffered_connection = Mock()
+        self.mysql.conn = buffered_connection
+        self.mysql.conn_unbuffered = unbuffered_connection
+
+        self.mysql.close_connections()
+        self.mysql.close_connections()
+
+        buffered_connection.close.assert_called_once_with()
+        unbuffered_connection.close.assert_called_once_with()
+        self.assertIsNone(self.mysql.conn)
+        self.assertIsNone(self.mysql.conn_unbuffered)
+
+    def test_close_connections_attempts_both_when_first_close_fails(self):
+        """A buffered close failure cannot leak the streaming connection."""
+        self.mysql = FastSyncTapMySql(self.connection_config, lambda value: value)
+        buffered_connection = Mock()
+        buffered_connection.close.side_effect = RuntimeError('buffered close failed')
+        unbuffered_connection = Mock()
+        self.mysql.conn = buffered_connection
+        self.mysql.conn_unbuffered = unbuffered_connection
+
+        self.mysql.close_connections(silent=True)
+
+        buffered_connection.close.assert_called_once_with()
+        unbuffered_connection.close.assert_called_once_with()
+        self.assertIsNone(self.mysql.conn)
+        self.assertIsNone(self.mysql.conn_unbuffered)
+
+    def test_close_connections_handles_a_partially_open_pair(self):
+        """Cleanup closes an unbuffered connection even when the first connect failed."""
+        self.mysql = FastSyncTapMySql(self.connection_config, lambda value: value)
+        unbuffered_connection = Mock()
+        self.mysql.conn = None
+        self.mysql.conn_unbuffered = unbuffered_connection
+
+        self.mysql.close_connections()
+
+        unbuffered_connection.close.assert_called_once_with()
+        self.assertIsNone(self.mysql.conn)
+        self.assertIsNone(self.mysql.conn_unbuffered)
 
     def test_get_connection_to_primary(self):
         """

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -65,6 +65,87 @@ class TestFastSyncTapPostgres(TestCase):
             == 'pipelinewise_some_db_some_tap'
         )
 
+    def test_close_connection_is_idempotent(self):
+        """Close each opened connection once and clear its cursor reference."""
+        connection = Mock()
+        primary_connection = Mock()
+        self.postgres.conn = connection
+        self.postgres.curr = Mock()
+        self.postgres.primary_host_conn = primary_connection
+        self.postgres.primary_host_curr = Mock()
+
+        self.postgres.close_connection()
+        self.postgres.close_connection()
+
+        connection.close.assert_called_once_with()
+        primary_connection.close.assert_called_once_with()
+        self.assertIsNone(self.postgres.conn)
+        self.assertIsNone(self.postgres.curr)
+        self.assertIsNone(self.postgres.primary_host_conn)
+        self.assertIsNone(self.postgres.primary_host_curr)
+
+    def test_close_connection_silences_driver_failure(self):
+        """Cleanup failures must not replace the original sync exception."""
+        connection = Mock()
+        connection.close.side_effect = RuntimeError('close failed')
+        self.postgres.conn = connection
+
+        self.postgres.close_connection(silent=True)
+
+        connection.close.assert_called_once_with()
+        self.assertIsNone(self.postgres.conn)
+
+    def test_fetch_current_log_pos_closes_primary_connection_on_success(self):
+        """The dedicated primary connection is released before reading the source LSN."""
+        primary_connection = Mock()
+
+        with patch.object(
+            self.postgres, 'get_connection', return_value=primary_connection
+        ), patch.object(
+            self.postgres, 'primary_host_query', return_value=[{'version': 120000}]
+        ), patch.object(
+            self.postgres, 'create_replication_slot'
+        ) as create_replication_slot, patch.object(
+            self.postgres, 'query', return_value=[{'current_lsn': '0/2A'}]
+        ):
+            bookmark = self.postgres.fetch_current_log_pos()
+
+        self.assertEqual({'lsn': 42, 'version': 1}, bookmark)
+        create_replication_slot.assert_called_once_with()
+        primary_connection.close.assert_called_once_with()
+        self.assertIsNone(self.postgres.primary_host_conn)
+        self.assertIsNone(self.postgres.primary_host_curr)
+
+    def test_fetch_current_log_pos_closes_primary_connection_on_failure(self):
+        """Primary setup, metadata, and replication-slot failures cannot leak their connection."""
+        failures = ('cursor', 'metadata', 'replication_slot')
+
+        for failure in failures:
+            with self.subTest(failure=failure):
+                primary_connection = Mock()
+                error_message = f'{failure.replace("_", " ")} failed'
+                primary_connection.cursor.side_effect = (
+                    RuntimeError(error_message) if failure == 'cursor' else None
+                )
+                primary_query_error = RuntimeError(error_message) if failure == 'metadata' else None
+                slot_error = RuntimeError(error_message) if failure == 'replication_slot' else None
+
+                with patch.object(
+                    self.postgres, 'get_connection', return_value=primary_connection
+                ), patch.object(
+                    self.postgres,
+                    'primary_host_query',
+                    return_value=[{'version': 120000}],
+                    side_effect=primary_query_error,
+                ), patch.object(
+                    self.postgres, 'create_replication_slot', side_effect=slot_error
+                ), self.assertRaisesRegex(RuntimeError, error_message):
+                    self.postgres.fetch_current_log_pos()
+
+                primary_connection.close.assert_called_once_with()
+                self.assertIsNone(self.postgres.primary_host_conn)
+                self.assertIsNone(self.postgres.primary_host_curr)
+
     def test_create_replication_slot_1(self):
         """
         Validate if replication slot creation SQL commands generated correctly in case no v15 slots exists

--- a/tests/units/fastsync/commons/test_fastsync_target_snowflake.py
+++ b/tests/units/fastsync/commons/test_fastsync_target_snowflake.py
@@ -213,6 +213,26 @@ class TestFastSyncTargetSnowflake(TestCase):
             '_SDC_DELETED_AT VARCHAR)'
         ])
 
+    def test_create_table_if_not_exists(self):
+        """PartialSync must preserve an existing native target table."""
+        self.snowflake.create_table(
+            target_schema='test_schema',
+            table_name='test_table',
+            columns=['"ID" INTEGER', '"TXT" VARCHAR'],
+            primary_key=['"ID"'],
+            allow_replace_table=False,
+        )
+
+        self.assertListEqual(self.snowflake.executed_queries, [
+            'CREATE TABLE IF NOT EXISTS "TEST_SCHEMA"."TEST_TABLE" ('
+            '"ID" INTEGER,"TXT" VARCHAR,'
+            '_SDC_EXTRACTED_AT TIMESTAMP_NTZ,'
+            '_SDC_BATCHED_AT TIMESTAMP_NTZ,'
+            '_SDC_DELETED_AT VARCHAR'
+            ', PRIMARY KEY ("ID"))',
+            'alter table "TEST_SCHEMA"."TEST_TABLE" alter column "ID" drop not null;'
+        ])
+
     def test_copy_to_table(self):
         """Validate if COPY command generated correctly"""
         # COPY table with standard table and column names
@@ -228,7 +248,7 @@ class TestFastSyncTargetSnowflake(TestCase):
         assert self.snowflake.executed_queries == [
             'COPY INTO test_schema."TEST_TABLE" FROM \'@dummy_stage/s3_key\''
             ' FILE_FORMAT = (type=CSV escape=NONE escape_unenclosed_field=\'\\x1e\''
-            ' field_optionally_enclosed_by=\'\"\' skip_header=0'
+            ' field_optionally_enclosed_by=\'\"\' empty_field_as_null=TRUE skip_header=0'
             ' compression=GZIP binary_format=HEX)'
         ]
 
@@ -245,7 +265,7 @@ class TestFastSyncTargetSnowflake(TestCase):
         assert self.snowflake.executed_queries == [
             'COPY INTO test_schema."FULL_TEMP" FROM \'@dummy_stage/s3_key\''
             ' FILE_FORMAT = (type=CSV escape=NONE escape_unenclosed_field=\'\\x1e\''
-            ' field_optionally_enclosed_by=\'\"\' skip_header=0'
+            ' field_optionally_enclosed_by=\'\"\' empty_field_as_null=TRUE skip_header=0'
             ' compression=GZIP binary_format=HEX)'
         ]
 
@@ -262,7 +282,7 @@ class TestFastSyncTargetSnowflake(TestCase):
         assert self.snowflake.executed_queries == [
             'COPY INTO test_schema."TABLE WITH SPACE AND UPPERCASE_TEMP" FROM \'@dummy_stage/s3 key with space\''
             ' FILE_FORMAT = (type=CSV escape=NONE escape_unenclosed_field=\'\\x1e\''
-            ' field_optionally_enclosed_by=\'\"\' skip_header=0'
+            ' field_optionally_enclosed_by=\'\"\' empty_field_as_null=TRUE skip_header=0'
             ' compression=GZIP binary_format=HEX)'
         ]
 
@@ -277,7 +297,19 @@ class TestFastSyncTargetSnowflake(TestCase):
             is_temporary=False,
         )
         assert self.snowflake.executed_queries == [
-            'GRANT SELECT ON test_schema."TEST_TABLE" TO ROLE test_role'
+            'GRANT SELECT ON TABLE test_schema."TEST_TABLE" TO ROLE test_role'
+        ]
+
+        # GRANT the staging table that will become live after SWAP
+        self.snowflake.executed_queries = []
+        self.snowflake.grant_select_on_table(
+            target_schema='test_schema',
+            table_name='test_table',
+            role='test_role',
+            is_temporary=True,
+        )
+        assert self.snowflake.executed_queries == [
+            'GRANT SELECT ON TABLE test_schema."TEST_TABLE_TEMP" TO ROLE test_role'
         ]
 
         # GRANT table with reserved word in table and column names in temp table
@@ -289,7 +321,7 @@ class TestFastSyncTargetSnowflake(TestCase):
             is_temporary=False,
         )
         assert self.snowflake.executed_queries == [
-            'GRANT SELECT ON test_schema."FULL" TO ROLE test_role'
+            'GRANT SELECT ON TABLE test_schema."FULL" TO ROLE test_role'
         ]
 
         # GRANT table with with space and uppercase in table name and s3 key
@@ -301,7 +333,7 @@ class TestFastSyncTargetSnowflake(TestCase):
             is_temporary=False,
         )
         assert self.snowflake.executed_queries == [
-            'GRANT SELECT ON test_schema."TABLE WITH SPACE AND UPPERCASE" TO ROLE test_role'
+            'GRANT SELECT ON TABLE test_schema."TABLE WITH SPACE AND UPPERCASE" TO ROLE test_role'
         ]
 
     def test_grant_usage_on_schema(self):

--- a/tests/units/fastsync/commons/test_fastsync_target_snowflake_normalization.py
+++ b/tests/units/fastsync/commons/test_fastsync_target_snowflake_normalization.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock, call
+
+from pipelinewise.fastsync.commons.target_snowflake import (
+    FastSyncTargetSnowflake,
+)
+
+
+def test_new_only_primary_key_normalization():
+    """Normalize a new target without altering an existing native or Iceberg table."""
+    target = object.__new__(FastSyncTargetSnowflake)
+    create_sql = (
+        'CREATE TABLE IF NOT EXISTS "TEST_SCHEMA"."TEST_TABLE" '
+        '("ID" INTEGER,_SDC_EXTRACTED_AT TIMESTAMP_NTZ,'
+        '_SDC_BATCHED_AT TIMESTAMP_NTZ,_SDC_DELETED_AT VARCHAR, '
+        'PRIMARY KEY ("ID"))'
+    )
+    show_sql = (
+        'SHOW TABLES IN SCHEMA "TEST_SCHEMA" STARTS WITH \'TEST_TABLE\''
+    )
+    query_tag = {'schema': 'test_schema', 'table': 'test_table'}
+
+    target.query = MagicMock(side_effect=[[{'name': 'TEST_TABLE'}], []])
+    target.create_table(
+        'test_schema',
+        'test_table',
+        ['"ID" INTEGER'],
+        ['"ID"'],
+        allow_replace_table=False,
+        normalize_primary_keys='if_created',
+    )
+    assert target.query.call_args_list == [
+        call(show_sql, query_tag_props=query_tag),
+        call(create_sql, query_tag_props=query_tag),
+    ]
+
+    target.query = MagicMock(side_effect=[[], [], []])
+    target.create_table(
+        'test_schema',
+        'test_table',
+        ['"ID" INTEGER'],
+        ['"ID"'],
+        allow_replace_table=False,
+        normalize_primary_keys='if_created',
+    )
+    assert target.query.call_args_list[-1] == call(
+        'alter table "TEST_SCHEMA"."TEST_TABLE" '
+        'alter column "ID" drop not null;',
+        query_tag_props=query_tag,
+    )

--- a/tests/units/fastsync/commons/test_fastsync_target_snowflake_publication.py
+++ b/tests/units/fastsync/commons/test_fastsync_target_snowflake_publication.py
@@ -1,0 +1,358 @@
+import json
+from unittest import TestCase
+from unittest.mock import MagicMock, call, patch
+
+from tests.units.fastsync.commons.test_fastsync_target_snowflake import (
+    FastSyncTargetSnowflakeMock,
+)
+
+
+class TestFastSyncTargetSnowflakePartialSync(TestCase):
+    """Unit tests for atomic PartialSync publication."""
+
+    def setUp(self) -> None:
+        self.snowflake = FastSyncTargetSnowflakeMock(
+            connection_config={'s3_bucket': 'dummy_bucket', 'stage': 'dummy_stage'},
+            transformation_config={},
+        )
+
+    @patch('pipelinewise.fastsync.commons.target_snowflake.pem2der', return_value=b'private-key')
+    @patch('pipelinewise.fastsync.commons.target_snowflake.snowflake.connector.connect')
+    def test_open_connection_disables_autocommit_for_transactions(self, mocked_connect, _mocked_pem2der):
+        """The transaction connection must disable Snowflake autocommit."""
+        self.snowflake.connection_config.update({
+            'user': 'test_user',
+            'private_key': 'private-key.pem',
+            'account': 'test_account',
+            'dbname': 'test_database',
+            'warehouse': 'test_warehouse',
+            'tap_id': 'test_tap',
+        })
+
+        self.snowflake.open_connection(
+            {'schema': 'test_schema', 'table': 'test_table'}, autocommit=False
+        )
+
+        mocked_connect.assert_called_once_with(
+            user='test_user',
+            private_key=b'private-key',
+            account='test_account',
+            database='test_database',
+            warehouse='test_warehouse',
+            authenticator='SNOWFLAKE_JWT',
+            autocommit=False,
+            session_parameters={
+                'QUOTED_IDENTIFIERS_IGNORE_CASE': 'FALSE',
+                'QUERY_TAG': json.dumps({
+                    'ppw_component': 'fastsync',
+                    'tap_id': 'test_tap',
+                    'database': 'test_database',
+                    'schema': 'test_schema',
+                    'table': 'test_table',
+                }),
+            },
+        )
+
+    def test_partial_hard_delete(self):
+        """Hard delete is limited to the selected, marked range."""
+        self.snowflake.partial_hard_delete(
+            'test_schema', 'target_table', ' WHERE updated_at >= \'2024-01-01\''
+        )
+
+        self.assertListEqual(self.snowflake.executed_queries, [
+            'DELETE FROM test_schema."TARGET_TABLE" WHERE updated_at >= \'2024-01-01\''
+            ' AND _SDC_DELETED_AT IS NOT NULL'
+        ])
+
+    def test_publish_partial_sync_executes_one_atomic_transaction(self):
+        """Marker, merge, and hard delete share one transaction."""
+        self.snowflake.execute_transaction = MagicMock()
+        self.snowflake.publish_partial_sync(
+            'test_schema',
+            'source_table',
+            'target_table',
+            ['id', 'value'],
+            ['id'],
+            ' WHERE updated_at >= \'2024-01-01\'',
+            hard_delete=True,
+        )
+
+        self.snowflake.execute_transaction.assert_called_once_with(
+            [
+                'UPDATE test_schema."TARGET_TABLE" SET _SDC_DELETED_AT = CURRENT_TIMESTAMP()'
+                ' WHERE updated_at >= \'2024-01-01\' AND _SDC_DELETED_AT IS NULL',
+                'MERGE INTO test_schema."TARGET_TABLE" USING test_schema."SOURCE_TABLE"'
+                ' ON "SOURCE_TABLE".ID = "TARGET_TABLE".ID'
+                ' WHEN MATCHED THEN UPDATE SET "TARGET_TABLE".ID = "SOURCE_TABLE".ID, '
+                '"TARGET_TABLE".VALUE = "SOURCE_TABLE".VALUE'
+                ' WHEN NOT MATCHED THEN INSERT (ID, VALUE)'
+                ' VALUES ("SOURCE_TABLE".ID, "SOURCE_TABLE".VALUE)',
+                'DELETE FROM test_schema."TARGET_TABLE" WHERE updated_at >= \'2024-01-01\''
+                ' AND _SDC_DELETED_AT IS NOT NULL',
+            ],
+            query_tag_props={'schema': 'test_schema', 'table': 'target_table'},
+        )
+
+    def test_publish_partial_sync_preserves_soft_deleted_rows(self):
+        """Soft-delete publication does not issue a physical delete."""
+        self.snowflake.execute_transaction = MagicMock()
+        self.snowflake.publish_partial_sync(
+            'test_schema', 'source_table', 'target_table', ['id'], ['id'],
+            ' WHERE updated_at >= \'2024-01-01\'', hard_delete=False,
+        )
+
+        transaction_queries = self.snowflake.execute_transaction.call_args.args[0]
+        self.assertEqual(len(transaction_queries), 2)
+        self.assertFalse(any(query.startswith('DELETE') for query in transaction_queries))
+
+    def test_execute_transaction_commits_all_queries(self):
+        """A successful transaction commits exactly once."""
+        connection = MagicMock()
+        cursor = MagicMock()
+        connection.cursor.return_value.__enter__.return_value = cursor
+        self.snowflake.open_connection = MagicMock(return_value=connection)
+
+        self.snowflake.execute_transaction(['UPDATE one', 'MERGE two'])
+
+        self.snowflake.open_connection.assert_called_once_with(None, autocommit=False)
+        self.assertListEqual(cursor.method_calls, [
+            call.execute('UPDATE one'),
+            call.execute('MERGE two'),
+        ])
+        connection.commit.assert_called_once_with()
+        connection.rollback.assert_not_called()
+        connection.close.assert_called_once_with()
+
+    def test_execute_transaction_rolls_back_publication_failures(self):
+        """Every publication-statement failure rolls back the transaction."""
+        queries = ['UPDATE marker', 'MERGE rows', 'DELETE stale']
+        for failed_query_index, error_message in (
+            (0, 'marker update failed'),
+            (1, 'merge failed'),
+            (2, 'delete failed'),
+        ):
+            with self.subTest(error_message=error_message):
+                connection = MagicMock()
+                cursor = MagicMock()
+                cursor.execute.side_effect = [
+                    *([None] * failed_query_index),
+                    RuntimeError(error_message),
+                ]
+                connection.cursor.return_value.__enter__.return_value = cursor
+                self.snowflake.open_connection = MagicMock(return_value=connection)
+
+                with self.assertRaisesRegex(RuntimeError, error_message):
+                    self.snowflake.execute_transaction(queries)
+
+                self.assertListEqual(
+                    cursor.method_calls,
+                    [call.execute(query) for query in queries[:failed_query_index + 1]],
+                )
+                connection.rollback.assert_called_once_with()
+                connection.commit.assert_not_called()
+                connection.close.assert_called_once_with()
+
+    def test_execute_transaction_rolls_back_and_propagates_commit_failure(self):
+        """A failed commit is reported after a best-effort rollback."""
+        connection = MagicMock()
+        connection.cursor.return_value.__enter__.return_value = MagicMock()
+        connection.commit.side_effect = RuntimeError('commit failed')
+        self.snowflake.open_connection = MagicMock(return_value=connection)
+
+        with self.assertRaisesRegex(RuntimeError, 'commit failed'):
+            self.snowflake.execute_transaction(['MERGE rows'])
+
+        connection.commit.assert_called_once_with()
+        connection.rollback.assert_called_once_with()
+        connection.close.assert_called_once_with()
+
+    def test_execute_transaction_ignores_close_failure_after_commit(self):
+        """A close failure cannot make a committed publication look unsuccessful."""
+        connection = MagicMock()
+        connection.cursor.return_value.__enter__.return_value = MagicMock()
+        connection.close.side_effect = RuntimeError('close failed')
+        self.snowflake.open_connection = MagicMock(return_value=connection)
+
+        with self.assertLogs(
+            'pipelinewise.fastsync.commons.target_snowflake', level='WARNING'
+        ) as logs:
+            self.snowflake.execute_transaction(['MERGE rows'])
+
+        connection.commit.assert_called_once_with()
+        connection.close.assert_called_once_with()
+        self.assertIn('Failed to close Snowflake publication connection', logs.output[0])
+
+    def test_execute_transaction_preserves_query_failure_when_cleanup_fails(self):
+        """Rollback and close failures do not mask the publication error."""
+        connection = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = RuntimeError('merge failed')
+        connection.cursor.return_value.__enter__.return_value = cursor
+        connection.rollback.side_effect = RuntimeError('rollback failed')
+        connection.close.side_effect = RuntimeError('close failed')
+        self.snowflake.open_connection = MagicMock(return_value=connection)
+
+        with self.assertLogs(
+            'pipelinewise.fastsync.commons.target_snowflake', level='WARNING'
+        ) as logs:
+            with self.assertRaisesRegex(RuntimeError, 'merge failed'):
+                self.snowflake.execute_transaction(['MERGE rows'])
+
+        connection.rollback.assert_called_once_with()
+        connection.close.assert_called_once_with()
+        self.assertEqual(len(logs.output), 2)
+        self.assertIn('Failed to roll back Snowflake publication transaction', logs.output[0])
+        self.assertIn('Failed to close Snowflake publication connection', logs.output[1])
+
+
+class TestFastSyncTargetSnowflakePublication(TestCase):
+    """Failure-boundary and staging-cleanup tests for publication."""
+
+    def setUp(self) -> None:
+        self.snowflake = FastSyncTargetSnowflakeMock(
+            connection_config={'s3_bucket': 'dummy_bucket', 'stage': 'dummy_stage'},
+            transformation_config={},
+        )
+
+    def test_swap_can_defer_cleanup_to_post_publication_finalizer(self):
+        """FullSync can separate committed cutover from cleanup and grants."""
+        self.snowflake.query = MagicMock()
+
+        self.snowflake.swap_tables(
+            schema='test_schema',
+            table_name='test_table',
+            cleanup_old_table=False,
+        )
+
+        self.snowflake.query.assert_called_once_with(
+            'ALTER TABLE test_schema."TEST_TABLE_TEMP" '
+            'SWAP WITH test_schema."TEST_TABLE"',
+            query_tag_props={'schema': 'test_schema', 'table': 'test_table'},
+        )
+
+    def test_cleanup_is_retried_without_repeating_the_committed_swap(self):
+        """A transient DROP failure retries cleanup but never the committed swap."""
+        self.snowflake.query = MagicMock(
+            side_effect=[None, RuntimeError('cleanup failed'), None]
+        )
+
+        with self.assertLogs(
+            'pipelinewise.fastsync.commons.target_snowflake', level='WARNING'
+        ) as logs:
+            self.snowflake.swap_tables(schema='test_schema', table_name='test_table')
+
+        self.assertEqual(
+            self.snowflake.query.call_args_list,
+            [
+                call(
+                    'ALTER TABLE test_schema."TEST_TABLE_TEMP" '
+                    'SWAP WITH test_schema."TEST_TABLE"',
+                    query_tag_props={'schema': 'test_schema', 'table': 'test_table'},
+                ),
+                call(
+                    'DROP TABLE IF EXISTS test_schema."TEST_TABLE_TEMP"',
+                    query_tag_props={'schema': 'test_schema', 'table': 'test_table'},
+                ),
+                call(
+                    'DROP TABLE IF EXISTS test_schema."TEST_TABLE_TEMP"',
+                    query_tag_props={'schema': 'test_schema', 'table': 'test_table'},
+                ),
+            ],
+        )
+        self.assertIn('cleanup failed', logs.output[0])
+
+    def test_cleanup_exhaustion_is_propagated_after_one_committed_swap(self):
+        """State must be withheld when the old table cannot be removed."""
+        cleanup_error = RuntimeError('cleanup failed')
+        self.snowflake.query = MagicMock(
+            side_effect=[None, cleanup_error, cleanup_error, cleanup_error]
+        )
+
+        with self.assertRaisesRegex(RuntimeError, 'cleanup failed'):
+            self.snowflake.swap_tables(schema='test_schema', table_name='test_table')
+
+        self.assertEqual(
+            self.snowflake.query.call_args_list[0],
+            call(
+                'ALTER TABLE test_schema."TEST_TABLE_TEMP" '
+                'SWAP WITH test_schema."TEST_TABLE"',
+                query_tag_props={'schema': 'test_schema', 'table': 'test_table'},
+            ),
+        )
+        self.assertEqual(
+            self.snowflake.query.call_args_list[1:],
+            [
+                call(
+                    'DROP TABLE IF EXISTS test_schema."TEST_TABLE_TEMP"',
+                    query_tag_props={'schema': 'test_schema', 'table': 'test_table'},
+                )
+            ] * 3,
+        )
+
+    def test_publication_failure_is_propagated(self):
+        """The staging DROP is non-fatal only after the table swap succeeds."""
+        self.snowflake.query = MagicMock(side_effect=RuntimeError('swap failed'))
+
+        with self.assertRaisesRegex(RuntimeError, 'swap failed'):
+            self.snowflake.swap_tables(schema='test_schema', table_name='test_table')
+
+        self.snowflake.query.assert_called_once_with(
+            'ALTER TABLE test_schema."TEST_TABLE_TEMP" SWAP WITH test_schema."TEST_TABLE"',
+            query_tag_props={'schema': 'test_schema', 'table': 'test_table'},
+        )
+
+    @patch('pipelinewise.fastsync.commons.target_snowflake.os.remove')
+    @patch('pipelinewise.fastsync.commons.target_snowflake.SnowflakeEncryptionUtil.encrypt_file')
+    def test_encrypted_upload_failure_removes_temporary_file(self, encrypt_file, remove):
+        """An S3 failure removes the encrypted staging copy."""
+        metadata = MagicMock(key='encrypted-key', iv='initial-vector')
+        encrypt_file.return_value = (metadata, '/tmp/encrypted-part')
+        self.snowflake.connection_config['client_side_encryption_master_key'] = 'master-key'
+        self.snowflake.s3 = MagicMock()
+        self.snowflake.s3.upload_file.side_effect = RuntimeError('upload failed')
+
+        with self.assertRaisesRegex(RuntimeError, 'upload failed'):
+            self.snowflake.upload_to_s3('/tmp/plain-part', tmp_dir='/tmp')
+
+        remove.assert_called_once_with('/tmp/encrypted-part')
+
+    @patch(
+        'pipelinewise.fastsync.commons.target_snowflake.os.remove',
+        side_effect=OSError('cleanup failed'),
+    )
+    @patch('pipelinewise.fastsync.commons.target_snowflake.SnowflakeEncryptionUtil.encrypt_file')
+    def test_encrypted_cleanup_failure_returns_uploaded_key(self, encrypt_file, remove):
+        """Local cleanup cannot hide a successfully uploaded key."""
+        metadata = MagicMock(key='encrypted-key', iv='initial-vector')
+        encrypt_file.return_value = (metadata, '/tmp/encrypted-part')
+        self.snowflake.connection_config['client_side_encryption_master_key'] = 'master-key'
+        self.snowflake.s3 = MagicMock()
+
+        with self.assertLogs(
+            'pipelinewise.fastsync.commons.target_snowflake', level='WARNING'
+        ) as logs:
+            s3_key = self.snowflake.upload_to_s3('/tmp/plain-part', tmp_dir='/tmp')
+
+        self.assertEqual(s3_key, 'plain-part')
+        remove.assert_called_once_with('/tmp/encrypted-part')
+        self.assertIn('Failed to remove encrypted staging file', logs.output[0])
+
+    def test_create_swap_target_does_not_mutate_existing_primary_keys(self):
+        """A FullSync swap placeholder does not alter the live table."""
+        self.snowflake.create_table(
+            target_schema='test_schema',
+            table_name='test_table',
+            columns=['"ID" INTEGER', '"TXT" VARCHAR'],
+            primary_key=['"ID"'],
+            allow_replace_table=False,
+            normalize_primary_keys=False,
+        )
+
+        self.assertListEqual(self.snowflake.executed_queries, [
+            'CREATE TABLE IF NOT EXISTS "TEST_SCHEMA"."TEST_TABLE" ('
+            '"ID" INTEGER,"TXT" VARCHAR,'
+            '_SDC_EXTRACTED_AT TIMESTAMP_NTZ,'
+            '_SDC_BATCHED_AT TIMESTAMP_NTZ,'
+            '_SDC_DELETED_AT VARCHAR'
+            ', PRIMARY KEY ("ID"))'
+        ])

--- a/tests/units/fastsync/commons/test_fastsync_utils.py
+++ b/tests/units/fastsync/commons/test_fastsync_utils.py
@@ -1,7 +1,10 @@
 import argparse
+import fcntl
+import multiprocessing
 import os
 import pytest
 
+from tempfile import TemporaryDirectory
 from unittest import TestCase, mock
 from unittest.mock import patch
 
@@ -9,6 +12,12 @@ from pipelinewise.fastsync.commons import utils
 from pipelinewise.fastsync.commons.utils import NotSelectedTableException
 
 RESOURCES_DIR = '{}/resources'.format(os.path.dirname(__file__))
+
+
+def _save_state_worker(state_path, table, bookmark, ready, finished):
+    ready.set()
+    utils.save_state_file(state_path, table, bookmark)
+    finished.set()
 
 
 # pylint: disable=missing-function-docstring,invalid-name,too-few-public-methods
@@ -56,10 +65,355 @@ class S3CsvMock:
         return {'modified_since': '2019-11-15T07:39:44.171098'}
 
 
-class TestFastSyncUtils(TestCase):
+class TestFastSyncUtils(TestCase):  # pylint: disable=too-many-public-methods
     """
     Unit tests for fastsync common functions
     """
+
+    def test_save_state_file_logs_completed_stream_write(self):
+        """The completion marker is emitted only after atomic persistence succeeds."""
+        with TemporaryDirectory() as temp_directory, self.assertLogs(
+            utils.LOGGER, level='INFO'
+        ) as logs:
+            utils.save_state_file(
+                f'{temp_directory}/state.json',
+                'public.table',
+                {'lsn': '16/B374D848'},
+            )
+
+        self.assertIn(
+            'INFO:pipelinewise.fastsync.commons.utils:'
+            'FastSync state updated for stream: public-table',
+            logs.output,
+        )
+
+    @patch('pipelinewise.fastsync.commons.utils.save_dict_to_json')
+    def test_save_state_file_does_not_log_completed_write_on_failure(self, save_mock):
+        """A failed atomic replace cannot produce a successful state marker."""
+        save_mock.side_effect = OSError('state write failed')
+        with TemporaryDirectory() as temp_directory, patch.object(
+            utils.LOGGER, 'info'
+        ) as log_mock, self.assertRaisesRegex(OSError, 'state write failed'):
+            utils.save_state_file(
+                f'{temp_directory}/state.json',
+                'public.table',
+                {'lsn': '16/B374D848'},
+            )
+
+        log_mock.assert_not_called()
+
+    def test_save_state_file_serializes_independent_processes(self):
+        """Concurrent writers must retain every table bookmark."""
+        context = multiprocessing.get_context('spawn')
+        processes = []
+
+        with TemporaryDirectory() as temp_directory:
+            state_path = f'{temp_directory}/state.json'
+            ready_events = [context.Event(), context.Event()]
+            finished_events = [context.Event(), context.Event()]
+            lock_path = f'{os.path.realpath(state_path)}.lock'
+
+            try:
+                with open(lock_path, 'a', encoding='utf-8') as lock_file:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                    for index in range(2):
+                        process = context.Process(
+                            target=_save_state_worker,
+                            args=(
+                                state_path,
+                                f'schema.table_{index}',
+                                {'position': index},
+                                ready_events[index],
+                                finished_events[index],
+                            ),
+                        )
+                        process.start()
+                        processes.append(process)
+
+                    for ready in ready_events:
+                        self.assertTrue(ready.wait(timeout=10))
+                    self.assertFalse(
+                        any(finished.wait(timeout=0.5) for finished in finished_events)
+                    )
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+                for process in processes:
+                    process.join(timeout=10)
+                    self.assertEqual(process.exitcode, 0)
+
+                self.assertEqual(
+                    utils.load_json(state_path)['bookmarks'],
+                    {
+                        'schema-table_0': {'position': 0},
+                        'schema-table_1': {'position': 1},
+                    },
+                )
+            finally:
+                for process in processes:
+                    if process.is_alive():
+                        process.terminate()
+                    process.join(timeout=10)
+
+    def test_upload_files_to_s3_uploads_all_parts_before_local_cleanup(self):
+        """Every remote upload completes before any local source part is removed."""
+        with TemporaryDirectory() as temp_directory:
+            file_parts = [
+                os.path.join(temp_directory, 'export.part0'),
+                os.path.join(temp_directory, 'export.part1'),
+            ]
+            for file_part in file_parts:
+                with open(file_part, 'w', encoding='utf8') as export_file:
+                    export_file.write('data')
+
+            snowflake = mock.MagicMock()
+
+            def upload(file_part, tmp_dir=None):
+                self.assertEqual(tmp_dir, temp_directory)
+                self.assertTrue(all(os.path.exists(path) for path in file_parts))
+                return f'loads/{os.path.basename(file_part)}'
+
+            snowflake.upload_to_s3.side_effect = upload
+
+            s3_keys, s3_pattern = utils.upload_files_to_s3(
+                snowflake, file_parts, temp_directory, 'staging-bucket'
+            )
+
+            self.assertEqual(
+                s3_keys,
+                ['loads/export.part0', 'loads/export.part1'],
+            )
+            self.assertEqual(s3_pattern, 'loads/export')
+            self.assertTrue(all(not os.path.exists(path) for path in file_parts))
+
+    def test_upload_files_to_s3_rolls_back_remote_parts_on_local_cleanup_failure(self):
+        """A local cleanup failure removes every successfully uploaded remote part."""
+        file_parts = ['/tmp/export.part0', '/tmp/export.part1']
+        snowflake = mock.MagicMock()
+        snowflake.upload_to_s3.side_effect = [
+            'loads/export.part0',
+            'loads/export.part1',
+        ]
+
+        with patch(
+            'pipelinewise.fastsync.commons.utils.os.remove',
+            side_effect=PermissionError('local cleanup failed'),
+        ), self.assertRaisesRegex(PermissionError, 'local cleanup failed'):
+            utils.upload_files_to_s3(
+                snowflake, file_parts, '/tmp', 'staging-bucket'
+            )
+
+        self.assertEqual(snowflake.s3.delete_object.call_args_list, [
+            mock.call(Bucket='staging-bucket', Key='loads/export.part0'),
+            mock.call(Bucket='staging-bucket', Key='loads/export.part1'),
+        ])
+
+    def test_run_post_publication_actions_reports_all_failures(self):
+        """Every post-publication action runs and each failure is identified."""
+        actions_run = []
+
+        def fail_state():
+            actions_run.append('state')
+            raise RuntimeError('state failed')
+
+        def fail_grants():
+            actions_run.append('grants')
+            raise RuntimeError('grant failed')
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'Post-publication actions failed: state persistence: state failed; '
+            'grant application: grant failed',
+        ):
+            utils.run_post_publication_actions([
+                ('state persistence', fail_state),
+                ('grant application', fail_grants),
+            ])
+
+        self.assertEqual(actions_run, ['state', 'grants'])
+
+    def test_apply_snowflake_grants_attempts_usage_and_select(self):
+        """A failed usage grant cannot prevent the independent select grant."""
+        snowflake = mock.MagicMock()
+        snowflake.grant_usage_on_schema.side_effect = RuntimeError(
+            'usage grant failed'
+        )
+        target_config = {
+            'default_target_schema_select_permissions': ['reporting_role']
+        }
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'schema usage grant: Privilege grants failed: '
+            'reporting_role: usage grant failed',
+        ):
+            utils.apply_snowflake_table_grants(
+                snowflake,
+                target_config,
+                'TARGET_SCHEMA',
+                'source.table',
+            )
+
+        snowflake.grant_usage_on_schema.assert_called_once_with(
+            'TARGET_SCHEMA', 'reporting_role', False
+        )
+        snowflake.grant_select_on_table.assert_called_once_with(
+            'TARGET_SCHEMA',
+            'source.table',
+            'reporting_role',
+            is_temporary=False,
+            to_group=False,
+        )
+        snowflake.grant_select_on_schema.assert_not_called()
+
+    def test_apply_snowflake_grants_attempts_every_role_and_staging_table(self):
+        """One invalid role cannot skip later roles or expose the raw live table."""
+        snowflake = mock.MagicMock()
+
+        def fail_first_usage(_schema, role, *_args, **_kwargs):
+            if role == 'bad_role':
+                raise RuntimeError('unknown role')
+
+        def fail_first_select(_schema, _table, role, *_args, **_kwargs):
+            if role == 'bad_role':
+                raise RuntimeError('unknown role')
+
+        snowflake.grant_usage_on_schema.side_effect = fail_first_usage
+        snowflake.grant_select_on_table.side_effect = fail_first_select
+        target_config = {
+            'default_target_schema_select_permissions': [
+                'bad_role',
+                'reporting_role',
+            ]
+        }
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'schema usage grant: .*bad_role.*live table select grant: .*bad_role',
+        ):
+            utils.apply_snowflake_table_grants(
+                snowflake,
+                target_config,
+                'TARGET_SCHEMA',
+                'source.table',
+                is_temporary=True,
+            )
+
+        self.assertEqual(snowflake.grant_usage_on_schema.call_args_list, [
+            mock.call('TARGET_SCHEMA', 'bad_role', False),
+            mock.call('TARGET_SCHEMA', 'reporting_role', False),
+        ])
+        self.assertEqual(snowflake.grant_select_on_table.call_args_list, [
+            mock.call(
+                'TARGET_SCHEMA',
+                'source.table',
+                'bad_role',
+                is_temporary=True,
+                to_group=False,
+            ),
+            mock.call(
+                'TARGET_SCHEMA',
+                'source.table',
+                'reporting_role',
+                is_temporary=True,
+                to_group=False,
+            ),
+        ])
+
+    def test_fullsync_finalizer_attempts_cleanup_and_grants_before_failing(self):
+        """Every post-publication prerequisite runs despite sibling failures."""
+        snowflake = mock.MagicMock()
+        timeline = []
+
+        def fail(name, message):
+            def side_effect(*_args, **_kwargs):
+                timeline.append(name)
+                raise RuntimeError(message)
+
+            return side_effect
+
+        snowflake.s3.delete_object.side_effect = fail('S3 cleanup', 'S3 delete failed')
+        snowflake.drop_table.side_effect = fail('table cleanup', 'table drop failed')
+        snowflake.grant_usage_on_schema.side_effect = fail(
+            'usage grant', 'usage grant failed'
+        )
+        snowflake.grant_select_on_table.side_effect = (
+            lambda *_args, **_kwargs: timeline.append('select grant')
+        )
+        target_config = {
+            'default_target_schema_select_permissions': ['reporting_role']
+        }
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'grant application: .*S3 staging cleanup: .*Snowflake staging cleanup:',
+        ):
+            utils.finalize_snowflake_fullsync(
+                snowflake,
+                ['staging/part.csv.gz'],
+                'staging-bucket',
+                target_config,
+                'TARGET_SCHEMA',
+                'source.table',
+            )
+
+        self.assertEqual(snowflake.s3.delete_object.call_count, 3)
+        snowflake.drop_table.assert_called_once_with(
+            'TARGET_SCHEMA',
+            'source.table',
+            is_temporary=True,
+            max_attempts=3,
+        )
+        snowflake.grant_usage_on_schema.assert_called_once_with(
+            'TARGET_SCHEMA', 'reporting_role', False
+        )
+        snowflake.grant_select_on_table.assert_called_once_with(
+            'TARGET_SCHEMA',
+            'source.table',
+            'reporting_role',
+            is_temporary=False,
+            to_group=False,
+        )
+        snowflake.grant_select_on_schema.assert_not_called()
+        self.assertEqual(
+            timeline,
+            [
+                'usage grant',
+                'select grant',
+                'S3 cleanup',
+                'S3 cleanup',
+                'S3 cleanup',
+                'table cleanup',
+            ],
+        )
+
+    def test_fullsync_finalizer_preserves_publication_and_cleanup_failures(self):
+        """A cleanup failure cannot replace the original ambiguous SWAP error."""
+        snowflake = mock.MagicMock()
+        snowflake.grant_usage_on_schema.side_effect = RuntimeError(
+            'grant failed'
+        )
+        target_config = {
+            'default_target_schema_select_permissions': ['reporting_role']
+        }
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'swap failed; post-publication finalization failed: .*grant failed',
+        ):
+            utils.finalize_snowflake_fullsync(
+                snowflake,
+                ['staging/part.csv.gz'],
+                'staging-bucket',
+                target_config,
+                'TARGET_SCHEMA',
+                'source.table',
+                publication_error=RuntimeError('swap failed'),
+            )
+
+        snowflake.s3.delete_object.assert_called_once_with(
+            Bucket='staging-bucket', Key='staging/part.csv.gz'
+        )
+        snowflake.drop_table.assert_called_once()
 
     def test_tablename_to_dict(self):
         """Test identifying schema and table names from fully qualified table names"""

--- a/tests/units/fastsync/commons/test_fastsync_utils_atomic.py
+++ b/tests/units/fastsync/commons/test_fastsync_utils_atomic.py
@@ -1,0 +1,107 @@
+import os
+
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import pytest
+
+from pipelinewise.fastsync.commons import utils
+from pipelinewise.fastsync.commons.target_snowflake import FastSyncTargetSnowflake
+
+
+def test_later_upload_failure_rolls_back():
+    """A failed later part removes prior uploads and preserves local exports."""
+    with TemporaryDirectory() as temp_directory:
+        file_parts = [
+            os.path.join(temp_directory, 'export.part0'),
+            os.path.join(temp_directory, 'export.part1'),
+        ]
+        for file_part in file_parts:
+            with open(file_part, 'w', encoding='utf8') as export_file:
+                export_file.write('data')
+
+        snowflake = object.__new__(FastSyncTargetSnowflake)
+        snowflake.connection_config = {'s3_key_prefix': 'loads/'}
+        snowflake.s3 = mock.MagicMock()
+        snowflake.upload_to_s3 = mock.Mock(side_effect=[
+            'loads/export.part0',
+            RuntimeError('second upload failed'),
+        ])
+
+        with pytest.raises(RuntimeError, match='second upload failed'):
+            utils.upload_files_to_s3(
+                snowflake, file_parts, temp_directory, 'staging-bucket'
+            )
+
+        assert all(os.path.exists(path) for path in file_parts)
+        assert snowflake.s3.delete_object.call_args_list == [
+            mock.call(Bucket='staging-bucket', Key='loads/export.part0'),
+            mock.call(Bucket='staging-bucket', Key='loads/export.part1'),
+        ]
+
+
+def test_atomic_save_preserves_valid_state():
+    """A partial temporary write cannot truncate the last valid state file."""
+    with TemporaryDirectory() as temp_directory:
+        state_path = os.path.join(temp_directory, 'state.json')
+        original_state = '{"bookmarks": {"source-table": {"position": 1}}}\n'
+        with open(state_path, 'w', encoding='utf-8') as state_file:
+            state_file.write(original_state)
+
+        def fail_after_partial_write(_data, file_handle, **_kwargs):
+            file_handle.write('{"bookmarks":')
+            raise TypeError('not serializable')
+
+        with mock.patch.object(
+            utils.json, 'dump', side_effect=fail_after_partial_write
+        ), pytest.raises(TypeError, match='not serializable'):
+            utils.save_dict_to_json(state_path, {'not': object()})
+
+        with open(state_path, encoding='utf-8') as state_file:
+            assert state_file.read() == original_state
+        assert not any(
+            name.startswith('.state.json.') and name.endswith('.tmp')
+            for name in os.listdir(temp_directory)
+        )
+
+
+def test_state_rename_fsyncs_directory():
+    """The durable rename is flushed only after the new state path exists."""
+    with TemporaryDirectory() as temp_directory:
+        state_path = os.path.join(temp_directory, 'state.json')
+        timeline = []
+        replace = os.replace
+
+        def replace_and_record(source, target):
+            replace(source, target)
+            timeline.append('replace')
+
+        with mock.patch.object(
+            utils.os,
+            'replace',
+            side_effect=replace_and_record,
+        ), mock.patch.object(
+            utils,
+            '_fsync_directory',
+            side_effect=lambda directory: timeline.append(('fsync', directory)),
+        ):
+            utils.save_dict_to_json(state_path, {'bookmark': 1})
+
+        assert timeline == ['replace', ('fsync', temp_directory)]
+
+
+def test_transient_grants_are_retried():
+    """A transient post-publication grant failure does not force republish."""
+    with mock.patch.object(
+        utils,
+        'apply_snowflake_table_grants',
+        side_effect=[RuntimeError('transient failure'), None],
+    ) as apply_mock:
+        utils.retry_snowflake_table_grants(
+            mock.sentinel.snowflake,
+            {'default_target_schema_select_permissions': ['role']},
+            'TARGET_SCHEMA',
+            'source.table',
+        )
+
+    assert apply_mock.call_count == 2

--- a/tests/units/fastsync/test_mysql_to_snowflake.py
+++ b/tests/units/fastsync/test_mysql_to_snowflake.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest.mock import call
+
 from . import assertions
 
 from pipelinewise.fastsync.mysql_to_snowflake import (
@@ -13,7 +15,7 @@ TARGET = 'FastSyncTargetSnowflake'
 
 
 # pylint: disable=missing-function-docstring,invalid-name
-class S3CsvToPostgres(unittest.TestCase):
+class MySqlToSnowflake(unittest.TestCase):
     """
     Unit tests for fastsync mysql to snowflake
     """
@@ -40,14 +42,83 @@ class S3CsvToPostgres(unittest.TestCase):
 
     @staticmethod
     def test_sync_table_runs_successfully_returns_true():
-        assertions.assert_sync_table_returns_true_on_success(
-            sync_table, PACKAGE_IN_SCOPE, TAP, TARGET
+        assertions.assert_snowflake_sync_table_native_workflow(
+            sync_table, PACKAGE_IN_SCOPE, TAP, source_type='mysql',
+            type_mapper=tap_type_to_target_type,
+        )
+
+    @staticmethod
+    def test_sync_table_publish_failure_does_not_save_state():
+        assertions.assert_snowflake_sync_table_native_workflow(
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            source_type='mysql',
+            type_mapper=tap_type_to_target_type,
+            publish_error=RuntimeError('publish failed'),
+        )
+
+    @staticmethod
+    def test_sync_table_reports_state_failure():
+        assertions.assert_snowflake_sync_table_native_workflow(
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            source_type='mysql',
+            type_mapper=tap_type_to_target_type,
+            state_error=RuntimeError('state failed'),
+        )
+
+    @staticmethod
+    def test_sync_table_grant_failure_withholds_state():
+        assertions.assert_snowflake_sync_table_native_workflow(
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            source_type='mysql',
+            type_mapper=tap_type_to_target_type,
+            grant_error=RuntimeError('grant failed'),
+        )
+
+    @staticmethod
+    def test_sync_table_preserves_publication_and_finalization_failures():
+        assertions.assert_snowflake_sync_table_native_workflow(
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            source_type='mysql',
+            type_mapper=tap_type_to_target_type,
+            publish_error=RuntimeError('publish failed'),
+            grant_error=RuntimeError('grant failed'),
+        )
+
+    @staticmethod
+    def test_sync_table_later_upload_failure_rolls_back_staging():
+        assertions.assert_snowflake_sync_table_rolls_back_later_upload_failure(
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            source_type='mysql',
+        )
+
+    @staticmethod
+    def test_sync_table_reports_and_retries_upload_cleanup_debt():
+        assertions.assert_snowflake_sync_table_rolls_back_later_upload_failure(
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            source_type='mysql',
+            rollback_cleanup_error=RuntimeError('delete failed'),
         )
 
     @staticmethod
     def test_sync_table_exception_on_copy_table_returns_failed_table_name_and_exception():
         assertions.assert_sync_table_exception_on_failed_copy(
-            sync_table, PACKAGE_IN_SCOPE, TAP, TARGET
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            TARGET,
+            expected_cleanup=call.close_connections(silent=True),
         )
 
     @staticmethod

--- a/tests/units/fastsync/test_postgres_to_snowflake.py
+++ b/tests/units/fastsync/test_postgres_to_snowflake.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest.mock import call
+
 from . import assertions
 
 from pipelinewise.fastsync.postgres_to_snowflake import (
@@ -21,7 +23,42 @@ class PostgresToSnowflake(unittest.TestCase):
     def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(
         self,
     ):
-        self.assertEqual('NUMBER', tap_type_to_target_type('serial'))
+        type_mappings = {
+            'char': 'VARCHAR',
+            'character': 'VARCHAR',
+            'varchar': 'VARCHAR',
+            'character varying': 'VARCHAR',
+            'text': 'VARCHAR',
+            'bit': 'BOOLEAN',
+            'varbit': 'NUMBER',
+            'bit varying': 'NUMBER',
+            'smallint': 'NUMBER',
+            'int': 'NUMBER',
+            'integer': 'NUMBER',
+            'bigint': 'NUMBER',
+            'smallserial': 'NUMBER',
+            'serial': 'NUMBER',
+            'bigserial': 'NUMBER',
+            'numeric': 'FLOAT',
+            'double precision': 'FLOAT',
+            'real': 'FLOAT',
+            'bool': 'BOOLEAN',
+            'boolean': 'BOOLEAN',
+            'date': 'TIMESTAMP_NTZ',
+            'timestamp': 'TIMESTAMP_NTZ',
+            'timestamp without time zone': 'TIMESTAMP_NTZ',
+            'timestamp with time zone': 'TIMESTAMP_NTZ',
+            'time': 'TIME',
+            'time without time zone': 'TIME',
+            'time with time zone': 'TIME',
+            'ARRAY': 'VARIANT',
+            'json': 'VARIANT',
+            'jsonb': 'VARIANT',
+        }
+
+        for source_type, expected_type in type_mappings.items():
+            with self.subTest(source_type=source_type):
+                self.assertEqual(expected_type, tap_type_to_target_type(source_type))
 
     def test_tap_type_to_target_type_with_undefined_tap_type_returns_CHARACTER_VARYING(
         self,
@@ -30,14 +67,83 @@ class PostgresToSnowflake(unittest.TestCase):
 
     @staticmethod
     def test_sync_table_runs_successfully_returns_true():
-        assertions.assert_sync_table_returns_true_on_success(
-            sync_table, PACKAGE_IN_SCOPE, TAP, TARGET
+        assertions.assert_snowflake_sync_table_native_workflow(
+            sync_table, PACKAGE_IN_SCOPE, TAP, source_type='postgres',
+            type_mapper=tap_type_to_target_type,
+        )
+
+    @staticmethod
+    def test_sync_table_publish_failure_does_not_save_state():
+        assertions.assert_snowflake_sync_table_native_workflow(
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            source_type='postgres',
+            type_mapper=tap_type_to_target_type,
+            publish_error=RuntimeError('publish failed'),
+        )
+
+    @staticmethod
+    def test_sync_table_reports_state_failure():
+        assertions.assert_snowflake_sync_table_native_workflow(
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            source_type='postgres',
+            type_mapper=tap_type_to_target_type,
+            state_error=RuntimeError('state failed'),
+        )
+
+    @staticmethod
+    def test_sync_table_grant_failure_withholds_state():
+        assertions.assert_snowflake_sync_table_native_workflow(
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            source_type='postgres',
+            type_mapper=tap_type_to_target_type,
+            grant_error=RuntimeError('grant failed'),
+        )
+
+    @staticmethod
+    def test_sync_table_preserves_publication_and_finalization_failures():
+        assertions.assert_snowflake_sync_table_native_workflow(
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            source_type='postgres',
+            type_mapper=tap_type_to_target_type,
+            publish_error=RuntimeError('publish failed'),
+            grant_error=RuntimeError('grant failed'),
+        )
+
+    @staticmethod
+    def test_sync_table_later_upload_failure_rolls_back_staging():
+        assertions.assert_snowflake_sync_table_rolls_back_later_upload_failure(
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            source_type='postgres',
+        )
+
+    @staticmethod
+    def test_sync_table_reports_and_retries_upload_cleanup_debt():
+        assertions.assert_snowflake_sync_table_rolls_back_later_upload_failure(
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            source_type='postgres',
+            rollback_cleanup_error=RuntimeError('delete failed'),
         )
 
     @staticmethod
     def test_sync_table_exception_on_copy_table_returns_failed_table_name_and_exception():
         assertions.assert_sync_table_exception_on_failed_copy(
-            sync_table, PACKAGE_IN_SCOPE, TAP, TARGET
+            sync_table,
+            PACKAGE_IN_SCOPE,
+            TAP,
+            TARGET,
+            expected_cleanup=call.close_connection(silent=True),
         )
 
     @staticmethod

--- a/tests/units/partialsync/test_mysql_to_snowflake.py
+++ b/tests/units/partialsync/test_mysql_to_snowflake.py
@@ -35,6 +35,123 @@ class PartialSyncTestCase(TestCase):
 
         self.assertEqual(f'{args.table}: {exception_message}', actual_return)
 
+    @mock.patch('pipelinewise.fastsync.commons.utils.save_state_file')
+    @mock.patch('pipelinewise.fastsync.commons.utils.get_bookmark_for_table', return_value='bookmark')
+    @mock.patch(
+        'pipelinewise.fastsync.partialsync.utils.upload_to_s3',
+        return_value=(['s3-key'], 's3-pattern'),
+    )
+    @mock.patch('pipelinewise.fastsync.partialsync.mysql_to_snowflake.FastSyncTapMySql')
+    @mock.patch('pipelinewise.fastsync.partialsync.mysql_to_snowflake.FastSyncTargetSnowflake')
+    def test_mysql_partial_sync_failure_state_semantics(
+        self, mocked_fastsync_sf, mocked_fastsyncmysql, _mocked_upload, _mocked_bookmark, mocked_save_state
+    ):
+        """Publication and staging-cleanup failures all withhold state."""
+        for failure_method, error_message in (
+            ('copy_to_table', 'copy failed'),
+            ('publish_partial_sync', 'transaction failed'),
+            ('drop_table', 'cleanup failed'),
+        ):
+            with self.subTest(failure_method=failure_method), TemporaryDirectory() as temp_directory:
+                args = PartialSync2SFArgs(temp_test_dir=temp_directory, end_value=None)
+                test_table = ('foo', {
+                    'column': 'foo_column',
+                    'start_value': '<S>1',
+                    'end_value': None,
+                    'drop_target_table': False,
+                })
+                file_part = f'{temp_directory}/part.csv.gz'
+                with open(file_part, 'w', encoding='utf8') as exported_file:
+                    exported_file.write('data')
+
+                source = mock.MagicMock()
+                source.export_source_table_data.return_value = [file_part]
+                source.map_column_types_to_target.return_value = {
+                    'columns': ['"ID" NUMBER'],
+                    'primary_key': ['"ID"'],
+                }
+                mocked_fastsyncmysql.return_value = source
+
+                snowflake = mock.MagicMock()
+                snowflake.query.return_value = []
+                getattr(snowflake, failure_method).side_effect = RuntimeError(error_message)
+                mocked_fastsync_sf.return_value = snowflake
+                mocked_save_state.reset_mock()
+
+                result = mysql_to_snowflake.partial_sync_table(test_table, args)
+
+                source.close_connections.assert_called_once_with(silent=True)
+                if failure_method == 'drop_table':
+                    self.assertIn('foo: cleanup failed; staging cleanup failed:', result)
+                else:
+                    self.assertEqual(f'foo: {error_message}', result)
+                mocked_save_state.assert_not_called()
+                snowflake.s3.delete_object.assert_called_once_with(
+                    Bucket=args.target['s3_bucket'], Key='s3-key'
+                )
+
+                if failure_method == 'copy_to_table':
+                    snowflake.obfuscate_columns.assert_not_called()
+                    snowflake.publish_partial_sync.assert_not_called()
+                    self.assertEqual(snowflake.create_table.call_count, 1)
+                elif failure_method == 'publish_partial_sync':
+                    snowflake.copy_to_table.assert_called_once_with(
+                        's3-pattern', 'foo_schema', 'foo', 4, is_temporary=True
+                    )
+                    snowflake.publish_partial_sync.assert_called_once()
+                expected_drop_call = mock.call(
+                    'foo_schema',
+                    'foo',
+                    is_temporary=True,
+                    max_attempts=3,
+                )
+                self.assertEqual(
+                    snowflake.drop_table.call_args_list,
+                    [expected_drop_call]
+                    * (2 if failure_method == 'drop_table' else 1),
+                )
+
+    @mock.patch('pipelinewise.fastsync.commons.utils.save_state_file')
+    @mock.patch(
+        'pipelinewise.fastsync.commons.utils.get_bookmark_for_table',
+        return_value='bookmark',
+    )
+    @mock.patch('pipelinewise.fastsync.partialsync.mysql_to_snowflake.FastSyncTapMySql')
+    @mock.patch('pipelinewise.fastsync.partialsync.mysql_to_snowflake.FastSyncTargetSnowflake')
+    def test_mysql_empty_unbounded_sync_publishes_and_advances_state(
+        self,
+        mocked_fastsync_sf,
+        mocked_fastsyncmysql,
+        _mocked_bookmark,
+        mocked_save_state,
+    ):
+        """An empty MariaDB/MySQL export still publishes its range and bookmark."""
+        args = PartialSync2SFArgs(temp_test_dir='FOO_DIR', end_value=None)
+        test_table = ('foo', {
+            'column': 'foo_column',
+            'start_value': '<S>1',
+            'end_value': None,
+            'drop_target_table': False,
+        })
+        source = mocked_fastsyncmysql.return_value
+        source.export_source_table_data.return_value = []
+        source.map_column_types_to_target.return_value = {
+            'columns': ['"ID" NUMBER'],
+            'primary_key': ['"ID"'],
+        }
+        snowflake = mocked_fastsync_sf.return_value
+        snowflake.query.return_value = []
+
+        result = mysql_to_snowflake.partial_sync_table(test_table, args)
+
+        self.assertIs(result, True)
+        snowflake.copy_to_table.assert_called_once_with(
+            'NO_FILES_TO_LOAD', 'foo_schema', 'foo', 0, is_temporary=True
+        )
+        snowflake.publish_partial_sync.assert_called_once()
+        snowflake.s3.delete_object.assert_not_called()
+        mocked_save_state.assert_called_once_with(args.state, 'foo', 'bookmark')
+
     def test_export_source_table_data(self):
         """Test export_source_table_data method"""
         expected_file_parts = []
@@ -198,7 +315,6 @@ class PartialSyncTestCase(TestCase):
             with TemporaryDirectory() as temp_directory:
                 file_size = 5
                 file_parts = [f'{temp_directory}/t1', ]
-                s3_keys = ['FOO_S3_KEYS', ]
                 s3_key_pattern = 'BAR_S3_KEY_PATTERN'
                 bookmark = 'foo_bookmark'
                 maped_column_types_to_target = {
@@ -213,39 +329,39 @@ class PartialSyncTestCase(TestCase):
 
                     return file_parts
 
-                mocked_upload_to_s3.return_value = (s3_keys, s3_key_pattern)
+                mocked_upload_to_s3.return_value = (['FOO_S3_KEYS'], s3_key_pattern)
                 mocked_bookmark.return_value = bookmark
                 mocked_export_data = mocked_fastsyncmysql.return_value.export_source_table_data
                 mocked_fastsyncmysql.return_value.map_column_types_to_target.return_value = maped_column_types_to_target
                 mocked_export_data.side_effect = export_data_to_file
 
                 actual_return = mysql_to_snowflake.partial_sync_table(test_table, args)
-                self.assertTrue(actual_return)
+                self.assertIs(actual_return, True)
+
+                mocked_fastsyncmysql.assert_called_once_with(
+                    args.tap, mysql_to_snowflake.tap_type_to_target_type
+                )
 
                 target = {
                     'schema': 'foo_schema',
                     'sf_object': mocked_fastsync_sf(),
                     'table': table_name,
-                    'temp': 'foo_temp'
+                    'temp': 'foo_temp',
+                    'publication_status': {'attempted': True},
                 }
-                columns_diff = {
-                    'added_columns': {'bar': 'type2', 'foo': 'type1'},
-                    'removed_columns': {},
-                    'source_columns': {'bar': 'type2', 'foo': 'type1'},
-                    'target_columns': []
-                }
-
-                mocked_fastsync_sf.return_value.query.assert_called_with(
-                    'UPDATE foo_schema."FOO" SET _SDC_DELETEd_AT = CURRENT_TIMESTAMP()'
-                    ' WHERE foo_column >= \'1\' AND _SDC_DELETED_AT IS NULL'
-                )
                 mocked_fastsync_sf.return_value.create_schema.assert_called_with('foo_schema')
-                mocked_fastsync_sf.return_value.create_table.assert_called_with(
+                mocked_fastsync_sf.return_value.create_table.assert_called_once_with(
                     'foo_schema', 'foo', ['foo type1', 'bar type2'], 'foo_primary', is_temporary=True)
+                mocked_fastsync_sf.return_value.query.assert_not_called()
+                mocked_fastsyncmysql.return_value.close_connections.assert_called_once_with(silent=True)
                 mocked_load_into_sf.assert_called_with(
-                    target, args, columns_diff, maped_column_types_to_target['primary_key'],
+                    target, args, maped_column_types_to_target['columns'],
+                    maped_column_types_to_target['primary_key'],
                     s3_key_pattern, file_size,
-                    f" WHERE {test_table[1]['column']} >= '{test_table[1]['start_value'][3:]}'"
+                    f" WHERE {test_table[1]['column']} >= '{test_table[1]['start_value'][3:]}'",
+                )
+                mocked_fastsync_sf.return_value.s3.delete_object.assert_called_once_with(
+                    Bucket=args.target['s3_bucket'], Key='FOO_S3_KEYS'
                 )
 
                 if end_value:

--- a/tests/units/partialsync/test_partial_sync_utils.py
+++ b/tests/units/partialsync/test_partial_sync_utils.py
@@ -1,16 +1,20 @@
+import json
+import os
+
 from unittest import TestCase, mock
 from tempfile import TemporaryDirectory
 
 from pipelinewise.fastsync.partialsync.utils import (
-    load_into_snowflake, upload_to_s3, update_state_file,
-    diff_source_target_columns, validate_boundary_value, get_sync_tables, quote_tag_to_char)
+    DYNAMIC_BOUNDARY_NOT_READY, delete_s3_objects, load_into_snowflake, upload_to_s3,
+    update_state_file, diff_source_target_columns, validate_boundary_value, get_sync_tables,
+    quote_tag_to_char)
 from pipelinewise.cli.errors import InvalidConfigException
 
 from tests.units.partialsync.utils import PartialSync2SFArgs
 from tests.units.partialsync.resources.test_partial_sync_utils.sample_sf_columns import SAMPLE_OUTPUT_FROM_SF
 
 
-class PartialSyncUtilsTestCase(TestCase):
+class PartialSyncUtilsTestCase(TestCase):  # pylint: disable=too-many-public-methods
     """Test case for partial sync utils"""
 
     def test_upload_to_s3(self):
@@ -29,72 +33,264 @@ class PartialSyncUtilsTestCase(TestCase):
             actual_return = upload_to_s3(mocked_snowflake, [test_file_part], temp_test_dir)
             self.assertTupleEqual(([test_s3_key], test_s3_key), actual_return)
             mocked_upload_to_s3.assert_called_with(test_file_part, tmp_dir=temp_test_dir)
+            self.assertFalse(os.path.exists(test_file_part))
+
+    def test_upload_to_s3_preserves_local_file_if_upload_fails(self):
+        """A failed upload must leave its local part available for diagnosis or retry."""
+        with TemporaryDirectory() as temp_test_dir:
+            test_file_part = f'{temp_test_dir}/foo.gz1'
+            with open(test_file_part, 'w', encoding='utf8') as file_to_test:
+                file_to_test.write('bar')
+
+            mocked_snowflake = mock.MagicMock()
+            mocked_snowflake.upload_to_s3.side_effect = RuntimeError('upload failed')
+
+            with self.assertRaisesRegex(RuntimeError, 'upload failed'):
+                upload_to_s3(mocked_snowflake, [test_file_part], temp_test_dir)
+
+            mocked_snowflake.upload_to_s3.assert_called_once_with(
+                test_file_part, tmp_dir=temp_test_dir
+            )
+            self.assertTrue(os.path.exists(test_file_part))
+
+    def test_upload_to_s3_cleans_prior_parts_and_preserves_locals_on_later_failure(self):
+        """A later upload failure removes completed remote parts without deleting local inputs."""
+        with TemporaryDirectory() as temp_test_dir:
+            file_parts = [
+                f'{temp_test_dir}/foo.part0',
+                f'{temp_test_dir}/foo.part1',
+            ]
+            for file_part in file_parts:
+                with open(file_part, 'w', encoding='utf8') as file_to_test:
+                    file_to_test.write('bar')
+
+            snowflake = mock.MagicMock()
+            snowflake.connection_config = {'s3_bucket': 'test-bucket'}
+            setattr(
+                snowflake,
+                '_get_s3_key',
+                mock.Mock(
+                    side_effect=['staging/foo.part0', 'staging/foo.part1']
+                ),
+            )
+            snowflake.upload_to_s3.side_effect = [
+                'staging/foo.part0',
+                RuntimeError('second upload failed'),
+            ]
+
+            with self.assertRaisesRegex(RuntimeError, 'second upload failed'):
+                upload_to_s3(snowflake, file_parts, temp_test_dir)
+
+            self.assertEqual(snowflake.upload_to_s3.call_args_list, [
+                mock.call(file_parts[0], tmp_dir=temp_test_dir),
+                mock.call(file_parts[1], tmp_dir=temp_test_dir),
+            ])
+            self.assertEqual(snowflake.s3.delete_object.call_args_list, [
+                mock.call(Bucket='test-bucket', Key='staging/foo.part0'),
+                mock.call(Bucket='test-bucket', Key='staging/foo.part1'),
+            ])
+            self.assertTrue(all(os.path.exists(file_part) for file_part in file_parts))
+
+    def test_upload_to_s3_preserves_cleanup_debt_on_rollback_failure(self):
+        """The caller receives uploaded keys when immediate rollback is exhausted."""
+        with TemporaryDirectory() as temp_test_dir:
+            file_parts = [
+                f'{temp_test_dir}/foo.part0',
+                f'{temp_test_dir}/foo.part1',
+            ]
+            for file_part in file_parts:
+                with open(file_part, 'w', encoding='utf8') as file_to_test:
+                    file_to_test.write('bar')
+
+            snowflake = mock.MagicMock()
+            snowflake.connection_config = {'s3_bucket': 'test-bucket'}
+            setattr(
+                snowflake,
+                '_get_s3_key',
+                mock.Mock(
+                    side_effect=['staging/foo.part0', 'staging/foo.part1']
+                ),
+            )
+            snowflake.upload_to_s3.side_effect = [
+                'staging/foo.part0',
+                RuntimeError('second upload failed'),
+            ]
+            snowflake.s3.delete_object.side_effect = RuntimeError('delete failed')
+
+            with self.assertRaisesRegex(
+                RuntimeError, 'staging upload rollback failed'
+            ) as raised:
+                upload_to_s3(snowflake, file_parts, temp_test_dir)
+
+            self.assertEqual(
+                raised.exception.s3_keys,
+                ['staging/foo.part0', 'staging/foo.part1'],
+            )
+            self.assertEqual(snowflake.s3.delete_object.call_count, 6)
+            self.assertTrue(all(os.path.exists(path) for path in file_parts))
+
+    def test_upload_to_s3_cleans_remote_parts_if_local_cleanup_fails(self):
+        """A local unlink failure cannot leave the completed multipart upload behind."""
+        with TemporaryDirectory() as temp_test_dir:
+            file_parts = [
+                f'{temp_test_dir}/foo.part0',
+                f'{temp_test_dir}/foo.part1',
+            ]
+            for file_part in file_parts:
+                with open(file_part, 'w', encoding='utf8') as file_to_test:
+                    file_to_test.write('bar')
+
+            snowflake = mock.MagicMock()
+            snowflake.connection_config = {'s3_bucket': 'test-bucket'}
+            snowflake.upload_to_s3.side_effect = [
+                'staging/foo.part0',
+                'staging/foo.part1',
+            ]
+
+            with mock.patch(
+                'pipelinewise.fastsync.commons.utils.os.remove',
+                side_effect=PermissionError('local cleanup failed'),
+            ), self.assertRaisesRegex(PermissionError, 'local cleanup failed'):
+                upload_to_s3(snowflake, file_parts, temp_test_dir)
+
+            self.assertEqual(snowflake.upload_to_s3.call_args_list, [
+                mock.call(file_parts[0], tmp_dir=temp_test_dir),
+                mock.call(file_parts[1], tmp_dir=temp_test_dir),
+            ])
+            self.assertEqual(snowflake.s3.delete_object.call_args_list, [
+                mock.call(Bucket='test-bucket', Key='staging/foo.part0'),
+                mock.call(Bucket='test-bucket', Key='staging/foo.part1'),
+            ])
+            self.assertTrue(all(os.path.exists(file_part) for file_part in file_parts))
+
+    def test_delete_s3_objects_retries_and_removes_every_object(self):
+        """A transient deletion failure is retried before later keys are removed."""
+        snowflake = mock.MagicMock()
+        snowflake.s3.delete_object.side_effect = [
+            RuntimeError('first delete failed'),
+            None,
+            None,
+        ]
+
+        with self.assertLogs('pipelinewise.fastsync.commons.utils', level='WARNING') as logs:
+            delete_s3_objects(
+                snowflake,
+                ['staging/first.csv.gz', 'staging/second.csv.gz'],
+                'test-bucket',
+            )
+
+        self.assertEqual(snowflake.s3.delete_object.call_args_list, [
+            mock.call(Bucket='test-bucket', Key='staging/first.csv.gz'),
+            mock.call(Bucket='test-bucket', Key='staging/first.csv.gz'),
+            mock.call(Bucket='test-bucket', Key='staging/second.csv.gz'),
+        ])
+        self.assertIn(
+            's3://test-bucket/staging/first.csv.gz: first delete failed',
+            logs.output[0],
+        )
+
+    def test_delete_s3_objects_reports_exhausted_cleanup(self):
+        """State callers receive a failure after all delete retries are exhausted."""
+        snowflake = mock.MagicMock()
+        snowflake.s3.delete_object.side_effect = RuntimeError('delete denied')
+
+        with self.assertRaisesRegex(RuntimeError, 'failed after 3 attempts'):
+            delete_s3_objects(
+                snowflake,
+                ['staging/first.csv.gz'],
+                'test-bucket',
+            )
+
+        self.assertEqual(snowflake.s3.delete_object.call_count, 3)
 
     def test_load_into_snowflake_hard_delete(self):
-        """Test load_into_snowflake method with hard delete"""
+        """Staging completes before the live target is published atomically."""
         snowflake = mock.MagicMock()
+        snowflake.query.return_value = []
         target = {
             'sf_object': snowflake,
             'schema': 'FOO_SCHEMA',
             'table': 'FOO_TABLE',
-            'temp': 'FOO_TEMP'
+            'temp': 'FOO_TEMP',
+            'publication_status': {'attempted': False},
         }
         args = PartialSync2SFArgs(
             temp_test_dir='temp_test_dir', start_value='20', end_value='30'
         )
-        columns_diff = {
-            'added_columns': ['FOO_ADDED_COLUMN'],
-            'source_columns': {'FOO_SOURCE_COLUMN': 'FOO_TYPE'}
-        }
+        source_columns = ['"FOO_SOURCE_COLUMN" FOO_TYPE']
         primary_keys = ['FOO_PRIMARY']
         s3_key_pattern = 'FOO_PATTERN'
         size_bytes = 3
         where_clause_sql = 'test'
-        load_into_snowflake(target, args, columns_diff, primary_keys, s3_key_pattern, size_bytes,
+        load_into_snowflake(target, args, source_columns, primary_keys, s3_key_pattern, size_bytes,
                             where_clause_sql)
 
-        snowflake.assert_has_calls([
+        self.assertEqual(snowflake.method_calls, [
             mock.call.copy_to_table(s3_key_pattern, target['schema'], args.table, size_bytes, is_temporary=True),
             mock.call.obfuscate_columns(target['schema'], args.table),
-            mock.call.add_columns(target['schema'], target['table'], columns_diff['added_columns']),
-            mock.call.merge_tables(
+            mock.call.create_table(
+                target_schema=target['schema'], table_name=target['table'], columns=source_columns,
+                primary_key=primary_keys, is_temporary=False, sort_columns=False, allow_replace_table=False,
+                normalize_primary_keys='if_created',
+            ),
+            mock.call.query('SHOW COLUMNS IN TABLE FOO_SCHEMA."FOO_TABLE"'),
+            mock.call.add_columns(target['schema'], target['table'], {'"FOO_SOURCE_COLUMN"': 'FOO_TYPE'}),
+            mock.call.publish_partial_sync(
                 target['schema'], target['temp'], target['table'],
-                ['FOO_SOURCE_COLUMN', '_SDC_EXTRACTED_AT', '_SDC_BATCHED_AT', '_SDC_DELETED_AT'], primary_keys),
-            mock.call.partial_hard_delete(target['schema'], target['table'], where_clause_sql),
-            mock.call.drop_table(target['schema'], target['temp'])
+                ['"FOO_SOURCE_COLUMN"', '_SDC_EXTRACTED_AT', '_SDC_BATCHED_AT', '_SDC_DELETED_AT'],
+                primary_keys, where_clause_sql, hard_delete=True,
+            ),
+            mock.call.drop_table(
+                target['schema'],
+                target['table'],
+                is_temporary=True,
+                max_attempts=3,
+            )
         ])
 
     def test_load_into_snowflake_soft_delete(self):
         """Test load_into_snowflake method with soft delete"""
         snowflake = mock.MagicMock()
+        snowflake.query.return_value = []
         target = {
             'sf_object': snowflake,
             'schema': 'FOO_SCHEMA',
             'table': 'FOO_TABLE',
-            'temp': 'FOO_TEMP'
+            'temp': 'FOO_TEMP',
+            'publication_status': {'attempted': False},
         }
         args = PartialSync2SFArgs(
             temp_test_dir='temp_test_dir', start_value='20', end_value='30', hard_delete=False
         )
-        columns_diff = {
-            'added_columns': ['FOO_ADDED_COLUMN'],
-            'source_columns': {'FOO_SOURCE_COLUMN': 'FOO_TYPE'}
-        }
+        source_columns = ['"FOO_SOURCE_COLUMN" FOO_TYPE']
         primary_keys = ['FOO_PRIMARY']
         s3_key_pattern = 'FOO_PATTERN'
         size_bytes = 3
         where_clause_sql = 'test'
-        load_into_snowflake(target, args, columns_diff, primary_keys, s3_key_pattern, size_bytes,
+        load_into_snowflake(target, args, source_columns, primary_keys, s3_key_pattern, size_bytes,
                             where_clause_sql)
 
-        snowflake.assert_has_calls([
+        self.assertEqual(snowflake.method_calls, [
             mock.call.copy_to_table(s3_key_pattern, target['schema'], args.table, size_bytes, is_temporary=True),
             mock.call.obfuscate_columns(target['schema'], args.table),
-            mock.call.add_columns(target['schema'], target['table'], columns_diff['added_columns']),
-            mock.call.merge_tables(target['schema'], target['temp'], target['table'],
-                                   ['FOO_SOURCE_COLUMN', '_SDC_EXTRACTED_AT', '_SDC_BATCHED_AT', '_SDC_DELETED_AT'],
-                                   primary_keys),
-            mock.call.drop_table(target['schema'], target['temp'])
+            mock.call.create_table(
+                target_schema=target['schema'], table_name=target['table'], columns=source_columns,
+                primary_key=primary_keys, is_temporary=False, sort_columns=False, allow_replace_table=False,
+                normalize_primary_keys='if_created',
+            ),
+            mock.call.query('SHOW COLUMNS IN TABLE FOO_SCHEMA."FOO_TABLE"'),
+            mock.call.add_columns(target['schema'], target['table'], {'"FOO_SOURCE_COLUMN"': 'FOO_TYPE'}),
+            mock.call.publish_partial_sync(
+                target['schema'], target['temp'], target['table'],
+                ['"FOO_SOURCE_COLUMN"', '_SDC_EXTRACTED_AT', '_SDC_BATCHED_AT', '_SDC_DELETED_AT'],
+                primary_keys, where_clause_sql, hard_delete=False,
+            ),
+            mock.call.drop_table(
+                target['schema'],
+                target['table'],
+                is_temporary=True,
+                max_attempts=3,
+            )
         ])
 
     def test_load_into_snowflake_drop_target_table_enabled(self):
@@ -109,22 +305,118 @@ class PartialSyncUtilsTestCase(TestCase):
         args = PartialSync2SFArgs(
             temp_test_dir='temp_test_dir', start_value='20', end_value='30', hard_delete=False, drop_target_table=True
         )
-        columns_diff = {
-            'added_columns': ['FOO_ADDED_COLUMN'],
-            'source_columns': {'FOO_SOURCE_COLUMN': 'FOO_TYPE'}
-        }
+        source_columns = ['"FOO_SOURCE_COLUMN" FOO_TYPE']
         primary_keys = ['FOO_PRIMARY']
         s3_key_pattern = 'FOO_PATTERN'
         size_bytes = 3
         where_clause_sql = 'test'
-        load_into_snowflake(target, args, columns_diff, primary_keys, s3_key_pattern, size_bytes,
-                            where_clause_sql)
+        timeline = []
+        snowflake.copy_to_table.side_effect = lambda *_args, **_kwargs: timeline.append('copy')
+        snowflake.obfuscate_columns.side_effect = (
+            lambda *_args, **_kwargs: timeline.append('obfuscate')
+        )
+        snowflake.swap_tables.side_effect = lambda *_args, **_kwargs: timeline.append('swap')
+        with mock.patch(
+            'pipelinewise.fastsync.partialsync.utils.common_utils.'
+            'apply_snowflake_table_grants',
+            side_effect=lambda *_args, **_kwargs: timeline.append('staging grant'),
+        ) as grant_mock:
+            load_into_snowflake(
+                target,
+                args,
+                source_columns,
+                primary_keys,
+                s3_key_pattern,
+                size_bytes,
+                where_clause_sql,
+            )
 
-        snowflake.assert_has_calls([
+        grant_mock.assert_called_once_with(
+            snowflake,
+            args.target,
+            target['schema'],
+            args.table,
+            is_temporary=True,
+        )
+        self.assertEqual(
+            timeline,
+            ['copy', 'obfuscate', 'staging grant', 'swap'],
+        )
+
+        self.assertEqual(snowflake.method_calls, [
             mock.call.copy_to_table(s3_key_pattern, target['schema'], args.table, size_bytes, is_temporary=True),
             mock.call.obfuscate_columns(target['schema'], args.table),
-            mock.call.add_columns(target['schema'], target['table'], columns_diff['added_columns']),
+            mock.call.create_table(
+                target_schema=target['schema'], table_name=target['table'], columns=source_columns,
+                primary_key=primary_keys, is_temporary=False, sort_columns=False, allow_replace_table=False,
+                normalize_primary_keys=False,
+            ),
             mock.call.swap_tables(target['schema'], target['table']),
+        ])
+
+    def test_load_into_snowflake_stops_if_copy_fails(self):
+        """A staging load failure must not mutate or publish the target."""
+        snowflake = mock.MagicMock()
+        snowflake.copy_to_table.side_effect = RuntimeError('copy failed')
+        target = {
+            'sf_object': snowflake,
+            'schema': 'FOO_SCHEMA',
+            'table': 'FOO_TABLE',
+            'temp': 'FOO_TEMP',
+            'publication_status': {'attempted': False},
+        }
+        args = PartialSync2SFArgs(
+            temp_test_dir='temp_test_dir', start_value='20', end_value='30'
+        )
+        source_columns = ['"FOO_SOURCE_COLUMN" FOO_TYPE']
+        with self.assertRaisesRegex(RuntimeError, 'copy failed'):
+            load_into_snowflake(
+                target, args, source_columns, ['FOO_PRIMARY'], 'FOO_PATTERN', 3, 'test'
+            )
+
+        self.assertFalse(target['publication_status']['attempted'])
+        self.assertEqual(snowflake.method_calls, [
+            mock.call.copy_to_table('FOO_PATTERN', 'FOO_SCHEMA', args.table, 3, is_temporary=True)
+        ])
+
+    def test_load_into_snowflake_stops_if_publication_fails(self):
+        """A publication failure must preserve staging and propagate to the caller."""
+        snowflake = mock.MagicMock()
+        snowflake.query.return_value = []
+        snowflake.publish_partial_sync.side_effect = RuntimeError('publication failed')
+        target = {
+            'sf_object': snowflake,
+            'schema': 'FOO_SCHEMA',
+            'table': 'FOO_TABLE',
+            'temp': 'FOO_TEMP',
+            'publication_status': {'attempted': False},
+        }
+        args = PartialSync2SFArgs(
+            temp_test_dir='temp_test_dir', start_value='20', end_value='30'
+        )
+        source_columns = ['"FOO_SOURCE_COLUMN" FOO_TYPE']
+        merge_columns = [
+            '"FOO_SOURCE_COLUMN"', '_SDC_EXTRACTED_AT', '_SDC_BATCHED_AT', '_SDC_DELETED_AT'
+        ]
+        with self.assertRaisesRegex(RuntimeError, 'publication failed'):
+            load_into_snowflake(
+                target, args, source_columns, ['FOO_PRIMARY'], 'FOO_PATTERN', 3, 'test'
+            )
+
+        self.assertTrue(target['publication_status']['attempted'])
+        self.assertEqual(snowflake.method_calls, [
+            mock.call.copy_to_table('FOO_PATTERN', 'FOO_SCHEMA', args.table, 3, is_temporary=True),
+            mock.call.obfuscate_columns('FOO_SCHEMA', args.table),
+            mock.call.create_table(
+                target_schema='FOO_SCHEMA', table_name='FOO_TABLE', columns=source_columns,
+                primary_key=['FOO_PRIMARY'], is_temporary=False, sort_columns=False, allow_replace_table=False,
+                normalize_primary_keys='if_created',
+            ),
+            mock.call.query('SHOW COLUMNS IN TABLE FOO_SCHEMA."FOO_TABLE"'),
+            mock.call.add_columns('FOO_SCHEMA', 'FOO_TABLE', {'"FOO_SOURCE_COLUMN"': 'FOO_TYPE'}),
+            mock.call.publish_partial_sync(
+                'FOO_SCHEMA', 'FOO_TEMP', 'FOO_TABLE', merge_columns, ['FOO_PRIMARY'], 'test', hard_delete=True,
+            ),
         ])
 
     def test_update_state_file(self):
@@ -143,6 +435,45 @@ class PartialSyncUtilsTestCase(TestCase):
                     mocked_save_state_file.assert_not_called()
                 else:
                     mocked_save_state_file.assert_called_with(args.state, args.table, bookmark)
+
+    @mock.patch(
+        'pipelinewise.fastsync.commons.utils.save_state_file',
+        side_effect=RuntimeError('state save failed'),
+    )
+    def test_update_state_file_propagates_save_failure(self, _mocked_save_state_file):
+        """A failed shared-state write must fail the table sync."""
+        args = PartialSync2SFArgs(
+            temp_test_dir='foo_temp', end_value=None, state='foo_state'
+        )
+
+        with self.assertRaisesRegex(RuntimeError, 'state save failed'):
+            update_state_file(args, {'foo': 2})
+
+    def test_update_state_file_preserves_multiple_table_bookmarks(self):
+        """Serialized workers retain every bookmark in their shared state file."""
+        with TemporaryDirectory() as temp_directory:
+            state_path = f'{temp_directory}/state.json'
+            args = PartialSync2SFArgs(
+                temp_test_dir=temp_directory, end_value=None, state=state_path
+            )
+
+            for table, bookmark in (
+                ('schema.first_table', {'position': 1}),
+                ('schema.second_table', {'position': 2}),
+            ):
+                args.table = table
+                update_state_file(args, bookmark)
+
+            with open(state_path, encoding='utf8') as state_file:
+                state = json.load(state_file)
+
+        self.assertEqual(
+            state['bookmarks'],
+            {
+                'schema-first_table': {'position': 1},
+                'schema-second_table': {'position': 2},
+            },
+        )
 
     def test_find_diff_columns(self):
         """Test find_diff_columns method works as expected"""
@@ -247,12 +578,17 @@ class PartialSyncUtilsTestCase(TestCase):
             test_query = '<D>SELECT * FROM baz'
             self.assertRaises(InvalidConfigException, validate_boundary_value, query_object, test_query)
 
-    def test_validate_dynamic_value_returns_null_if_dynamic_value_returns_nothing(self):
-        """Test if validate_boundary_value returns NULL if dynamic value returns nothing"""
+    def test_validate_dynamic_value_returns_missing_boundary_sentinel(self):
+        """No dynamic scalar is distinct from a valid empty source range."""
         query_object = mock.MagicMock()
-        query_object.return_value = []
         test_query = '<D>SELECT id FROM foo WHERE id=1;'
-        self.assertEqual('NULL', validate_boundary_value(query_object, test_query))
+        for query_result in ([], [(None,)], [{'id': None}]):
+            with self.subTest(query_result=query_result):
+                query_object.return_value = query_result
+                self.assertIs(
+                    DYNAMIC_BOUNDARY_NOT_READY,
+                    validate_boundary_value(query_object, test_query),
+                )
 
     def test_get_sync_tables(self):
         """Test if get_sync_tables wotks as expected"""

--- a/tests/units/partialsync/test_postgres_to_snowflake.py
+++ b/tests/units/partialsync/test_postgres_to_snowflake.py
@@ -36,6 +36,123 @@ class PartialSyncTestCase(TestCase):
 
         self.assertEqual(f'{args.table}: {exception_message}', actual_return)
 
+    @mock.patch('pipelinewise.fastsync.commons.utils.save_state_file')
+    @mock.patch('pipelinewise.fastsync.commons.utils.get_bookmark_for_table', return_value='bookmark')
+    @mock.patch(
+        'pipelinewise.fastsync.partialsync.utils.upload_to_s3',
+        return_value=(['s3-key'], 's3-pattern'),
+    )
+    @mock.patch('pipelinewise.fastsync.partialsync.postgres_to_snowflake.FastSyncTapPostgres')
+    @mock.patch('pipelinewise.fastsync.partialsync.postgres_to_snowflake.FastSyncTargetSnowflake')
+    def test_postgres_partial_sync_failure_state_semantics(
+        self, mocked_fastsync_sf, mocked_fastsyncpg, _mocked_upload, _mocked_bookmark, mocked_save_state
+    ):
+        """Publication and staging-cleanup failures all withhold state."""
+        for failure_method, error_message in (
+            ('copy_to_table', 'copy failed'),
+            ('publish_partial_sync', 'transaction failed'),
+            ('drop_table', 'cleanup failed'),
+        ):
+            with self.subTest(failure_method=failure_method), TemporaryDirectory() as temp_directory:
+                args = PartialSync2SFArgs(temp_test_dir=temp_directory, end_value=None)
+                test_table = ('foo', {
+                    'column': 'foo_column',
+                    'start_value': '<S>1',
+                    'end_value': None,
+                    'drop_target_table': False,
+                })
+                file_part = f'{temp_directory}/part.csv.gz'
+                with open(file_part, 'w', encoding='utf8') as exported_file:
+                    exported_file.write('data')
+
+                source = mock.MagicMock()
+                source.export_source_table_data.return_value = [file_part]
+                source.map_column_types_to_target.return_value = {
+                    'columns': ['"ID" NUMBER'],
+                    'primary_key': ['"ID"'],
+                }
+                mocked_fastsyncpg.return_value = source
+
+                snowflake = mock.MagicMock()
+                snowflake.query.return_value = []
+                getattr(snowflake, failure_method).side_effect = RuntimeError(error_message)
+                mocked_fastsync_sf.return_value = snowflake
+                mocked_save_state.reset_mock()
+
+                result = postgres_to_snowflake.partial_sync_table(test_table, args)
+
+                source.close_connection.assert_called_once_with()
+                if failure_method == 'drop_table':
+                    self.assertIn('foo: cleanup failed; staging cleanup failed:', result)
+                else:
+                    self.assertEqual(f'foo: {error_message}', result)
+                mocked_save_state.assert_not_called()
+                snowflake.s3.delete_object.assert_called_once_with(
+                    Bucket=args.target['s3_bucket'], Key='s3-key'
+                )
+
+                if failure_method == 'copy_to_table':
+                    snowflake.obfuscate_columns.assert_not_called()
+                    snowflake.publish_partial_sync.assert_not_called()
+                    self.assertEqual(snowflake.create_table.call_count, 1)
+                elif failure_method == 'publish_partial_sync':
+                    snowflake.copy_to_table.assert_called_once_with(
+                        's3-pattern', 'foo_schema', 'foo', 4, is_temporary=True
+                    )
+                    snowflake.publish_partial_sync.assert_called_once()
+                expected_drop_call = mock.call(
+                    'foo_schema',
+                    'foo',
+                    is_temporary=True,
+                    max_attempts=3,
+                )
+                self.assertEqual(
+                    snowflake.drop_table.call_args_list,
+                    [expected_drop_call]
+                    * (2 if failure_method == 'drop_table' else 1),
+                )
+
+    @mock.patch('pipelinewise.fastsync.commons.utils.save_state_file')
+    @mock.patch(
+        'pipelinewise.fastsync.commons.utils.get_bookmark_for_table',
+        return_value='bookmark',
+    )
+    @mock.patch('pipelinewise.fastsync.partialsync.postgres_to_snowflake.FastSyncTapPostgres')
+    @mock.patch('pipelinewise.fastsync.partialsync.postgres_to_snowflake.FastSyncTargetSnowflake')
+    def test_postgres_empty_unbounded_sync_publishes_and_advances_state(
+        self,
+        mocked_fastsync_sf,
+        mocked_fastsyncpg,
+        _mocked_bookmark,
+        mocked_save_state,
+    ):
+        """An empty PostgreSQL export still publishes its range and bookmark."""
+        args = PartialSync2SFArgs(temp_test_dir='FOO_DIR', end_value=None)
+        test_table = ('foo', {
+            'column': 'foo_column',
+            'start_value': '<S>1',
+            'end_value': None,
+            'drop_target_table': False,
+        })
+        source = mocked_fastsyncpg.return_value
+        source.export_source_table_data.return_value = []
+        source.map_column_types_to_target.return_value = {
+            'columns': ['"ID" NUMBER'],
+            'primary_key': ['"ID"'],
+        }
+        snowflake = mocked_fastsync_sf.return_value
+        snowflake.query.return_value = []
+
+        result = postgres_to_snowflake.partial_sync_table(test_table, args)
+
+        self.assertIs(result, True)
+        snowflake.copy_to_table.assert_called_once_with(
+            'NO_FILES_TO_LOAD', 'foo_schema', 'foo', 0, is_temporary=True
+        )
+        snowflake.publish_partial_sync.assert_called_once()
+        snowflake.s3.delete_object.assert_not_called()
+        mocked_save_state.assert_called_once_with(args.state, 'foo', 'bookmark')
+
     def test_export_source_table_data(self):
         """Test export_source_table_data method"""
         expected_file_parts = []
@@ -195,7 +312,6 @@ class PartialSyncTestCase(TestCase):
             with TemporaryDirectory() as temp_directory:
                 file_size = 5
                 file_parts = [f'{temp_directory}/t1', ]
-                s3_keys = ['FOO_S3_KEYS', ]
                 s3_key_pattern = 'BAR_S3_KEY_PATTERN'
                 bookmark = 'foo_bookmark'
                 maped_column_types_to_target = {
@@ -210,40 +326,40 @@ class PartialSyncTestCase(TestCase):
 
                     return file_parts
 
-                mocked_upload_to_s3.return_value = (s3_keys, s3_key_pattern)
+                mocked_upload_to_s3.return_value = (['FOO_S3_KEYS'], s3_key_pattern)
                 mocked_bookmark.return_value = bookmark
                 mocked_export_data = mocked_fastsyncpg.return_value.export_source_table_data
                 mocked_fastsyncpg.return_value.map_column_types_to_target.return_value = maped_column_types_to_target
                 mocked_export_data.side_effect = export_data_to_file
 
                 actual_return = postgres_to_snowflake.partial_sync_table(test_table, args)
-                self.assertTrue(actual_return)
+                self.assertIs(actual_return, True)
+
+                mocked_fastsyncpg.assert_called_once_with(
+                    args.tap, postgres_to_snowflake.tap_type_to_target_type
+                )
 
                 target = {
                     'schema': 'foo_schema',
                     'sf_object': mocked_fastsync_sf(),
                     'table': table_name,
-                    'temp': 'foo_temp'
+                    'temp': 'foo_temp',
+                    'publication_status': {'attempted': True},
                 }
-                columns_diff = {
-                    'added_columns': {'bar': 'type2', 'foo': 'type1'},
-                    'removed_columns': {},
-                    'source_columns': {'bar': 'type2', 'foo': 'type1'},
-                    'target_columns': []
-                }
-
-                mocked_fastsync_sf.return_value.query.assert_called_with(
-                    'UPDATE foo_schema."FOO" SET _SDC_DELETEd_AT = CURRENT_TIMESTAMP()'
-                    ' WHERE foo_column >= \'1\' AND _SDC_DELETED_AT IS NULL'
-                                                                        )
                 mocked_fastsync_sf.return_value.create_schema.assert_called_with('foo_schema')
-                mocked_fastsync_sf.return_value.create_table.assert_called_with(
+                mocked_fastsync_sf.return_value.create_table.assert_called_once_with(
                     'foo_schema', 'foo', ['foo type1', 'bar type2'], 'foo_primary', is_temporary=True)
+                mocked_fastsync_sf.return_value.query.assert_not_called()
+                mocked_fastsyncpg.return_value.close_connection.assert_called_once_with()
 
                 mocked_load_into_sf.assert_called_with(
-                    target, args, columns_diff, maped_column_types_to_target['primary_key'],
+                    target, args, maped_column_types_to_target['columns'],
+                    maped_column_types_to_target['primary_key'],
                     s3_key_pattern, file_size,
-                    f" WHERE {test_table[1]['column']} >= '{test_table[1]['start_value'][3:]}'"
+                    f" WHERE {test_table[1]['column']} >= '{test_table[1]['start_value'][3:]}'",
+                )
+                mocked_fastsync_sf.return_value.s3.delete_object.assert_called_once_with(
+                    Bucket=args.target['s3_bucket'], Key='FOO_S3_KEYS'
                 )
 
                 if end_value:

--- a/tests/units/partialsync/test_upload_order.py
+++ b/tests/units/partialsync/test_upload_order.py
@@ -1,0 +1,439 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase, mock
+
+from pipelinewise.fastsync.partialsync import mysql_to_snowflake
+from pipelinewise.fastsync.partialsync import postgres_to_snowflake
+from tests.units.partialsync.utils import PartialSync2SFArgs
+
+
+class PartialSyncUploadOrderTestCase(TestCase):
+    """Composition tests for local and remote PartialSync staging lifecycle."""
+
+    # pylint: disable=too-many-locals
+    def _run_route(
+        self,
+        sync_module,
+        tap_class_name,
+        **scenario,
+    ):
+        publication_error = scenario.get('publication_error')
+        staging_error = scenario.get('staging_error')
+        cleanup_error = scenario.get('cleanup_error')
+        grant_error = scenario.get('grant_error')
+        table_start_value = scenario.get('table_start_value', '<S>1')
+        table_end_value = scenario.get('table_end_value')
+        source_query_result = scenario.get('source_query_result', ((0,),))
+        with TemporaryDirectory() as temp_directory:
+            file_part = Path(temp_directory, 'part.csv.gz')
+            file_part.write_text('data', encoding='utf8')
+            args = PartialSync2SFArgs(
+                temp_test_dir=temp_directory,
+                end_value=table_end_value,
+            )
+            table = ('foo', {
+                'column': 'foo_column',
+                'start_value': table_start_value,
+                'end_value': table_end_value,
+                'drop_target_table': False,
+            })
+            timeline = []
+
+            source = mock.MagicMock()
+            source.query.return_value = source_query_result
+            source.export_source_table_data.return_value = [str(file_part)]
+            source.map_column_types_to_target.return_value = {
+                'columns': ['"ID" NUMBER'],
+                'primary_key': ['"ID"'],
+            }
+            snowflake = mock.MagicMock()
+
+            def getsize(path):
+                timeline.append('getsize')
+                self.assertTrue(Path(path).exists())
+                return Path(path).stat().st_size
+
+            def upload(path, tmp_dir=None):
+                timeline.append('upload')
+                self.assertTrue(Path(path).exists())
+                self.assertEqual(tmp_dir, temp_directory)
+                return 'staging/part.csv.gz'
+
+            def publish(*load_args):
+                timeline.append('publish')
+                if staging_error:
+                    raise staging_error
+                load_args[0]['publication_status']['attempted'] = True
+                self.assertFalse(file_part.exists())
+                if publication_error:
+                    raise publication_error
+
+            def delete_object(**kwargs):
+                timeline.append('remote_delete')
+                self.assertEqual(kwargs, {
+                    'Bucket': args.target['s3_bucket'],
+                    'Key': 'staging/part.csv.gz',
+                })
+                if cleanup_error:
+                    raise cleanup_error
+
+            def save_state(*_args):
+                timeline.append('state')
+
+            def apply_grants(*_args, **_kwargs):
+                timeline.append('grants')
+                if grant_error:
+                    raise grant_error
+
+            snowflake.upload_to_s3.side_effect = upload
+            snowflake.s3.delete_object.side_effect = delete_object
+            with mock.patch.object(
+                sync_module, tap_class_name, return_value=source
+            ), mock.patch.object(
+                sync_module, 'FastSyncTargetSnowflake', return_value=snowflake
+            ), mock.patch.object(
+                sync_module.os.path, 'getsize', side_effect=getsize
+            ), mock.patch.object(
+                sync_module.utils, 'load_into_snowflake', side_effect=publish
+            ) as load_into_snowflake, mock.patch.object(
+                sync_module.utils.common_utils,
+                'save_state_file',
+                side_effect=save_state,
+            ) as save_state_file, mock.patch.object(
+                sync_module.common_utils, 'get_bookmark_for_table', return_value='bookmark'
+            ) as get_bookmark, mock.patch.object(
+                sync_module.common_utils, 'get_target_schema', return_value='foo_schema'
+            ) as get_target_schema, mock.patch.object(
+                sync_module.common_utils,
+                'apply_snowflake_table_grants',
+                side_effect=apply_grants,
+            ) as apply_grants_mock:
+                result = sync_module.partial_sync_table(table, args)
+
+            return {
+                'args': args,
+                'file_exists': file_part.exists(),
+                'load': load_into_snowflake,
+                'result': result,
+                'source': source,
+                'snowflake': snowflake,
+                'state': save_state_file,
+                'grants': apply_grants_mock,
+                'bookmark': get_bookmark,
+                'target_schema': get_target_schema,
+                'timeline': timeline,
+            }
+
+    def _assert_successful_lifecycle(self, sync_module, tap_class_name):
+        actual = self._run_route(sync_module, tap_class_name)
+
+        self.assertIs(actual['result'], True)
+        self.assertEqual(
+            actual['timeline'],
+            ['getsize', 'upload', 'publish', 'grants', 'remote_delete', 'state'],
+        )
+        self.assertFalse(actual['file_exists'])
+        self.assertEqual(actual['load'].call_args.args[5], 4)
+        actual['snowflake'].s3.delete_object.assert_called_once_with(
+            Bucket=actual['args'].target['s3_bucket'],
+            Key='staging/part.csv.gz',
+        )
+        actual['state'].assert_called_once_with(
+            actual['args'].state,
+            'foo',
+            'bookmark',
+        )
+
+    def _assert_publication_failure_cleans_remote_object(self, sync_module, tap_class_name):
+        actual = self._run_route(
+            sync_module,
+            tap_class_name,
+            publication_error=RuntimeError('publication failed'),
+        )
+
+        self.assertEqual(actual['result'], 'foo: publication failed')
+        self.assertEqual(
+            actual['timeline'],
+            ['getsize', 'upload', 'publish', 'grants', 'remote_delete'],
+        )
+        actual['snowflake'].s3.delete_object.assert_called_once_with(
+            Bucket=actual['args'].target['s3_bucket'],
+            Key='staging/part.csv.gz',
+        )
+        actual['snowflake'].drop_table.assert_called_once_with(
+            'foo_schema',
+            'foo',
+            is_temporary=True,
+            max_attempts=3,
+        )
+        actual['state'].assert_not_called()
+
+    def _assert_staging_failure_does_not_repair_grants(
+            self, sync_module, tap_class_name):
+        actual = self._run_route(
+            sync_module,
+            tap_class_name,
+            staging_error=RuntimeError('staging failed'),
+        )
+
+        self.assertEqual(actual['result'], 'foo: staging failed')
+        self.assertEqual(
+            actual['timeline'],
+            ['getsize', 'upload', 'publish', 'remote_delete'],
+        )
+        actual['grants'].assert_not_called()
+        actual['state'].assert_not_called()
+
+    def _assert_cleanup_failure_withholds_state(self, sync_module, tap_class_name):
+        with self.assertLogs('pipelinewise.fastsync.commons.utils', level='WARNING') as logs:
+            actual = self._run_route(
+                sync_module,
+                tap_class_name,
+                cleanup_error=RuntimeError('cleanup failed'),
+            )
+
+        self.assertIn(
+            'PartialSync staging cleanup after successful publication failed after 3 attempts',
+            actual['result'],
+        )
+        self.assertIn('staging cleanup failed', actual['result'])
+        self.assertEqual(
+            actual['timeline'],
+            ['getsize', 'upload', 'publish']
+            + ['grants']
+            + ['remote_delete'] * 6,
+        )
+        actual['state'].assert_not_called()
+        self.assertIn('cleanup failed', logs.output[0])
+
+    def _assert_grant_failure_withholds_state(self, sync_module, tap_class_name):
+        actual = self._run_route(
+            sync_module,
+            tap_class_name,
+            grant_error=RuntimeError('grant failed'),
+        )
+
+        self.assertEqual(actual['result'], 'foo: grant failed')
+        self.assertEqual(
+            actual['timeline'],
+            ['getsize', 'upload', 'publish']
+            + ['grants'] * 3
+            + ['remote_delete'],
+        )
+        actual['state'].assert_not_called()
+        self.assertEqual(actual['grants'].call_count, 3)
+        self.assertTrue(all(
+            grant_call == mock.call(
+                actual['snowflake'],
+                actual['args'].target,
+                'foo_schema',
+                'foo',
+                is_temporary=False,
+            )
+            for grant_call in actual['grants'].call_args_list
+        ))
+
+    def _assert_dynamic_zero_end_boundary_is_retained(self, sync_module, tap_class_name):
+        actual = self._run_route(
+            sync_module,
+            tap_class_name,
+            table_end_value='<D>SELECT 0',
+        )
+        expected_where_clause = " WHERE foo_column >= '1' AND foo_column <= '0'"
+
+        self.assertIs(actual['result'], True)
+        self.assertEqual(actual['load'].call_args.args[6], expected_where_clause)
+        actual['state'].assert_not_called()
+        actual['source'].export_source_table_data.assert_called_once_with(
+            actual['args'],
+            actual['args'].target.get('tap_id'),
+            expected_where_clause,
+        )
+
+    def _assert_empty_dynamic_boundary_is_successful_noop(self, sync_module, tap_class_name):
+        for boundary in ('start', 'end'):
+            for query_result in ([], [(None,)], [{'next_boundary': None}]):
+                with self.subTest(boundary=boundary, query_result=query_result):
+                    kwargs = {
+                        'source_query_result': query_result,
+                        f'table_{boundary}_value': '<D>SELECT next_boundary',
+                    }
+                    actual = self._run_route(sync_module, tap_class_name, **kwargs)
+
+                    self.assertIs(actual['result'], True)
+                    self.assertEqual(actual['timeline'], [])
+                    if tap_class_name == 'FastSyncTapMySql':
+                        actual['source'].open_connections.assert_called_once_with()
+                        actual['source'].close_connections.assert_called_once_with(silent=True)
+                    else:
+                        actual['source'].open_connection.assert_called_once_with()
+                        actual['source'].close_connection.assert_called_once_with()
+                    actual['bookmark'].assert_not_called()
+                    actual['source'].map_column_types_to_target.assert_not_called()
+                    actual['source'].export_source_table_data.assert_not_called()
+                    actual['target_schema'].assert_not_called()
+                    actual['snowflake'].create_schema.assert_not_called()
+                    actual['snowflake'].create_table.assert_not_called()
+                    actual['snowflake'].upload_to_s3.assert_not_called()
+                    actual['load'].assert_not_called()
+                    actual['grants'].assert_not_called()
+                    actual['snowflake'].s3.delete_object.assert_not_called()
+                    actual['state'].assert_not_called()
+
+    def _run_main_with_results(self, sync_module, sync_results):
+        args = PartialSync2SFArgs(temp_test_dir='FOO_DIR')
+        args.table = 'first,second'
+        args.column = 'id,id'
+        args.start_value = '1,1'
+        args.end_value = '2,2'
+        sync_tables = {'first': {}, 'second': {}}
+        pool = mock.MagicMock()
+        worker_pool = pool.return_value.__enter__.return_value
+        worker_pool.map.return_value = sync_results
+
+        exit_code = None
+        with mock.patch.object(
+            sync_module.utils,
+            'parse_args_for_partial_sync',
+            return_value=args,
+        ), mock.patch.object(
+            sync_module.utils,
+            'get_sync_tables',
+            return_value=sync_tables,
+        ), mock.patch.object(
+            sync_module.common_utils,
+            'get_pool_size',
+            return_value=2,
+        ), mock.patch.object(
+            sync_module.multiprocessing,
+            'Pool',
+            pool,
+        ), self.assertLogs('pipelinewise') as logs:
+            try:
+                sync_module.main_impl()
+            except SystemExit as exc:
+                exit_code = exc.code
+
+        worker_pool.map.assert_called_once()
+        self.assertEqual(
+            worker_pool.map.call_args.args[1],
+            sync_tables.items(),
+        )
+        summary = next(log for log in logs.output if 'SUMMARY' in log)
+        return exit_code, summary
+
+    def test_partial_sync_summary_treats_only_true_as_success(self):
+        """Both source routes accept successful no-ops without hiding failures."""
+        scenarios = (
+            (
+                [True, True],
+                'Exceptions during table sync   : []',
+                None,
+            ),
+            (
+                [True, 'second: failed'],
+                "Exceptions during table sync   : ['second: failed']",
+                1,
+            ),
+            (
+                [True, False],
+                'Exceptions during table sync   : [False]',
+                1,
+            ),
+        )
+        for sync_module in (mysql_to_snowflake, postgres_to_snowflake):
+            for results, failure_log, expected_exit in scenarios:
+                with self.subTest(
+                    route=sync_module.__name__,
+                    results=results,
+                ):
+                    exit_code, summary = self._run_main_with_results(
+                        sync_module,
+                        results,
+                    )
+                    self.assertEqual(exit_code, expected_exit)
+                    self.assertIn(failure_log, summary)
+
+    def test_mariadb_partial_sync_staging_lifecycle_order(self):
+        """MariaDB cleans local then remote staging around successful publication."""
+        self._assert_successful_lifecycle(
+            mysql_to_snowflake, 'FastSyncTapMySql'
+        )
+
+    def test_postgres_partial_sync_staging_lifecycle_order(self):
+        """PostgreSQL cleans local then remote staging around successful publication."""
+        self._assert_successful_lifecycle(
+            postgres_to_snowflake, 'FastSyncTapPostgres'
+        )
+
+    def test_mariadb_publication_failure_cleans_remote_object(self):
+        """MariaDB removes uploaded staging data when publication fails."""
+        self._assert_publication_failure_cleans_remote_object(
+            mysql_to_snowflake, 'FastSyncTapMySql'
+        )
+
+    def test_postgres_publication_failure_cleans_remote_object(self):
+        """PostgreSQL removes uploaded staging data when publication fails."""
+        self._assert_publication_failure_cleans_remote_object(
+            postgres_to_snowflake, 'FastSyncTapPostgres'
+        )
+
+    def test_mariadb_staging_failure_does_not_repair_live_grants(self):
+        """A MariaDB staging failure is not treated as live publication."""
+        self._assert_staging_failure_does_not_repair_grants(
+            mysql_to_snowflake, 'FastSyncTapMySql'
+        )
+
+    def test_postgres_staging_failure_does_not_repair_live_grants(self):
+        """A PostgreSQL staging failure is not treated as live publication."""
+        self._assert_staging_failure_does_not_repair_grants(
+            postgres_to_snowflake, 'FastSyncTapPostgres'
+        )
+
+    def test_mariadb_cleanup_failure_withholds_state(self):
+        """MariaDB cannot advance state while staging cleanup is unresolved."""
+        self._assert_cleanup_failure_withholds_state(
+            mysql_to_snowflake, 'FastSyncTapMySql'
+        )
+
+    def test_postgres_cleanup_failure_withholds_state(self):
+        """PostgreSQL cannot advance state while staging cleanup is unresolved."""
+        self._assert_cleanup_failure_withholds_state(
+            postgres_to_snowflake, 'FastSyncTapPostgres'
+        )
+
+    def test_mariadb_grant_failure_withholds_state(self):
+        """MariaDB cannot advance state when published access is not repaired."""
+        self._assert_grant_failure_withholds_state(
+            mysql_to_snowflake, 'FastSyncTapMySql'
+        )
+
+    def test_postgres_grant_failure_withholds_state(self):
+        """PostgreSQL cannot advance state when published access is not repaired."""
+        self._assert_grant_failure_withholds_state(
+            postgres_to_snowflake, 'FastSyncTapPostgres'
+        )
+
+    def test_mariadb_dynamic_zero_end_boundary_is_retained(self):
+        """MariaDB keeps a dynamic numeric zero as the requested upper bound."""
+        self._assert_dynamic_zero_end_boundary_is_retained(
+            mysql_to_snowflake, 'FastSyncTapMySql'
+        )
+
+    def test_postgres_dynamic_zero_end_boundary_is_retained(self):
+        """PostgreSQL keeps a dynamic numeric zero as the requested upper bound."""
+        self._assert_dynamic_zero_end_boundary_is_retained(
+            postgres_to_snowflake, 'FastSyncTapPostgres'
+        )
+
+    def test_mariadb_empty_dynamic_boundary_is_successful_noop(self):
+        """MariaDB treats a missing dynamic boundary as side-effect-free success."""
+        self._assert_empty_dynamic_boundary_is_successful_noop(
+            mysql_to_snowflake, 'FastSyncTapMySql'
+        )
+
+    def test_postgres_empty_dynamic_boundary_is_successful_noop(self):
+        """PostgreSQL treats a missing dynamic boundary as side-effect-free success."""
+        self._assert_empty_dynamic_boundary_is_successful_noop(
+            postgres_to_snowflake, 'FastSyncTapPostgres'
+        )

--- a/tests/units/test_ci_check_no_file_changes.py
+++ b/tests/units/test_ci_check_no_file_changes.py
@@ -1,0 +1,188 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+DETECTOR = REPOSITORY_ROOT / 'scripts' / 'ci_check_no_file_changes.sh'
+
+FAKE_CURL = r'''#!/usr/bin/env bash
+set -u
+
+page=''
+while (( $# > 0 )); do
+  case "$1" in
+    --data-urlencode)
+      if [[ $2 == page=* ]]; then
+        page=${2#page=}
+      fi
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+printf '%s\n' "${page}" >> "${FAKE_CURL_LOG}"
+
+write_full_docs_page() {
+  printf '['
+  for ((index = 1; index <= 100; index += 1)); do
+    if (( index > 1 )); then
+      printf ','
+    fi
+    printf '{"filename":"docs/page-%s.rst"}' "${index}"
+  done
+  printf ']'
+}
+
+case "${FAKE_CURL_SCENARIO}:${page}" in
+  second_page_python:1)
+    write_full_docs_page
+    ;;
+  second_page_python:2)
+    printf '[{"filename":"pipelinewise/cli/pipelinewise.py"}]'
+    ;;
+  docs_only:1)
+    printf '[{"filename":"docs/index.rst"}]'
+    ;;
+  config_only:1)
+    printf '[{"filename":"dev-project/pipelinewise-config/config.yml"}]'
+    ;;
+  detector_only:1)
+    printf '[{"filename":"scripts/ci_check_no_file_changes.sh"}]'
+    ;;
+  api_failure:1)
+    printf 'API unavailable\n' >&2
+    exit 22
+    ;;
+  invalid_response:1)
+    printf '{"message":"rate limit exceeded"}'
+    ;;
+  *)
+    printf 'Unexpected scenario or page: %s:%s\n' "${FAKE_CURL_SCENARIO}" "${page}" >&2
+    exit 2
+    ;;
+esac
+'''
+
+FAKE_JQ = r'''#!/usr/bin/env python3
+import json
+import sys
+
+
+try:
+    payload = json.load(sys.stdin)
+except (json.JSONDecodeError, OSError):
+    sys.exit(1)
+
+filenames_are_valid = isinstance(payload, list) and all(
+    isinstance(item, dict) and isinstance(item.get('filename'), str)
+    for item in payload
+)
+expression = sys.argv[-1]
+
+if expression.startswith('type =='):
+    sys.exit(0 if filenames_are_valid else 1)
+if not filenames_are_valid:
+    sys.exit(1)
+if expression == 'length':
+    print(len(payload))
+elif expression == '.[].filename':
+    for item in payload:
+        print(item['filename'])
+else:
+    sys.exit(2)
+'''
+
+
+def run_detector(tmp_path, scenario, *checks):
+    """Run the detector with deterministic GitHub API command doubles."""
+    fake_bin = tmp_path / 'bin'
+    fake_bin.mkdir()
+    fake_curl = fake_bin / 'curl'
+    fake_curl.write_text(FAKE_CURL, encoding='utf-8')
+    fake_curl.chmod(0o755)
+    fake_jq = fake_bin / 'jq'
+    fake_jq.write_text(FAKE_JQ, encoding='utf-8')
+    fake_jq.chmod(0o755)
+
+    request_log = tmp_path / 'curl-pages.log'
+    environment = os.environ.copy()
+    environment.update(
+        {
+            'FAKE_CURL_LOG': str(request_log),
+            'FAKE_CURL_SCENARIO': scenario,
+            'GITHUB_REPO': 'transferwise/pipelinewise',
+            'PATH': f'{fake_bin}:{environment["PATH"]}',
+            'PR_NUMBER': '1321',
+        }
+    )
+
+    result = subprocess.run(
+        [str(DETECTOR), *checks],
+        cwd=REPOSITORY_ROOT,
+        env=environment,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    pages = request_log.read_text(encoding='utf-8').splitlines()
+    return result, pages
+
+
+def test_second_page_python_change_runs_ci(tmp_path):
+    """A relevant file after page one must run CI."""
+    result, pages = run_detector(tmp_path, 'second_page_python', 'python', 'config')
+
+    assert result.returncode == 1
+    assert pages == ['1', '2']
+    assert 'Detected changes in following file: pipelinewise/cli/pipelinewise.py' in result.stdout
+
+
+def test_docs_only_skips_python_config(tmp_path):
+    """Documentation-only changes may skip Python and config checks."""
+    result, pages = run_detector(tmp_path, 'docs_only', 'python', 'config')
+
+    assert result.returncode == 0
+    assert pages == ['1']
+    assert 'No changes detected... Exiting with SUCCESS code' in result.stdout
+
+
+def test_config_change_triggers_checks(tmp_path):
+    """A dev-project change must run Python and config checks."""
+    result, pages = run_detector(tmp_path, 'config_only', 'python', 'config')
+
+    assert result.returncode == 1
+    assert pages == ['1']
+    assert 'Detected changes in following file: dev-project/pipelinewise-config/config.yml' in result.stdout
+
+
+def test_detector_change_triggers_checks(tmp_path):
+    """A change to the detector must run its own regression tests."""
+    result, pages = run_detector(tmp_path, 'detector_only', 'python')
+
+    assert result.returncode == 1
+    assert pages == ['1']
+    assert 'Detected changes in following file: scripts/ci_check_no_file_changes.sh' in result.stdout
+
+
+def test_api_failure_triggers_checks(tmp_path):
+    """An API failure must run CI rather than produce a false green."""
+    result, pages = run_detector(tmp_path, 'api_failure', 'python')
+
+    assert result.returncode == 1
+    assert pages == ['1']
+    assert 'Unable to determine changed files; Exiting with FAILURE code' in result.stdout
+    assert 'Failed to fetch changed files from GitHub' in result.stderr
+
+
+def test_invalid_response_triggers_checks(tmp_path):
+    """A malformed API response must run CI rather than skip it."""
+    result, pages = run_detector(tmp_path, 'invalid_response', 'python')
+
+    assert result.returncode == 1
+    assert pages == ['1']
+    assert 'Unable to determine changed files; Exiting with FAILURE code' in result.stdout
+    assert 'GitHub changed-files response is invalid' in result.stderr

--- a/tests/units/test_end_to_end_helpers.py
+++ b/tests/units/test_end_to_end_helpers.py
@@ -1,0 +1,952 @@
+import hashlib
+import json
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase, mock
+
+from tests.end_to_end.helpers import assertions
+from tests.end_to_end.helpers import env as env_module
+from tests.end_to_end.helpers.env import E2EEnv
+from tests.end_to_end import target_snowflake as target_snowflake_module
+from tests.end_to_end.target_snowflake import TargetSnowflake
+from tests.end_to_end.target_snowflake.tap_mariadb import TapMariaDB
+from tests.end_to_end.target_snowflake.tap_postgres import TapPostgres
+
+
+class EndToEndHelpersTestCase(TestCase):  # pylint: disable=too-many-public-methods
+    """Tests for E2E control-flow helpers that do not require external services."""
+
+    def setUp(self):
+        self.env = mock.MagicMock()
+        self.comparison_columns = [
+            {
+                'name': 'cid',
+                'source_expression': '"cid"',
+                'target_expression': '"CID"',
+                'normalizer': 'integer',
+            },
+            {
+                'name': 'payload',
+                'source_expression': '"payload"',
+                'target_expression': '"PAYLOAD"',
+                'normalizer': 'json',
+            },
+            {
+                'name': 'secret',
+                'source_expression': '"secret"',
+                'target_expression': '"SECRET"',
+                'normalizer': 'text',
+                'source_normalizer': 'hash_skip_first_2',
+            },
+            {
+                'name': 'active',
+                'source_expression': '"active"',
+                'target_expression': '"ACTIVE"',
+                'normalizer': 'boolean',
+            },
+        ]
+        self.tap_parameters = {
+            'env': self.env,
+            'tap': 'postgres_to_sf',
+            'tap_type': 'postgres',
+            'target': 'snowflake',
+            'source_db': 'public',
+            'table': 'edgydata',
+            'column': 'cid',
+            'comparison_columns': self.comparison_columns,
+        }
+
+    @staticmethod
+    def _write_state(temp_directory, state):
+        state_path = Path(
+            temp_directory, '.pipelinewise', 'snowflake', 'postgres_to_sf', 'state.json'
+        )
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        with state_path.open('w', encoding='utf-8') as state_file:
+            json.dump(state, state_file)
+        return state_path
+
+    def test_state_validation_accepts_structured_fastsync_bookmarks(self):
+        """FastSync state without a Singer log must contain usable bookmarks."""
+        with TemporaryDirectory() as temp_directory:
+            self._write_state(
+                temp_directory,
+                {
+                    'currently_syncing': None,
+                    'bookmarks': {
+                        'public-table': {'lsn': '16/B374D848', 'version': 1}
+                    },
+                },
+            )
+            with mock.patch.object(assertions.Path, 'home', return_value=Path(temp_directory)):
+                assertions.assert_state_file_valid(
+                    'snowflake',
+                    'postgres_to_sf',
+                    expected_streams={'public-table'},
+                )
+
+    def test_state_validation_rejects_malformed_fastsync_bookmarks(self):
+        """A state file's existence alone cannot make malformed bookmarks pass."""
+        malformed_states = (
+            {},
+            {'bookmarks': []},
+            {'bookmarks': {'public-table': 'not-an-object'}},
+            {'bookmarks': {'': {}}},
+        )
+        for state in malformed_states:
+            with self.subTest(state=state), TemporaryDirectory() as temp_directory:
+                self._write_state(temp_directory, state)
+                with mock.patch.object(
+                    assertions.Path, 'home', return_value=Path(temp_directory)
+                ), self.assertRaises(AssertionError):
+                    assertions.assert_state_file_valid('snowflake', 'postgres_to_sf')
+
+    def test_state_validation_accepts_full_table_bookmark_without_progress(self):
+        """FULL_TABLE state is structurally valid even though its bookmark is empty."""
+        with TemporaryDirectory() as temp_directory:
+            self._write_state(
+                temp_directory,
+                {'bookmarks': {'public-full-table': {}}},
+            )
+            with mock.patch.object(
+                assertions.Path, 'home', return_value=Path(temp_directory)
+            ):
+                assertions.assert_state_file_valid(
+                    'snowflake',
+                    'postgres_to_sf',
+                    expected_streams={'public-full-table'},
+                )
+
+    def test_state_validation_requires_progress_only_for_declared_streams(self):
+        """An empty FULL_TABLE bookmark cannot satisfy a LOG/INCREMENTAL stream."""
+        with TemporaryDirectory() as temp_directory:
+            self._write_state(
+                temp_directory,
+                {'bookmarks': {'public-table': {}}},
+            )
+            with mock.patch.object(
+                assertions.Path, 'home', return_value=Path(temp_directory)
+            ), self.assertRaises(AssertionError):
+                assertions.assert_state_file_valid(
+                    'snowflake',
+                    'postgres_to_sf',
+                    expected_streams={'public-table'},
+                    expected_progress_streams={'public-table'},
+                )
+
+    def test_state_validation_rejects_a_wrong_fastsync_stream(self):
+        """A valid bookmark for another stream cannot satisfy the expected table."""
+        with TemporaryDirectory() as temp_directory:
+            self._write_state(
+                temp_directory,
+                {
+                    'bookmarks': {
+                        'public-other': {'lsn': '16/B374D848', 'version': 1}
+                    }
+                },
+            )
+            with mock.patch.object(
+                assertions.Path, 'home', return_value=Path(temp_directory)
+            ), self.assertRaises(AssertionError):
+                assertions.assert_state_file_valid(
+                    'snowflake',
+                    'postgres_to_sf',
+                    expected_streams={'public-table'},
+                )
+
+    def test_state_validation_compares_parsed_singer_state(self):
+        """Singer state comparison detects semantic mismatch independent of formatting."""
+        persisted_state = {'currently_syncing': None, 'bookmarks': {'public-table': {}}}
+        emitted_state = {'currently_syncing': None, 'bookmarks': {'public-other': {}}}
+        with TemporaryDirectory() as temp_directory:
+            self._write_state(temp_directory, persisted_state)
+            log_path = Path(temp_directory, 'run.log')
+            with Path(f'{log_path}.success').open('w', encoding='utf-8') as log_file:
+                log_file.write(
+                    f'INFO STATE emitted from target: {json.dumps(persisted_state)}\n'
+                    f'INFO STATE emitted from target: {json.dumps(emitted_state)}\n'
+                )
+
+            with mock.patch.object(
+                assertions.Path, 'home', return_value=Path(temp_directory)
+            ), self.assertRaises(AssertionError):
+                assertions.assert_state_file_valid(
+                    'snowflake',
+                    'postgres_to_sf',
+                    str(log_path),
+                    require_emitted_state=True,
+                )
+
+    def test_state_validation_parses_target_snowflake_raw_json(self):
+        """The real target-snowflake state output is a bare JSON line."""
+        persisted_state = {
+            'currently_syncing': None,
+            'bookmarks': {'public-table': {'lsn': '16/B374D848'}},
+        }
+        with TemporaryDirectory() as temp_directory:
+            self._write_state(temp_directory, persisted_state)
+            log_path = Path(temp_directory, 'run.log')
+            Path(f'{log_path}.success').write_text(
+                f'INFO Emitting state {json.dumps(persisted_state)}\n'
+                f'{json.dumps(persisted_state)}\n',
+                encoding='utf-8',
+            )
+
+            with mock.patch.object(
+                assertions.Path, 'home', return_value=Path(temp_directory)
+            ):
+                assertions.assert_state_file_valid(
+                    'snowflake',
+                    'postgres_to_sf',
+                    str(log_path),
+                    require_emitted_state=True,
+                )
+
+    def test_singer_state_validation_rejects_a_missing_emission(self):
+        """Pre-existing FastSync state cannot mask a Singer state regression."""
+        with TemporaryDirectory() as temp_directory:
+            self._write_state(
+                temp_directory,
+                {'bookmarks': {'public-table': {'lsn': '16/B374D848'}}},
+            )
+            log_path = Path(temp_directory, 'run.log')
+            Path(f'{log_path}.success').write_text(
+                'time=2026-08-07 log_level=INFO message=No state emitted\n',
+                encoding='utf-8',
+            )
+
+            with mock.patch.object(
+                assertions.Path, 'home', return_value=Path(temp_directory)
+            ), self.assertRaises(AssertionError):
+                assertions.assert_state_file_valid(
+                    'snowflake',
+                    'postgres_to_sf',
+                    str(log_path),
+                    require_emitted_state=True,
+                )
+
+    def test_fastsync_state_marker_requires_the_expected_stream(self):
+        """A marker for a sibling table cannot mask a missing FastSync state write."""
+        with TemporaryDirectory() as temp_directory:
+            log_path = Path(temp_directory, 'run.log')
+            with Path(f'{log_path}.success').open('w', encoding='utf-8') as log_file:
+                log_file.write(
+                    'INFO FastSync state updated for stream: public-other\n'
+                )
+
+            with self.assertRaises(AssertionError):
+                assertions.assert_fastsync_state_persisted(
+                    str(log_path), {'public-table'}
+                )
+
+    def test_fastsync_state_marker_accepts_the_expected_stream(self):
+        """The harness accepts a marker emitted after the requested table write."""
+        with TemporaryDirectory() as temp_directory:
+            log_path = Path(temp_directory, 'run.log')
+            with Path(f'{log_path}.success').open('w', encoding='utf-8') as log_file:
+                log_file.write(
+                    'time=2026-08-07 18:00:00 '
+                    'logger_name=pipelinewise.fastsync.commons.utils '
+                    'log_level=INFO message=FastSync state updated for stream: '
+                    'public-table\n'
+                )
+
+            assertions.assert_fastsync_state_persisted(
+                str(log_path), {'public-table'}
+            )
+
+    def test_fastsync_state_marker_rejects_an_unexpected_sibling(self):
+        """Exact markers catch a worker that persisted an unintended stream set."""
+        with TemporaryDirectory() as temp_directory:
+            log_path = Path(temp_directory, 'run.log')
+            Path(f'{log_path}.success').write_text(
+                'INFO FastSync state updated for stream: public-table\n'
+                'INFO FastSync state updated for stream: public-sibling\n',
+                encoding='utf-8',
+            )
+
+            with self.assertRaises(AssertionError):
+                assertions.assert_fastsync_state_persisted(
+                    str(log_path), {'public-table'}
+                )
+
+    def test_fastsync_state_marker_rejects_a_duplicate_execution(self):
+        """Repeated completion markers cannot masquerade as one FastSync run."""
+        with TemporaryDirectory() as temp_directory:
+            log_path = Path(temp_directory, 'run.log')
+            Path(f'{log_path}.success').write_text(
+                'INFO FastSync state updated for stream: public-table\n'
+                'INFO FastSync state updated for stream: public-table\n',
+                encoding='utf-8',
+            )
+
+            with self.assertRaises(AssertionError):
+                assertions.assert_fastsync_state_persisted(
+                    str(log_path), {'public-table'}
+                )
+
+    def test_bounded_partial_sync_requires_state_to_remain_unchanged(self):
+        """A bounded repair must not advance the shared Singer bookmark."""
+        original_state = {
+            'bookmarks': {'public-table': {'lsn': '16/B374D848'}}
+        }
+        with TemporaryDirectory() as temp_directory:
+            self._write_state(temp_directory, original_state)
+            with mock.patch.object(
+                assertions.Path, 'home', return_value=Path(temp_directory)
+            ):
+                assertions._assert_partial_sync_state(  # pylint: disable=protected-access
+                    self.tap_parameters,
+                    end_value=10,
+                    state_before=original_state,
+                    log_path='unused',
+                )
+
+                self._write_state(
+                    temp_directory,
+                    {'bookmarks': {'public-table': {'lsn': 'changed'}}},
+                )
+                with self.assertRaises(AssertionError):
+                    assertions._assert_partial_sync_state(  # pylint: disable=protected-access
+                        self.tap_parameters,
+                        end_value=10,
+                        state_before=original_state,
+                        log_path='unused',
+                    )
+
+    @mock.patch('tests.end_to_end.helpers.assertions.assert_resync_tables_success')
+    def test_assert_resync_populates_target_compares_the_complete_fixture(self, resync_mock):
+        """Every configured expression is compared after explicit normalization."""
+        hashed_secret = 'se' + hashlib.sha256(b'cret').hexdigest()
+        self.env.get_rows_from_source.return_value = [
+            (1, {'b': [2], 'a': 1}, 'secret', 1),
+        ]
+        self.env.get_rows_from_target_snowflake.return_value = [
+            (1, '{"a":1,"b":[2]}', hashed_secret, True),
+        ]
+
+        records = assertions.assert_resync_populates_target(
+            self.tap_parameters, primary_key='cid'
+        )
+
+        self.assertEqual(records, [(1, '{"a":1,"b":[2]}', hashed_secret, True)])
+        resync_mock.assert_called_once_with(
+            'postgres_to_sf',
+            'snowflake',
+            expected_streams={'public-edgydata'},
+            tables='public.edgydata',
+        )
+        self.env.get_rows_from_source.assert_called_once_with(
+            tap_type='postgres',
+            source_db='public',
+            table='edgydata',
+            columns=['"cid"', '"payload"', '"secret"', '"active"'],
+            primary_key='cid',
+        )
+        self.env.get_rows_from_target_snowflake.assert_called_once_with(
+            tap_type='postgres',
+            table='edgydata',
+            columns=['"CID"', '"PAYLOAD"', '"SECRET"', '"ACTIVE"'],
+            primary_key='cid',
+        )
+
+    @mock.patch('tests.end_to_end.helpers.assertions.assert_resync_tables_success')
+    def test_assert_resync_populates_target_rejects_a_partial_load(self, resync_mock):
+        """A non-empty but incomplete target is a failure and is not retried."""
+        hashed_secret = 'se' + hashlib.sha256(b'cret').hexdigest()
+        self.env.get_rows_from_source.return_value = [
+            (1, {'a': 1}, 'secret', 1),
+            (2, {'a': 2}, 'secret', 1),
+        ]
+        self.env.get_rows_from_target_snowflake.return_value = [
+            (1, '{"a":1}', hashed_secret, True),
+        ]
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            'first mismatch at ordered row 2; expected .* got .<missing>.; '
+            'expected 2 rows, got 1',
+        ):
+            assertions.assert_resync_populates_target(
+                self.tap_parameters, primary_key='cid'
+            )
+
+        resync_mock.assert_called_once_with(
+            'postgres_to_sf',
+            'snowflake',
+            expected_streams={'public-edgydata'},
+            tables='public.edgydata',
+        )
+
+    @mock.patch('tests.end_to_end.helpers.assertions.assert_resync_tables_success')
+    def test_assert_resync_populates_target_rejects_non_key_corruption(self, resync_mock):
+        """A corrupt value outside the old key/sample pair must fail setup."""
+        hashed_secret = 'se' + hashlib.sha256(b'cret').hexdigest()
+        self.env.get_rows_from_source.return_value = [
+            (1, {'nested': {'value': 1}}, 'secret', 1),
+        ]
+        self.env.get_rows_from_target_snowflake.return_value = [
+            (1, '{"nested":{"value":999}}', hashed_secret, True),
+        ]
+
+        with self.assertRaisesRegex(AssertionError, 'FastSync did not reproduce public.edgydata'):
+            assertions.assert_resync_populates_target(
+                self.tap_parameters, primary_key='cid'
+            )
+
+        resync_mock.assert_called_once_with(
+            'postgres_to_sf',
+            'snowflake',
+            expected_streams={'public-edgydata'},
+            tables='public.edgydata',
+        )
+
+    @mock.patch('tests.end_to_end.helpers.assertions.assert_resync_tables_success')
+    def test_assert_resync_populates_target_rejects_an_empty_source_fixture(self, resync_mock):
+        """An accidentally empty source and target must not make setup pass."""
+        self.env.get_rows_from_source.return_value = []
+        self.env.get_rows_from_target_snowflake.return_value = []
+
+        with self.assertRaisesRegex(AssertionError, 'Source fixture public.edgydata is empty'):
+            assertions.assert_resync_populates_target(
+                self.tap_parameters, primary_key='cid'
+            )
+
+        resync_mock.assert_called_once_with(
+            'postgres_to_sf',
+            'snowflake',
+            expected_streams={'public-edgydata'},
+            tables='public.edgydata',
+        )
+
+    @mock.patch('tests.end_to_end.helpers.assertions.assert_state_file_valid')
+    @mock.patch('tests.end_to_end.helpers.assertions.assert_fastsync_state_persisted')
+    @mock.patch('tests.end_to_end.helpers.assertions.assert_command_success')
+    @mock.patch(
+        'tests.end_to_end.helpers.assertions.tasks.find_run_tap_log_file',
+        return_value='/tmp/run.fastsync.log',
+    )
+    @mock.patch(
+        'tests.end_to_end.helpers.assertions.tasks.run_command',
+        return_value=[
+            0,
+            'Writing output into /tmp/run.fastsync.log\n',
+            '',
+        ],
+    )
+    def test_resync_command_scopes_fastsync_to_the_requested_table(
+        self,
+        run_command_mock,
+        _find_log_mock,
+        _success_mock,
+        _state_marker_mock,
+        _state_file_mock,
+    ):
+        """Fixture setup must not resync unrelated tables or expect their markers."""
+        assertions.assert_resync_tables_success(
+            'postgres_to_sf',
+            'snowflake',
+            expected_streams={'public-edgydata'},
+            tables='public.edgydata',
+        )
+
+        run_command_mock.assert_called_once_with(
+            'pipelinewise fast_sync --tap postgres_to_sf --target snowflake '
+            '--tables public.edgydata'
+        )
+
+    def test_get_rows_from_source_uses_the_requested_route_and_order(self):
+        """Source verification must query the configured table and primary-key order."""
+        env = mock.Mock(spec=E2EEnv)
+        env.run_query_tap_postgres.return_value = [(1, '12:00'), (2, '13:00')]
+
+        records = E2EEnv.get_rows_from_source(
+            env,
+            tap_type='postgres',
+            source_db='public',
+            table='edgydata',
+            columns=['cid', 'ctimentz'],
+            primary_key='cid',
+        )
+
+        self.assertEqual(records, [(1, '12:00'), (2, '13:00')])
+        env.run_query_tap_postgres.assert_called_once_with(
+            'SELECT cid, ctimentz FROM public.edgydata ORDER BY cid'
+        )
+
+    def test_get_rows_from_source_accepts_canonical_tap_route_identifiers(self):
+        """Snowflake E2E base classes pass TAP_* identifiers to source helpers."""
+        env = mock.Mock(spec=E2EEnv)
+
+        for tap_type, method_name in (
+            ('TAP_MYSQL', 'run_query_tap_mysql'),
+            ('TAP_POSTGRES', 'run_query_tap_postgres'),
+        ):
+            with self.subTest(tap_type=tap_type):
+                query_method = getattr(env, method_name)
+                query_method.return_value = [(1,)]
+
+                records = E2EEnv.get_rows_from_source(
+                    env,
+                    tap_type=tap_type,
+                    source_db='source_db',
+                    table='source_table',
+                    columns=['id'],
+                    primary_key='id',
+                )
+
+                self.assertEqual(records, [(1,)])
+                query_method.assert_called_once_with(
+                    'SELECT id FROM source_db.source_table ORDER BY id'
+                )
+
+    def test_get_rows_from_target_uses_the_unique_schema_and_order(self):
+        """Target verification must use this run's schema and primary-key order."""
+        env = mock.Mock(spec=E2EEnv)
+        env.sf_schema_postfix = '_unique'
+        env.run_query_target_snowflake.return_value = [(1, '12:00')]
+
+        records = E2EEnv.get_rows_from_target_snowflake(
+            env,
+            tap_type='postgres',
+            table='edgydata',
+            columns=['cid', 'ctimentz'],
+            primary_key='cid',
+        )
+
+        self.assertEqual(records, [(1, '12:00')])
+        env.run_query_target_snowflake.assert_called_once_with(
+            'SELECT cid, ctimentz FROM ppw_e2e_tap_postgres_unique.edgydata '
+            'ORDER BY "CID"'
+        )
+
+    def test_get_rows_from_target_accepts_canonical_tap_route_identifier(self):
+        """Canonical TAP_* names must not duplicate the schema's tap_ prefix."""
+        env = mock.Mock(spec=E2EEnv)
+        env.sf_schema_postfix = '_unique'
+        env.run_query_target_snowflake.return_value = [(1,)]
+
+        records = E2EEnv.get_rows_from_target_snowflake(
+            env,
+            tap_type='TAP_MYSQL',
+            table='weight_unit',
+            columns=['weight_unit_id'],
+            primary_key='weight_unit_id',
+        )
+
+        self.assertEqual(records, [(1,)])
+        env.run_query_target_snowflake.assert_called_once_with(
+            'SELECT weight_unit_id FROM ppw_e2e_tap_mysql_unique.weight_unit '
+            'ORDER BY "WEIGHT_UNIT_ID"'
+        )
+
+    def test_environment_uses_configured_snowflake_schema_postfix_everywhere(self):
+        """A fixed override must replace the generated query/cleanup postfix."""
+        env = object.__new__(E2EEnv)
+        env.sf_schema_postfix = '_generated'
+
+        with mock.patch.object(env_module, 'load_dotenv'), mock.patch.object(
+            E2EEnv, '_is_env_connector_configured', return_value=True
+        ), mock.patch.dict(
+            env_module.os.environ,
+            {'TARGET_SNOWFLAKE_SCHEMA_POSTFIX': '_configured'},
+            clear=True,
+        ):
+            env._load_env()  # pylint: disable=protected-access
+
+        self.assertEqual(env.sf_schema_postfix, '_configured')
+        self.assertTrue(env.sf_schema_postfix_is_override)
+        self.assertEqual(
+            env.get_conn_env_var('TARGET_SNOWFLAKE', 'SCHEMA_POSTFIX'),
+            '_configured',
+        )
+
+    def test_environment_keeps_generated_postfix_without_an_override(self):
+        """The generated postfix is the single value when no override exists."""
+        env = object.__new__(E2EEnv)
+        env.sf_schema_postfix = '_generated'
+
+        with mock.patch.object(env_module, 'load_dotenv'), mock.patch.object(
+            E2EEnv, '_is_env_connector_configured', return_value=True
+        ), mock.patch.dict(env_module.os.environ, {}, clear=True):
+            env._load_env()  # pylint: disable=protected-access
+
+        self.assertEqual(env.sf_schema_postfix, '_generated')
+        self.assertFalse(env.sf_schema_postfix_is_override)
+        self.assertEqual(
+            env.get_conn_env_var('TARGET_SNOWFLAKE', 'SCHEMA_POSTFIX'),
+            '_generated',
+        )
+
+    def test_partial_sync_command_includes_each_boundary_once(self):
+        """Render both boundaries exactly once, including a zero start value."""
+        command = assertions._get_command_for_partial_sync(  # pylint: disable=protected-access
+            self.tap_parameters,
+            start_value=0,
+            end_value=7,
+        )
+
+        self.assertEqual(
+            command,
+            'pipelinewise partial_sync_table --tap postgres_to_sf --target snowflake '
+            '--table public.edgydata --column cid --start_value 0 --end_value 7',
+        )
+
+    def test_partial_sync_command_omits_an_unspecified_end_boundary(self):
+        """Do not render a synthetic end boundary when none was requested."""
+        command = assertions._get_command_for_partial_sync(  # pylint: disable=protected-access
+            self.tap_parameters,
+            start_value=3,
+        )
+
+        self.assertEqual(
+            command,
+            'pipelinewise partial_sync_table --tap postgres_to_sf --target snowflake '
+            '--table public.edgydata --column cid --start_value 3',
+        )
+
+    @mock.patch('tests.end_to_end.target_snowflake.shutil.rmtree')
+    def test_remove_generated_config_removes_the_exact_directory(self, rmtree_mock):
+        """Generated-target cleanup must remove only its resolved directory."""
+        target = TargetSnowflake(methodName='runTest')
+
+        target.remove_dir_from_config_dir('snowflake/postgres_to_sf')
+
+        rmtree_mock.assert_called_once_with(
+            os.path.join(
+                target_snowflake_module.CONFIG_DIR,
+                'snowflake/postgres_to_sf',
+            )
+        )
+
+    @mock.patch(
+        'tests.end_to_end.target_snowflake.shutil.rmtree',
+        side_effect=FileNotFoundError,
+    )
+    def test_remove_generated_config_tolerates_a_missing_directory(self, rmtree_mock):
+        """An already absent generated-target directory is clean state."""
+        target = TargetSnowflake(methodName='runTest')
+
+        target.remove_dir_from_config_dir('snowflake')
+
+        rmtree_mock.assert_called_once()
+
+    @mock.patch(
+        'tests.end_to_end.target_snowflake.shutil.rmtree',
+        side_effect=PermissionError('cleanup failed'),
+    )
+    def test_remove_generated_config_propagates_other_failures(self, _rmtree_mock):
+        """Permission and filesystem failures must fail target setup."""
+        target = TargetSnowflake(methodName='runTest')
+
+        with self.assertRaisesRegex(PermissionError, 'cleanup failed'):
+            target.remove_dir_from_config_dir('snowflake')
+
+    @mock.patch('tests.end_to_end.helpers.env.shutil.rmtree')
+    def test_environment_config_cleanup_removes_the_exact_directory(self, rmtree_mock):
+        """Environment cleanup must resolve the requested generated target."""
+        E2EEnv.remove_dir_from_config_dir('postgres_dwh')
+
+        rmtree_mock.assert_called_once_with(
+            os.path.join(env_module.CONFIG_DIR, 'postgres_dwh')
+        )
+
+    @mock.patch(
+        'tests.end_to_end.helpers.env.shutil.rmtree',
+        side_effect=FileNotFoundError,
+    )
+    def test_environment_config_cleanup_tolerates_absence(self, rmtree_mock):
+        """Environment cleanup tolerates only an already absent directory."""
+        E2EEnv.remove_dir_from_config_dir('snowflake')
+
+        rmtree_mock.assert_called_once()
+
+    @mock.patch(
+        'tests.end_to_end.helpers.env.shutil.rmtree',
+        side_effect=PermissionError('cleanup failed'),
+    )
+    def test_environment_config_cleanup_propagates_failures(self, _rmtree_mock):
+        """Environment cleanup must surface permission failures."""
+        with self.assertRaisesRegex(PermissionError, 'cleanup failed'):
+            E2EEnv.remove_dir_from_config_dir('snowflake')
+
+    def test_unconfigured_template_cleanup_propagates_permission_failures(self):
+        """Stale rendered YAML cannot silently survive a failed deletion."""
+        env = object.__new__(E2EEnv)
+
+        with TemporaryDirectory() as temp_directory:
+            template_path = os.path.join(temp_directory, 'optional.yml.template')
+            with open(template_path, 'w', encoding='utf-8') as template_file:
+                template_file.write('key: value')
+
+            with mock.patch.object(
+                    env, '_find_env_conn_by_template_name', return_value=['OPTIONAL']
+            ), mock.patch.object(
+                    env, '_is_env_connector_configured', return_value=False
+            ), mock.patch.object(env_module.glob, 'glob', return_value=[template_path]), \
+                    mock.patch.object(
+                        env_module.os,
+                        'remove',
+                        side_effect=PermissionError('cleanup failed'),
+                    ):
+                with self.assertRaisesRegex(PermissionError, 'cleanup failed'):
+                    env._init_test_project_dir(temp_directory)  # pylint: disable=protected-access
+
+    def test_snowflake_setup_propagates_config_cleanup_failure(self):
+        """Target setup must stop immediately when generated config cannot be cleaned."""
+        target = TargetSnowflake(methodName='runTest')
+        self.env.env = {'TAP_MYSQL': {'is_configured': True}}
+        target.get_e2e_env = mock.Mock(return_value=self.env)
+        target.remove_dir_from_config_dir = mock.Mock(
+            side_effect=PermissionError('cleanup failed')
+        )
+        credentials_check = mock.Mock()
+        setattr(target, 'check_snowflake_credentials_provided', credentials_check)
+        target.check_validate_taps = mock.Mock()
+        target.check_import_config = mock.Mock()
+
+        with self.assertRaisesRegex(PermissionError, 'cleanup failed'):
+            target.setUp('mariadb_to_sf', 'snowflake', 'TAP_MYSQL')
+
+        credentials_check.assert_not_called()
+        target.check_validate_taps.assert_not_called()
+        target.check_import_config.assert_not_called()
+
+    def test_snowflake_setup_resets_config_before_validate_and_import(self):
+        """Register exact cleanup without deleting another run during setup."""
+        target = TargetSnowflake(methodName='runTest')
+        events = []
+        self.env.env = {
+            'TAP_MYSQL': {'is_configured': True},
+            'TARGET_SNOWFLAKE': {'is_configured': True},
+        }
+        self.env.sf_schema_postfix = '_unique'
+        self.env.sf_schema_postfix_is_override = False
+        self.env.run_query_target_snowflake.side_effect = (
+            lambda *args: events.append(('snowflake_query', args)) or []
+        )
+        target.get_e2e_env = mock.Mock(
+            side_effect=lambda: events.append(('get_env', ())) or self.env
+        )
+        target.remove_dir_from_config_dir = mock.Mock(
+            side_effect=lambda *args: events.append(('remove_config', args))
+        )
+        setattr(
+            target,
+            'check_snowflake_credentials_provided',
+            mock.Mock(side_effect=lambda: events.append(('check_credentials', ()))),
+        )
+        target.check_validate_taps = mock.Mock(
+            side_effect=lambda: events.append(('validate', ()))
+        )
+        target.check_import_config = mock.Mock(
+            side_effect=lambda: events.append(('import', ()))
+        )
+        target.drop_sf_schema_if_exists = mock.Mock(
+            side_effect=lambda *args: events.append(('drop_schema', args))
+        )
+
+        target.setUp('mariadb_to_sf', 'snowflake', 'TAP_MYSQL')
+
+        self.assertEqual(
+            events,
+            [
+                ('get_env', ()),
+                ('remove_config', ('snowflake',)),
+                ('check_credentials', ()),
+                ('validate', ()),
+                ('import', ()),
+            ],
+        )
+        self.assertEqual(target.tap_type, 'TAP_MYSQL')
+
+        target.doCleanups()
+
+        self.assertEqual(
+            events[5:],
+            [
+                ('drop_schema', ('PPW_E2E_TAP_MYSQL_2_UNIQUE',)),
+                ('drop_schema', ('PPW_E2E_TAP_MYSQL_PUBLIC2_UNIQUE',)),
+                ('drop_schema', ('PPW_E2E_TAP_MYSQL_UNIQUE',)),
+                ('remove_config', ('snowflake/mariadb_to_sf',)),
+            ],
+        )
+
+    def test_mariadb_setup_resets_source_before_validate_and_import(self):
+        """Discovery must inspect the freshly reset MariaDB fixture."""
+        target = TapMariaDB(methodName='runTest')
+        events = []
+        self.env.env = {
+            'TAP_MYSQL': {'is_configured': True},
+            'TARGET_SNOWFLAKE': {'is_configured': True},
+        }
+        self.env.sf_schema_postfix = '_unique'
+        self.env.sf_schema_postfix_is_override = False
+        self.env.setup_tap_mysql.side_effect = lambda: events.append(('reset_mysql', ()))
+        target.get_e2e_env = mock.Mock(
+            side_effect=lambda: events.append(('get_env', ())) or self.env
+        )
+        target.remove_dir_from_config_dir = mock.Mock(
+            side_effect=lambda *args: events.append(('remove_config', args))
+        )
+        setattr(
+            target,
+            'check_snowflake_credentials_provided',
+            mock.Mock(side_effect=lambda: events.append(('check_credentials', ()))),
+        )
+        target.check_validate_taps = mock.Mock(
+            side_effect=lambda: events.append(('validate', ()))
+        )
+        target.check_import_config = mock.Mock(
+            side_effect=lambda: events.append(('import', ()))
+        )
+        target.drop_sf_schema_if_exists = mock.Mock()
+
+        target.setUp('mariadb_to_sf', 'snowflake')
+
+        self.assertEqual(
+            events,
+            [
+                ('get_env', ()),
+                ('remove_config', ('snowflake',)),
+                ('check_credentials', ()),
+                ('reset_mysql', ()),
+                ('validate', ()),
+                ('import', ()),
+            ],
+        )
+        self.env.setup_tap_mysql.assert_called_once_with()
+        target.doCleanups()
+
+    def test_postgres_setup_resets_source_before_validate_and_import(self):
+        """Discovery must inspect the freshly reset PostgreSQL fixture."""
+        target = TapPostgres(methodName='runTest')
+        events = []
+        self.env.env = {
+            'TAP_POSTGRES': {'is_configured': True},
+            'TARGET_SNOWFLAKE': {'is_configured': True},
+        }
+        self.env.sf_schema_postfix = '_unique'
+        self.env.sf_schema_postfix_is_override = False
+        self.env.clean_up_temp_dir.side_effect = lambda: events.append(('clean_temp', ()))
+        self.env.setup_tap_postgres.side_effect = lambda: events.append(
+            ('reset_postgres', ())
+        )
+        target.get_e2e_env = mock.Mock(
+            side_effect=lambda: events.append(('get_env', ())) or self.env
+        )
+        target.remove_dir_from_config_dir = mock.Mock(
+            side_effect=lambda *args: events.append(('remove_config', args))
+        )
+        setattr(
+            target,
+            'check_snowflake_credentials_provided',
+            mock.Mock(side_effect=lambda: events.append(('check_credentials', ()))),
+        )
+        target.check_validate_taps = mock.Mock(
+            side_effect=lambda: events.append(('validate', ()))
+        )
+        target.check_import_config = mock.Mock(
+            side_effect=lambda: events.append(('import', ()))
+        )
+        target.drop_sf_schema_if_exists = mock.Mock()
+
+        target.setUp('postgres_to_sf', 'snowflake')
+
+        self.assertEqual(
+            events,
+            [
+                ('get_env', ()),
+                ('remove_config', ('snowflake',)),
+                ('check_credentials', ()),
+                ('clean_temp', ()),
+                ('reset_postgres', ()),
+                ('validate', ()),
+                ('import', ()),
+            ],
+        )
+        self.env.clean_up_temp_dir.assert_called_once_with()
+        self.env.setup_tap_postgres.assert_called_once_with()
+        target.doCleanups()
+
+    def test_source_reset_failure_keeps_registered_cleanup(self):
+        """A source-reset failure must stop discovery and retain base cleanup."""
+        target = TapPostgres(methodName='runTest')
+        self.env.env = {
+            'TAP_POSTGRES': {'is_configured': True},
+            'TARGET_SNOWFLAKE': {'is_configured': True},
+        }
+        self.env.sf_schema_postfix = '_current'
+        self.env.sf_schema_postfix_is_override = False
+        self.env.setup_tap_postgres.side_effect = RuntimeError('source reset failed')
+        target.get_e2e_env = mock.Mock(return_value=self.env)
+        target.remove_dir_from_config_dir = mock.Mock()
+        setattr(target, 'check_snowflake_credentials_provided', mock.Mock())
+        target.check_validate_taps = mock.Mock()
+        target.check_import_config = mock.Mock()
+        target.drop_sf_schema_if_exists = mock.Mock()
+
+        with self.assertRaisesRegex(RuntimeError, 'source reset failed'):
+            target.setUp('postgres_to_sf', 'snowflake')
+
+        target.check_validate_taps.assert_not_called()
+        target.check_import_config.assert_not_called()
+        target.doCleanups()
+
+        self.assertEqual(
+            target.drop_sf_schema_if_exists.call_args_list,
+            [
+                mock.call('PPW_E2E_TAP_POSTGRES_2_CURRENT'),
+                mock.call('PPW_E2E_TAP_POSTGRES_PUBLIC2_CURRENT'),
+                mock.call('PPW_E2E_TAP_POSTGRES_CURRENT'),
+            ],
+        )
+        self.assertEqual(
+            target.remove_dir_from_config_dir.call_args_list,
+            [
+                mock.call('snowflake'),
+                mock.call('snowflake/postgres_to_sf'),
+            ],
+        )
+
+    def test_snowflake_setup_failure_runs_exact_registered_cleanup(self):
+        """A later setup failure must not leak this run's schemas or config."""
+        target = TargetSnowflake(methodName='runTest')
+        self.env.env = {
+            'TAP_POSTGRES': {'is_configured': True},
+            'TARGET_SNOWFLAKE': {'is_configured': True},
+        }
+        self.env.sf_schema_postfix = '_current'
+        self.env.sf_schema_postfix_is_override = True
+        target.get_e2e_env = mock.Mock(return_value=self.env)
+        target.remove_dir_from_config_dir = mock.Mock()
+        setattr(target, 'check_snowflake_credentials_provided', mock.Mock())
+        target.check_validate_taps = mock.Mock(side_effect=RuntimeError('validation failed'))
+        target.check_import_config = mock.Mock()
+        target.drop_sf_schema_if_exists = mock.Mock()
+
+        with self.assertRaisesRegex(RuntimeError, 'validation failed'):
+            target.setUp('postgres_to_sf', 'snowflake', 'TAP_POSTGRES')
+
+        target.doCleanups()
+
+        self.assertEqual(
+            target.drop_sf_schema_if_exists.call_args_list,
+            [
+                mock.call('PPW_E2E_TAP_POSTGRES_CURRENT'),
+                mock.call('PPW_E2E_TAP_POSTGRES_PUBLIC2_CURRENT'),
+                mock.call('PPW_E2E_TAP_POSTGRES_2_CURRENT'),
+                mock.call('PPW_E2E_TAP_POSTGRES_2_CURRENT'),
+                mock.call('PPW_E2E_TAP_POSTGRES_PUBLIC2_CURRENT'),
+                mock.call('PPW_E2E_TAP_POSTGRES_CURRENT'),
+            ],
+        )
+        self.assertEqual(
+            target.remove_dir_from_config_dir.call_args_list,
+            [
+                mock.call('snowflake'),
+                mock.call('snowflake/postgres_to_sf'),
+            ],
+        )
+        target.check_import_config.assert_not_called()

--- a/tests/units/test_end_to_end_task_helpers.py
+++ b/tests/units/test_end_to_end_task_helpers.py
@@ -1,0 +1,63 @@
+from unittest import TestCase
+
+from tests.end_to_end.helpers import tasks
+
+
+class EndToEndTaskHelpersTestCase(TestCase):
+    """Tests for command-output parsing used by the E2E assertions."""
+
+    def test_find_run_tap_log_file_returns_the_only_matching_engine_log(self):
+        """Return the one log belonging to the requested engine."""
+        stdout = (
+            'Writing output into /tmp/run.singer.log\n'
+            'Writing output into /tmp/run.fastsync.log\n'
+        )
+
+        self.assertEqual(
+            tasks.find_run_tap_log_file(stdout, 'fastsync'),
+            '/tmp/run.fastsync.log',
+        )
+
+    def test_find_run_tap_log_file_rejects_missing_engine_log(self):
+        """Fail clearly when the requested engine did not start."""
+        with self.assertRaisesRegex(
+            AssertionError,
+            'Expected exactly one fastsync log file, found 0',
+        ):
+            tasks.find_run_tap_log_file('', 'fastsync')
+
+    def test_find_run_tap_log_file_rejects_duplicate_engine_logs(self):
+        """Reject an unintended second run of the same sync engine."""
+        stdout = (
+            'Writing output into /tmp/first.fastsync.log\n'
+            'Writing output into /tmp/second.fastsync.log\n'
+        )
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            'Expected exactly one fastsync log file, found 2',
+        ):
+            tasks.find_run_tap_log_file(stdout, 'fastsync')
+
+    def test_log_engines_reject_extra(self):
+        """Reject an unrequested different sync engine."""
+        stdout = (
+            'Writing output into /tmp/run.fastsync.log\n'
+            'Writing output into /tmp/run.partialsync.log\n'
+        )
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            "Expected sync engine logs {'fastsync': 1}, "
+            "found {'fastsync': 1, 'partialsync': 1}",
+        ):
+            tasks.assert_run_tap_log_engines(stdout, ('fastsync',))
+
+    def test_log_engines_accept_exact_set(self):
+        """Accept one log for every requested engine and no others."""
+        stdout = (
+            'Writing output into /tmp/run.fastsync.log\n'
+            'Writing output into /tmp/run.singer.log\n'
+        )
+
+        tasks.assert_run_tap_log_engines(stdout, ('fastsync', 'singer'))

--- a/tests/units/test_end_to_end_temp_cleanup_helpers.py
+++ b/tests/units/test_end_to_end_temp_cleanup_helpers.py
@@ -1,0 +1,95 @@
+import os
+
+from tempfile import TemporaryDirectory
+from unittest import TestCase, mock
+
+from tests.end_to_end.helpers import env as env_module
+from tests.end_to_end.helpers.env import E2EEnv
+
+
+class EndToEndTempCleanupHelpersTestCase(TestCase):
+    """Tests for E2E staging cleanup that do not require external services."""
+
+    def test_temp_cleanup_removes_files_and_unlinks_directory_symlinks(self):
+        """Clean files and links without recursively deleting a link target."""
+        with TemporaryDirectory() as temp_directory:
+            temp_file = os.path.join(temp_directory, 'part.csv.gz')
+            target_directory = os.path.join(temp_directory, 'source-data')
+            directory_symlink = os.path.join(temp_directory, 'source-link')
+            os.mkdir(target_directory)
+            with open(temp_file, 'w', encoding='utf-8') as file_handle:
+                file_handle.write('staged data')
+            os.symlink(target_directory, directory_symlink)
+
+            with mock.patch.object(
+                env_module.glob,
+                'glob',
+                return_value=[temp_file, directory_symlink],
+            ):
+                E2EEnv.clean_up_temp_dir()
+
+            self.assertFalse(os.path.exists(temp_file))
+            self.assertFalse(os.path.lexists(directory_symlink))
+            self.assertTrue(os.path.isdir(target_directory))
+
+    def test_temp_cleanup_removes_directories_recursively(self):
+        """Clean nested connector staging directories left by E2E runs."""
+        with TemporaryDirectory() as temp_directory:
+            staging_directory = os.path.join(temp_directory, 'mongo_source_db')
+            os.mkdir(staging_directory)
+            with open(
+                os.path.join(staging_directory, 'document.json'),
+                'w',
+                encoding='utf-8',
+            ) as file_handle:
+                file_handle.write('{}')
+
+            with mock.patch.object(
+                env_module.glob, 'glob', return_value=[staging_directory]
+            ):
+                E2EEnv.clean_up_temp_dir()
+
+            self.assertFalse(os.path.exists(staging_directory))
+
+    def test_temp_cleanup_tolerates_a_concurrently_removed_entry(self):
+        """A file disappearing between discovery and deletion is clean state."""
+        temp_file = os.path.join(env_module.CONFIG_DIR, 'tmp', 'part.csv.gz')
+
+        with mock.patch.object(
+            env_module.glob, 'glob', return_value=[temp_file]
+        ), mock.patch.object(
+            env_module.os, 'remove', side_effect=FileNotFoundError
+        ) as remove_mock:
+            E2EEnv.clean_up_temp_dir()
+
+        remove_mock.assert_called_once_with(temp_file)
+
+    def test_temp_cleanup_propagates_file_removal_failures(self):
+        """A file-removal error must not leave stale staged data silently."""
+        temp_file = os.path.join(env_module.CONFIG_DIR, 'tmp', 'part.csv.gz')
+
+        with mock.patch.object(
+            env_module.glob, 'glob', return_value=[temp_file]
+        ), mock.patch.object(
+            env_module.os,
+            'remove',
+            side_effect=PermissionError('cleanup failed'),
+        ):
+            with self.assertRaisesRegex(PermissionError, 'cleanup failed'):
+                E2EEnv.clean_up_temp_dir()
+
+    def test_temp_cleanup_propagates_directory_removal_failures(self):
+        """A directory-removal error must not leave staged data silently."""
+        with TemporaryDirectory() as temp_directory:
+            staging_directory = os.path.join(temp_directory, 'mongo_source_db')
+            os.mkdir(staging_directory)
+
+            with mock.patch.object(
+                env_module.glob, 'glob', return_value=[staging_directory]
+            ), mock.patch.object(
+                env_module.shutil,
+                'rmtree',
+                side_effect=PermissionError('cleanup failed'),
+            ):
+                with self.assertRaisesRegex(PermissionError, 'cleanup failed'):
+                    E2EEnv.clean_up_temp_dir()


### PR DESCRIPTION
## Context

This is review slice **1 of 6** from the AP-2830 quality audit. The six slices will be merged separately for review and deployed together as PipelineWise **0.79.0** after the final slice is merged. During review, `setup.py` remains at `0.78.0` and the CHANGELOG uses temporary `0.79.0-sliceN` headings. The version bump and consolidation into one `0.79.0` entry happen only before deployment.

This slice hardens shared FastSync and Snowflake target behavior before the source-specific releases. It makes FullSync and PartialSync publication failure-safe, makes FastSync state writes process-safe and crash-safe, closes source connections after failures, and strengthens the shared test harness.

It also fixes GitHub CI changed-file detection so large pull requests and GitHub API failures cannot produce false-green, fast-finishing checks. Changed-file requests are authenticated and paginated, and failures are handled fail-closed.

The six review slices are:

- 1/6 — Harden shared FastSync and Snowflake target behaviour
- 2/6 — Harden PostgreSQL, including target-snowflake unit CI
- 3/6 — Harden MariaDB and MySQL
- 4/6 — Harden existing Snowflake table conversion
- 5/6 — Rewrite documentation
- 6/6 — Update CI and dependencies

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue) [optional]
- [ ] New feature (non-breaking change which adds functionality) [optional]
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) [optional]
- [ ] Documentation Update (if none of the other choices apply) [optional]

## Validation

- Focused dev-project unit tests — 50 passed, 6 subtests passed
- Focused dev-project PostgreSQL/MariaDB-to-Snowflake E2E — 3 passed
- GitHub Actions — all lint, unit, connector-install, documentation, and E2E checks passed
- `git diff --check` — passed for this slice

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Relevant documentation is updated including usage instructions
