### PR TITLE
Improve contribution and troubleshooting guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,55 @@
 ## Context
 
-_Describe the problem your PR is trying to solve_
+<!-- Describe the problem, its operational consequence, and any related issue. -->
 
 
-## Types of changes
+## Changes
 
-What types of changes does your code introduce to PipelineWise?
-_Put an `x` in the boxes that apply_
+<!-- Summarize the chosen behaviour and explain non-obvious decisions. -->
 
-- [ ] Bugfix (non-breaking change which fixes an issue) [optional]
-- [ ] New feature (non-breaking change which adds functionality) [optional]
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) [optional]
-- [ ] Documentation Update (if none of the other choices apply) [optional]
+
+## Type of change
+
+<!-- Select every type that applies. -->
+
+- [ ] Bug fix
+- [ ] New functionality
+- [ ] Maintenance, dependency, or CI
+- [ ] Documentation
+- [ ] Breaking change
+
+
+## Compatibility and operations
+
+<!--
+Describe compatibility, state, schema, data, migration, deployment, rollback, and
+recovery considerations. Write "N/A" where none apply.
+-->
+
+
+## Validation
+
+<!--
+List exact commands and pass, fail, and skip counts. Explain unavailable or
+credential-dependent checks; do not report them as passing.
+-->
+
+| Command or check | Result |
+|---|---|
+| `...` | ... |
 
 
 ## Checklist
 
-- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
-- [ ] Description above provides context of the change
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] Unit tests for changes (not needed for documentation changes)
-- [ ] CI checks pass with my changes
-- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
-- [ ] Relevant documentation is updated including usage instructions
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
+- [ ] This pull request is focused and can be reviewed and reverted
+      independently.
+- [ ] Behavioural changes have regression tests, or I explained why tests are not
+      applicable.
+- [ ] Relevant documentation and changelog entries are updated, or I explained
+      why they are not applicable.
+- [ ] Applicable local checks pass; failures, skips, and unavailable checks are
+      documented above.
+- [ ] The change contains no credentials, private keys, production identifiers,
+      or source records.
+- [ ] Breaking and compatibility impacts are identified above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,8 @@ Also follow scoped checks:
 ## Git and completion
 
 Branch from `master` and keep diffs task-scoped.
+Create every commit with a cryptographic signature using `git commit -S`; never
+create or push an unsigned commit.
 
 Keep CHANGELOG entries concise and atomic: one independently reviewable change per bullet. Use headings to preserve test categories instead of combining multiple changes in one bullet.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,13 @@ requirements are clear.
 ## Before changing code
 
 1. Fork the repository and create a focused branch from `master`.
-2. Inspect the relevant implementation and tests before proposing a change.
-3. Reproduce defects with the smallest deterministic test you can.
-4. Use the [`dev-project`](dev-project/README.md) Docker environment wherever
+2. Sign every commit using `git commit -S`; unsigned commits are not accepted.
+3. Inspect the relevant implementation and tests before proposing a change.
+4. Reproduce defects with the smallest deterministic test you can.
+5. Use the [`dev-project`](dev-project/README.md) Docker environment wherever
    possible. Its Linux runtime, databases, and connector layout best approximate
    production.
-5. If you use an AI coding agent, ensure it follows the root and applicable
+6. If you use an AI coding agent, ensure it follows the root and applicable
    scoped `AGENTS.md` files.
 
 Never commit credentials, populated environment files, private keys, production

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,40 +1,45 @@
 # Contributing to PipelineWise
 
-PipelineWise accepts focused bug fixes, tests, documentation, and connector
-improvements. Discuss large features or compatibility changes in a GitHub issue
-before implementation so support, migration, and operational requirements are
-clear.
+PipelineWise welcomes focused bug fixes, tests, documentation, and connector
+improvements. Discuss large features, breaking changes, and new connectors in a
+GitHub issue before implementation so the compatibility and operational
+requirements are clear.
 
 ## Before changing code
 
-1. Fork the repository and branch from `master`.
-2. Read the root `AGENTS.md` and the scoped file for the package you will change.
-3. Inspect the existing worktree and preserve unrelated changes.
-4. Reproduce the problem with the smallest deterministic test.
-5. Use the `dev-project` Docker environment wherever possible; its Linux,
-   database, and connector layout best approximates production.
+1. Fork the repository and create a focused branch from `master`.
+2. Inspect the relevant implementation and tests before proposing a change.
+3. Reproduce defects with the smallest deterministic test you can.
+4. Use the [`dev-project`](dev-project/README.md) Docker environment wherever
+   possible. Its Linux runtime, databases, and connector layout best approximate
+   production.
+5. If you use an AI coding agent, ensure it follows the root and applicable
+   scoped `AGENTS.md` files.
 
-Do not include credentials, populated environment files, private keys, source
-records, or production identifiers in a pull request.
+Never commit credentials, populated environment files, private keys, production
+identifiers, or source records. Replace sensitive values with deterministic test
+fixtures that preserve the relevant type, size, or boundary.
 
 ## Implementation expectations
 
-- Keep changes within the owning package and avoid unrelated formatting.
-- Add regression coverage for observable behaviour, failure boundaries, state,
-  cleanup, and retries.
-- Preserve target-bounded Singer acknowledgement and replay safety.
-- Update connector configuration, samples, schemas, and documentation together.
-- Treat FastSync as a native transfer optimisation, not a replication method.
-- Add a changelog entry for release-visible behaviour or dependency changes.
+- Keep the change within the owning package and avoid unrelated formatting.
+- Add regression tests for changed behaviour. Cover relevant state, failure,
+  cleanup, retry, and replay boundaries.
+- Update configuration schemas, samples, and documentation with their behaviour.
+- Declare dependencies in the owning `setup.py`; do not rely on transitive
+  installations.
+- Add a concise changelog entry for release-visible behaviour or dependency
+  changes. Keep each independently reviewable change in its own bullet.
+- Only Maintainers can correlate all changelog entries and convert into a Release
 
-New connectors begin as Experimental. Promotion to Available requires maintained
-ownership, dependency and CI coverage, deterministic interruption recovery, and a
-documented operated route.
+New connectors begin as Experimental. Maintainers promote a connector to
+Available only after its ownership, dependencies, compatibility, CI coverage,
+recovery behaviour, and operated routes are documented.
 
 ## Verification
 
-Run checks in the ready `pipelinewise` container. The root implementation gates
-are:
+Run applicable checks in the ready `pipelinewise` container. The root
+implementation gates are:
 
 ```bash
 ruff check pipelinewise tests
@@ -44,10 +49,18 @@ flake8 pipelinewise --count --max-complexity=15 --max-line-length=120 --statisti
 pytest --cov=pipelinewise --cov-fail-under=77 -v tests/units
 ```
 
-Never run bare `pytest tests/`; it collects credentialed end-to-end tests.
+Never run bare `pytest tests/`; it also collects credentialed end-to-end tests.
 
-Connector source has its own Makefile, lint, unit, coverage, integration, and E2E
-requirements under `singer-connectors/AGENTS.md`. Root gates do not inspect it.
+Changes under `singer-connectors/` require the owning connector's install, lint,
+unit, coverage, and applicable integration targets. Root checks do not inspect
+vendored connector source. Run relevant database and end-to-end routes serially
+using the [`dev-project`](dev-project/README.md) environment.
+
+After configuration schema or sample changes, run:
+
+```bash
+pipelinewise validate --dir dev-project/pipelinewise-config
+```
 
 For documentation changes, run:
 
@@ -56,36 +69,41 @@ cd docs
 make check
 ```
 
-Always run `git diff --check`. Report exact commands and pass, fail, and skip
-counts; an unavailable or skipped integration is not a passing result.
+Always run `git diff --check`. In the pull request, list exact commands and their
+pass, fail, and skip counts. Treat skipped, unavailable, or credential-dependent
+checks as explicit coverage gaps rather than passing verification.
 
 ## Pull requests
 
-A pull request should contain:
+Keep each pull request focused enough to review and revert independently. Explain:
 
-- the problem and operational consequence;
-- the chosen behaviour and compatibility impact;
-- tests that fail without the change;
-- migration, rollback, or recovery instructions where relevant;
-- documentation and changelog updates; and
-- exact validation evidence.
+- the problem and its operational consequence;
+- the chosen behaviour and any compatibility impact;
+- the tests that demonstrate behavioural changes;
+- migration, deployment, rollback, and recovery considerations where relevant;
+- documentation and changelog changes; and
+- exact validation results, including skipped or unavailable checks.
 
-Keep each pull request small enough to review and revert independently.
+Documentation-only and maintenance changes may not need behavioural tests. State
+why a requirement is not applicable instead of marking unperformed work complete.
 
-## Bug reports
+## Bug and security reports
 
-[Open an issue](https://github.com/transferwise/pipelinewise/issues/new) with:
+[Open a public issue](https://github.com/transferwise/pipelinewise/issues/new) for
+non-sensitive defects and include:
 
 - PipelineWise and connector versions;
 - source, target, and replication method;
 - minimal configuration with secrets removed;
 - exact reproduction steps;
 - expected and actual results;
-- the complete relevant log excerpt; and
+- the relevant sanitized log excerpt; and
 - whether state or target data changed.
 
-Do not attach production data. Replace sensitive values with deterministic test
-fixtures that preserve the failing type, size, or boundary.
+Do not disclose suspected vulnerabilities, credentials, or sensitive production
+details in a public issue. Use [GitHub private vulnerability
+reporting](https://github.com/transferwise/pipelinewise/security/advisories/new)
+to contact the maintainers securely.
 
 ## License
 

--- a/docs/user_guide/troubleshooting.rst
+++ b/docs/user_guide/troubleshooting.rst
@@ -20,28 +20,33 @@ Symptom index
    * - Symptom
      - Area
      - First check
-   * - ``Lost connection`` or ``max_allowed_packet``
+   * - :ref:`Lost connection <troubleshooting_mysql_lost_connection>` or
+       :ref:`max_allowed_packet <troubleshooting_mysql_max_allowed_packet>`
      - MariaDB / MySQL
      - Session timeouts and packet limits.
-   * - Missing or corrupt binlog
+   * - :ref:`Missing <troubleshooting_mysql_missing_binlog>` or
+       :ref:`corrupt binlog <troubleshooting_mysql_bogus_log_event>`
      - MariaDB / MySQL LOG_BASED
      - Source retention and saved binlog position.
-   * - ``wal_level >= logical`` or missing slot
+   * - :ref:`wal_level <troubleshooting_postgres_wal_level>` or
+       :ref:`missing slot <troubleshooting_postgres_missing_slot>`
      - PostgreSQL LOG_BASED
      - Primary configuration and slot existence.
-   * - ``PGRES_COPY_BOTH``
+   * - :ref:`PGRES_COPY_BOTH <troubleshooting_postgres_pgres_copy_both>`
      - PostgreSQL LOG_BASED
-     - ``wal_sender_timeout`` and target backpressure.
-   * - LOG_BASED throughput falls behind without errors
+     - Source logs, network, timeout, and target backpressure.
+   * - :ref:`LOG_BASED throughput falls behind without errors
+       <troubleshooting_postgres_logical_decoding_spill>`
      - PostgreSQL LOG_BASED
      - Logical-decoding disk spill and ``logical_decoding_work_mem``.
-   * - Recovery conflict
+   * - :ref:`Recovery conflict <troubleshooting_postgres_recovery_conflict>`
      - PostgreSQL replica reads
      - Standby replay delay settings.
-   * - Table not found or zero discovered tables
+   * - :ref:`Table not found <troubleshooting_fastsync_table_not_found>` or
+       :ref:`zero discovered tables <troubleshooting_discovery_zero_tables>`
      - Discovery / FastSync
      - Source name and replication-user permissions.
-   * - Stale ``.running`` log
+   * - :ref:`Stale running log <troubleshooting_logging>`
      - Process lifecycle
      - PID file and complete process tree.
 
@@ -58,7 +63,10 @@ See :ref:`replication_methods` for a detailed explanation of each replication me
     not have this requirement. PipelineWise validates this during import and reports
     the affected stream before a run starts.
 
-**When to resync**
+.. _troubleshooting_when_to_resync:
+
+When to resync
+''''''''''''''
 
 * For **INCREMENTAL** replication you almost never need to resync, unless there
   was data corruption or a large number of old rows were updated that need to
@@ -68,14 +76,20 @@ See :ref:`replication_methods` for a detailed explanation of each replication me
 * For **LOG_BASED** PostgreSQL, you need to resync if the replication slot is no
   longer available.
 
-**INCREMENTAL method and missing updates**
+.. _troubleshooting_incremental_missing_updates:
+
+INCREMENTAL method and missing updates
+''''''''''''''''''''''''''''''''''''''
 
 When using incremental replication, PipelineWise will miss new or updated records if
 the ``replication_key`` column is being back-filled (i.e. older rows are receiving
 new values for the replication key). Consider using ``LOG_BASED`` replication if
 you need to capture all changes.
 
-**Using replica_host for large table resyncs (1 TB+)**
+.. _troubleshooting_replica_host_resyncs:
+
+Using replica_host for large table resyncs (1 TB+)
+''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Both MySQL and PostgreSQL taps support setting a ``replica_host`` key. When set,
 the initial FastSync will be done on the replica, reducing pressure on the primary
@@ -85,13 +99,19 @@ it created on the primary to continue replication.
 You can use this effectively with a partial sync (``sync_start_from``) to resync
 large tables and/or switch them to log-based replication.
 
-**Changes to transformations**
+.. _troubleshooting_transformation_changes:
+
+Changes to transformations
+''''''''''''''''''''''''''
 
 Changes to transformations will only be applied to newly extracted data. If you need
 the transformation applied to existing data in the target, you will need to resync
 the affected tables.
 
-**Resync table size limit**
+.. _troubleshooting_resync_size_limit:
+
+Resync table size limit
+'''''''''''''''''''''''
 
 For MySQL and PostgreSQL taps, ``fast_sync`` checks the size of non-partial-sync
 tables and will refuse to proceed if any table exceeds the configured
@@ -102,7 +122,10 @@ to override this check.
 MariaDB / MySQL Errors
 ''''''''''''''''''''''
 
-**Lost connection to MySQL server (Errno 104, Connection reset by peer)**
+.. _troubleshooting_mysql_lost_connection:
+
+Lost connection to MySQL server (Errno 104, Connection reset by peer)
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 *Log message:*
 
@@ -128,7 +151,10 @@ Add the following ``session_sqls`` block to your ``tap.yml``:
       - SET SESSION net_read_timeout=3600
       - SET SESSION innodb_lock_wait_timeout=3600
 
-**Unknown encoding: utf8mb3**
+.. _troubleshooting_mysql_utf8mb3:
+
+Unknown encoding: utf8mb3
+"""""""""""""""""""""""""
 
 *How to fix:*
 The tap cannot decode ``utf8mb3`` data. Identify the affected table or column, then
@@ -136,7 +162,10 @@ work with your database administrator to test and convert its character set to a
 supported encoding such as ``utf8mb4``. A character-set conversion changes source
 data and should be tested before it is applied in production.
 
-**Bogus data in log event**
+.. _troubleshooting_mysql_bogus_log_event:
+
+Bogus data in log event
+"""""""""""""""""""""""
 
 *Why it happens:*
 The source server (OS or MySQL service) restarted unexpectedly, corrupting the
@@ -147,7 +176,10 @@ Run a full resync with
 ``pipelinewise fast_sync --tap <tap_id> --target <target_id>``. See :ref:`resync`
 for the impact and available table-selection options.
 
-**Log event exceeded max_allowed_packet**
+.. _troubleshooting_mysql_max_allowed_packet:
+
+Log event exceeded max_allowed_packet
+"""""""""""""""""""""""""""""""""""""
 
 *Log message:*
 
@@ -159,7 +191,10 @@ for the impact and available table-selection options.
 Increase ``max_allowed_packet`` on the source server. If the problem persists after
 increasing the value, run a FastSync to rebuild the affected tables.
 
-**Missing binlog**
+.. _troubleshooting_mysql_missing_binlog:
+
+Missing binlog
+""""""""""""""
 
 *Log message:*
 
@@ -186,7 +221,10 @@ retention period.
 
 3. As a last resort, change the replication method from ``LOG_BASED`` to another method.
 
-**Changing the binlog position in state.json**
+.. _troubleshooting_mysql_state_position:
+
+Changing the binlog position in state.json
+""""""""""""""""""""""""""""""""""""""""""
 
 Prefer :ref:`cli_reset_state` for a controlled failover with an exact position
 mapping. If no supported mapping is available and manual recovery is unavoidable,
@@ -231,7 +269,10 @@ position is uncertain.
 PostgreSQL Errors
 '''''''''''''''''
 
-**requires wal_level >= logical**
+.. _troubleshooting_postgres_wal_level:
+
+requires wal_level >= logical
+"""""""""""""""""""""""""""""
 
 *Log message:*
 
@@ -247,7 +288,10 @@ Set ``wal_level`` to ``logical`` on the source database. Note that changing the 
 level requires restarting the database instance. If the tap owner cannot tolerate a
 restart, consider changing the replication method to something other than ``LOG_BASED``.
 
-**PGRES_COPY_BOTH and no message from the libpq**
+.. _troubleshooting_postgres_pgres_copy_both:
+
+PGRES_COPY_BOTH and no message from the libpq
+"""""""""""""""""""""""""""""""""""""""""""""
 
 *Log message:*
 
@@ -257,28 +301,36 @@ restart, consider changing the replication method to something other than ``LOG_
     PGRES_COPY_BOTH and no message from the libpq
 
 *Why it happens:*
-PostgreSQL kills the replication connection because it thinks the client has died.
-This usually happens when it takes a long time to load data into the target.
+This libpq message says that the replication COPY connection ended without a more
+specific client-side error; it does not identify the cause. Possible causes include
+a PostgreSQL restart or termination, a network interruption,
+``wal_sender_timeout`` expiry, or delayed feedback while the target is blocked.
+Compare the PipelineWise, source PostgreSQL, and network logs from the same UTC
+interval before changing timeouts or state.
 
 *How to fix:*
 
-* **Option 1: Upgrade to PostgreSQL 12 or above.** PG12 and above supports session-level
-  ``wal_sender_timeout`` and PipelineWise takes advantage of it.
+* **If the source or network terminated the connection,** correct that cause and
+  restart the same tap without advancing state.
 
-* **Option 2: Increase the ``wal_sender_timeout`` value on the source.**
-  A ``wal_sender_timeout`` value of less than 5 minutes will often result in this error.
-  Check the current value with:
+* **For PostgreSQL versions before 12, consider upgrading.** PostgreSQL 12 and
+  later support the session-level ``wal_sender_timeout`` that PipelineWise sets.
+
+* **If the PostgreSQL log reports a sender timeout,** check the effective value:
 
   .. code-block:: sql
 
       SELECT name, setting, unit FROM pg_settings WHERE name = 'wal_sender_timeout';
 
-* **Option 3: Enable or increase the tap ``stream_buffer_size``.**
-  The ``stream_buffer_size`` is a buffer allowing synchronous reading and loading of data.
-  Note that a small ``wal_sender_timeout`` will cause even a very large ``stream_buffer_size``
-  to run out of space, so fix ``wal_sender_timeout`` first.
+* **If target backpressure is confirmed, enable or increase
+  ``stream_buffer_size``.** This buffer decouples reading from loading. It cannot
+  compensate indefinitely for a blocked target or an unsuitable timeout, so fix
+  those causes first.
 
-**LOG_BASED replication is slow or falling behind**
+.. _troubleshooting_postgres_logical_decoding_spill:
+
+LOG_BASED replication is slow or falling behind
+"""""""""""""""""""""""""""""""""""""""""""""""
 
 *Why it happens:*
 On PostgreSQL 13 and later, ``logical_decoding_work_mem`` limits the memory used
@@ -315,6 +367,29 @@ not prove a current bottleneck.
     FROM pg_stat_replication_slots
     ORDER BY spill_bytes DESC;
 
+Check slot activity and acknowledgement separately. ``confirmed_flush_lsn`` is
+the position acknowledged by the consumer, while ``restart_lsn`` is the oldest
+WAL that may still be required. The calculated value approximates WAL retained
+for each slot:
+
+.. code-block:: sql
+
+    SELECT slot_name,
+           active,
+           confirmed_flush_lsn,
+           restart_lsn,
+           pg_size_pretty(
+               pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::bigint
+           ) AS retained_wal
+    FROM pg_replication_slots
+    WHERE slot_type = 'logical'
+    ORDER BY slot_name;
+
+Sample these values over the same interval as the spill counters. An inactive
+slot identifies a disconnected consumer. A stationary ``confirmed_flush_lsn``
+shows that acknowledgement is not advancing, but does not by itself distinguish
+source decoding from target or network backpressure.
+
 See the PostgreSQL documentation for
 `logical_decoding_work_mem <https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-LOGICAL-DECODING-WORK-MEM>`_
 and
@@ -337,7 +412,10 @@ Increasing this setting reduces decoding spill; it does not fix target, network,
 or ``stream_buffer_size`` backpressure. Replication lag alone does not require a
 resync.
 
-**Canceling statement due to conflict with recovery**
+.. _troubleshooting_postgres_recovery_conflict:
+
+Canceling statement due to conflict with recovery
+"""""""""""""""""""""""""""""""""""""""""""""""""
 
 *Log message:*
 
@@ -362,7 +440,10 @@ values with:
 *How to fix:*
 Increase ``max_standby_streaming_delay`` on the replica.
 
-**Connection already closed**
+.. _troubleshooting_postgres_connection_closed:
+
+Connection already closed
+"""""""""""""""""""""""""
 
 *Log message:*
 
@@ -377,7 +458,10 @@ The source server is likely configured to kill idle connections.
 *How to fix:*
 Review the idle connection timeout settings on the source PostgreSQL server.
 
-**recovery is in progress**
+.. _troubleshooting_postgres_recovery_in_progress:
+
+recovery is in progress
+"""""""""""""""""""""""
 
 *Log message:*
 
@@ -387,15 +471,15 @@ Review the idle connection timeout settings on the source PostgreSQL server.
     HINT: WAL control functions cannot be executed during recovery.
 
 *Why it happens:*
-The tap is configured with a mix of incremental and log-based replication methods,
-and the connection points to a replica. Log-based replication cannot run against a
-replica.
+The tap is reading INCREMENTAL or FULL_TABLE replication from a replica. (LOG_BASED from a replica is not possible)
 
 *How to fix:*
-Point the tap at the primary server, or change the log-based tables to use a different
-replication method.
+Point the tap at the primary server, or increase `max_standby_streaming_delay`.
 
-**Unable to find replication slot**
+.. _troubleshooting_postgres_missing_slot:
+
+Unable to find replication slot
+"""""""""""""""""""""""""""""""
 
 *How to fix:*
 Run ``pipelinewise fast_sync --tap <tap_id> --target <target_id>`` to resync the
@@ -410,7 +494,10 @@ tap and recreate the replication slot. See :ref:`resync` before proceeding.
 FastSync Errors
 '''''''''''''''
 
-**Table not found**
+.. _troubleshooting_fastsync_table_not_found:
+
+Table not found
+"""""""""""""""
 
 *Log message:*
 
@@ -439,7 +526,10 @@ FastSync cannot find the table in the source database. Common causes:
 
    If this returns no results, the replication user lacks ``SELECT`` privilege.
 
-**Failure to import tap (0 tables discovered)**
+.. _troubleshooting_discovery_zero_tables:
+
+Failure to import tap (0 tables discovered)
+"""""""""""""""""""""""""""""""""""""""""""
 
 *Log message:*
 
@@ -460,6 +550,8 @@ FastSync cannot find the table in the source database. Common causes:
    in the source database.
 
 
+.. _troubleshooting_logging:
+
 Logging and Diagnostics
 '''''''''''''''''''''''
 
@@ -467,21 +559,23 @@ Use ``pipelinewise status`` to get an overview of all configured pipelines and
 their last run status. Use ``pipelinewise test_tap_connection`` to verify
 connectivity to a source before running a full sync.
 
-Log files are written to ``~/.pipelinewise/<target_id>/<tap_id>/log/`` with a
-``.success`` or ``.failed`` suffix indicating the outcome of each run.
-See :ref:`logging` for details.
+Runtime files are written below ``PIPELINEWISE_CONFIG_DIRECTORY``, which defaults
+to ``~/.pipelinewise``. Tap logs are stored under
+``<target_id>/<tap_id>/log/`` and use ``.running``, ``.success``, or ``.failed``
+suffixes. See :ref:`logging` for details.
 
 To follow the progress of a running sync:
 
 .. code-block:: bash
 
-    $ tail -f ~/.pipelinewise/<target_id>/<tap_id>/log/*running
+    $ pipelinewise_config_dir="${PIPELINEWISE_CONFIG_DIRECTORY:-$HOME/.pipelinewise}"
+    $ tail -f "$pipelinewise_config_dir/<target_id>/<tap_id>/log/"*running
 
 You can also check the temporary files being written during a sync:
 
 .. code-block:: bash
 
-    $ ls -lah ~/.pipelinewise/tmp/*<tap_id>*
+    $ ls -lah "$pipelinewise_config_dir/tmp/"*<tap_id>*
 
 
 Verify recovery

--- a/docs/user_guide/troubleshooting.rst
+++ b/docs/user_guide/troubleshooting.rst
@@ -32,6 +32,9 @@ Symptom index
    * - ``PGRES_COPY_BOTH``
      - PostgreSQL LOG_BASED
      - ``wal_sender_timeout`` and target backpressure.
+   * - LOG_BASED throughput falls behind without errors
+     - PostgreSQL LOG_BASED
+     - Logical-decoding disk spill and ``logical_decoding_work_mem``.
    * - Recovery conflict
      - PostgreSQL replica reads
      - Standby replay delay settings.
@@ -274,6 +277,65 @@ This usually happens when it takes a long time to load data into the target.
   The ``stream_buffer_size`` is a buffer allowing synchronous reading and loading of data.
   Note that a small ``wal_sender_timeout`` will cause even a very large ``stream_buffer_size``
   to run out of space, so fix ``wal_sender_timeout`` first.
+
+**LOG_BASED replication is slow or falling behind**
+
+*Why it happens:*
+On PostgreSQL 13 and later, ``logical_decoding_work_mem`` limits the memory used
+by each logical replication connection. When decoded changes exceed the limit,
+PostgreSQL writes them to local disk. A value that is too low for the source
+workload can therefore cause frequent disk spill and substantially reduce
+LOG_BASED throughput.
+
+Each active logical replication connection has its own buffer. A busy source, large
+or concurrent transactions, or several PipelineWise replications consuming slots
+on the same PostgreSQL cluster can increase both spill I/O and total memory demand.
+
+*How to diagnose:*
+Check the configured value. PostgreSQL versions before 13 return no row because
+they do not provide this setting:
+
+.. code-block:: sql
+
+    SELECT name, setting, unit, source
+    FROM pg_settings
+    WHERE name = 'logical_decoding_work_mem';
+
+On PostgreSQL 14 and later, compare the following counters over the period when
+replication is slow. Increasing ``spill_count`` or ``spill_bytes`` confirms that
+logical decoding is writing changes to disk; a large historical total alone does
+not prove a current bottleneck.
+
+.. code-block:: sql
+
+    SELECT slot_name,
+           spill_txns,
+           spill_count,
+           pg_size_pretty(spill_bytes) AS spill_bytes
+    FROM pg_stat_replication_slots
+    ORDER BY spill_bytes DESC;
+
+See the PostgreSQL documentation for
+`logical_decoding_work_mem <https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-LOGICAL-DECODING-WORK-MEM>`_
+and
+`logical replication slot statistics <https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-PG-STAT-REPLICATION-SLOTS-VIEW>`_.
+
+*How to fix:*
+Work with the source database administrator to increase the setting incrementally
+for the PipelineWise replication role and database. There is no universal value;
+test against the transaction sizes and concurrency of the source. For example:
+
+.. code-block:: sql
+
+    ALTER ROLE <replication_user> IN DATABASE <source_database>
+    SET logical_decoding_work_mem = '<tested_value>';
+
+Restart the tap after changing a role or database default so its replication
+connection receives the new value. Budget memory for every concurrent logical
+replication connection and monitor database memory and disk I/O while tuning.
+Increasing this setting reduces decoding spill; it does not fix target, network,
+or ``stream_buffer_size`` backpressure. Replication lag alone does not require a
+resync.
 
 **Canceling statement due to conflict with recovery**
 


### PR DESCRIPTION
## Context

PipelineWise's contribution guidance and pull-request template did not consistently collect the operational impact, compatibility information, validation evidence, and skipped-check details expected during review.

The troubleshooting guide also lacked PostgreSQL logical-decoding spill diagnostics, used hard-coded runtime paths, presented one possible cause of `PGRES_COPY_BOTH` as certain, and required readers to scan for unlinked topics.

## Changes

- Rewrite the contributor guide around focused changes, Docker-first verification, sensitive-data handling, connector expectations, and evidence-backed pull requests.
- Rewrite the PR template to capture changes, compatibility and operational impact, exact validation results, and honest not-applicable explanations.
- Remove the internal Jira branch convention from the public PR template.
- Link security reports to GitHub private vulnerability reporting.
- Require signed commits in `AGENTS.md` and `CONTRIBUTING.md`.
- Document how `logical_decoding_work_mem` can affect PostgreSQL LOG_BASED throughput.
- Add slot activity, acknowledgement, spill, and retained-WAL diagnostics.
- Make `PGRES_COPY_BOTH` diagnosis evidence-led and distinguish source, network, timeout, and target backpressure.
- Replace hard-coded runtime paths with `PIPELINEWISE_CONFIG_DIRECTORY`.
- Convert troubleshooting topics into anchored subsections and link the symptom index to them.

## Type of change
- [x] Documentation

## Compatibility and operations

Documentation and contribution-process changes only. There is no runtime, state, schema, data, migration, deployment, rollback, or recovery impact.

## Validation

| Command or check | Result |
|---|---|
| `docker exec pipelinewise bash -lc 'cd /opt/pipelinewise/docs && make check'` | Passed: 6 reference tests and strict 45-page Sphinx build |
| PostgreSQL slot/retained-WAL query against the dev PostgreSQL 16 source | Passed: query executed and returned both logical slots |
| `git diff --check` | Passed |
| Signature check for every commit in `origin/master..HEAD` | Passed: all three commits have good GPG signatures |

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] This pull request is focused and can be reviewed and reverted independently.
- [x] Behavioural tests are not applicable because this is documentation-only.
- [x] Relevant documentation is updated; no changelog entry is needed for documentation-only changes.
- [x] Applicable local checks pass; no checks were skipped.
- [x] The change contains no credentials, private keys, production identifiers, or source records.
- [x] There are no breaking or compatibility impacts.
