### PR TITLE
Add tap-level Snowflake Iceberg v3 configuration and VARIANT support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+0.80.0 (2026-08-19)
+--------------------
+
+**Snowflake Iceberg groundwork**
+
+- Configure native or managed Iceberg v3 Singer tables per tap
+- Preserve nested Singer values as VARIANT in explicitly configured Iceberg v3 tables
+- Restrict Iceberg v3 configuration to unflattened, hard-delete RDBMS-to-Snowflake taps
+- Reject explicitly configured Iceberg FullSync and PartialSync before target mutation
+- Reject explicit formats that conflict with existing Snowflake tables
+- Preserve deprecated target-level `iceberg_create` behaviour when tap-level format is omitted
+
+**Fixes**
+
+- Execute unparameterized Snowflake SQL containing literal `%` without parameter-binding errors
+
+**Test hardening**
+
+- Cover exact target-snowflake table-format discovery for wildcard-like identifiers
+- Verify nested, null, empty, Unicode, escaped, and large VARIANT values on managed Iceberg v3
+
 0.79.1 (2026-08-18)
 --------------------
 

--- a/docs/concept/fastsync.rst
+++ b/docs/concept/fastsync.rst
@@ -62,9 +62,13 @@ Supported routes
      - Yes
      - No
 
-Endpoint support status from :ref:`connector_support` still applies. A normal
-``run_tap`` falls back to Singer when FullSync is unavailable. The explicit
-``fast_sync`` command instead fails without loading data.
+The Snowflake rows currently cover native tables only. With explicit
+``target_table_format: iceberg``, FullSync and PartialSync fail before target
+mutation and do not fall back to Singer.
+
+Endpoint support status from :ref:`connector_support` still applies. For a
+route without a FastSync component, a normal ``run_tap`` falls back to Singer.
+The explicit ``fast_sync`` command instead fails without loading data.
 
 
 Automatic selection and handover

--- a/docs/connectors/targets/snowflake.rst
+++ b/docs/connectors/targets/snowflake.rst
@@ -75,7 +75,6 @@ Configuration
      s3_key_prefix: "pipelinewise/"
      stage: "<SCHEMA>.<STAGE>"
      file_format: "<SCHEMA>.<FILE_FORMAT>"
-     iceberg_create: false
 
 .. list-table:: Connector-specific settings
    :header-rows: 1
@@ -130,7 +129,8 @@ Configuration
    * - ``iceberg_create``
      - No
      - ``false``
-     - Creates new Singer-path tables as managed Iceberg tables.
+     - Deprecated target-wide setting for new Singer-path Iceberg tables.
+       Prefer tap-level ``target_table_format`` and ``iceberg_version``.
    * - ``max_parallelism``
      - No
      - ``16``
@@ -154,7 +154,9 @@ schema-wide grant behaviour.
 Iceberg tables
 --------------
 
-Singer-path loads can create new managed Iceberg tables. FastSync and PartialSync
-cannot currently create or load Iceberg tables. Existing native tables can be
-converted with the bundled utility. See :ref:`snowflake_iceberg` for prerequisites,
-cutover, limitations, and recovery.
+The Singer connector can create managed Iceberg v3 tables when the tap selects
+that format. This does not yet enable a complete RDBMS-to-Iceberg route: fresh
+taps normally require FastSync first. FullSync and PartialSync with explicit
+Iceberg configuration fail before changing the target. Existing native tables
+can be converted with the bundled utility. See :ref:`snowflake_iceberg` for
+configuration, prerequisites, and limitations.

--- a/docs/connectors/targets/snowflake_iceberg.rst
+++ b/docs/connectors/targets/snowflake_iceberg.rst
@@ -3,9 +3,11 @@
 Snowflake Iceberg tables
 ========================
 
-PipelineWise can create new managed Snowflake Iceberg tables through the Singer
-target path or copy an existing native table into an Iceberg table with the
-``copy-native-to-iceberg`` utility.
+The target-snowflake Singer connector can create managed Snowflake Iceberg v3
+tables. This is connector groundwork for later FastSync support, not a complete
+RDBMS-to-Iceberg route. Fresh RDBMS taps normally require FullSync before Singer,
+and that path remains unavailable. The existing ``copy-native-to-iceberg``
+utility can copy a native table separately.
 
 
 Support
@@ -19,12 +21,18 @@ Support
    * - Operation
      - Status
      - Behaviour
-   * - Singer creates a new table
-     - Available
-     - ``iceberg_create: true`` creates a managed Iceberg table.
+   * - Singer with explicit v3 tap configuration
+     - Connector groundwork
+     - When Singer runs without a FastSync selection, creates a managed Iceberg
+       v3 table and stores objects and arrays as ``VARIANT``.
+   * - Singer with target-level ``iceberg_create``
+     - Deprecated compatibility
+     - Preserves the existing Iceberg mapping, including objects and arrays as
+       ``TEXT``.
    * - FastSync or PartialSync
      - Unavailable
-     - Fails rather than replacing or merging an Iceberg table.
+     - Explicit tap-level Iceberg configuration fails before creating or
+       changing a target table.
    * - Convert an existing native table
      - Available utility
      - Copies data into a companion table, then optionally promotes it.
@@ -33,36 +41,81 @@ Support
 Snowflake prerequisites
 -----------------------
 
-Configure a default catalog and external volume on the target database:
+Explicit v3 creation sets ``CATALOG = 'SNOWFLAKE'`` and leaves
+``EXTERNAL_VOLUME`` unset. Snowflake uses the effective schema, database, or
+account default. If no different default is configured, Snowflake-managed
+storage is used.
+
+To use your own cloud storage, create an external volume and configure it as a
+default on the schema, database, or account. For example:
 
 .. code-block:: sql
 
    CREATE OR REPLACE EXTERNAL VOLUME <external_volume> ...;
-   ALTER DATABASE <target_database> SET CATALOG = 'snowflake';
    ALTER DATABASE <target_database>
      SET EXTERNAL_VOLUME = <external_volume>;
 
-The target role needs the parent-object, warehouse, catalog, external-volume,
-and ``CREATE ICEBERG TABLE`` privileges required by Snowflake. Follow Snowflake's
+The target role needs the parent-object, warehouse, and ``CREATE ICEBERG TABLE``
+privileges required by Snowflake. A custom external volume also requires its
+applicable privileges. PipelineWise does not preflight these privileges; a
+failed ``CREATE ICEBERG TABLE`` reports the Snowflake error. Follow Snowflake's
 `managed Iceberg table documentation
 <https://docs.snowflake.com/en/user-guide/tables-iceberg>`_ for the account-level
 setup.
 
 
-Create new Iceberg tables
--------------------------
+Create new Singer tables
+------------------------
 
-Set ``iceberg_create`` in the target YAML before the Singer target creates the
-table:
+Set the desired format in the tap YAML. It applies to every selected table in
+that tap:
+
+.. code-block:: yaml
+
+   target: "snowflake"
+   target_table_format: iceberg
+   iceberg_version: 3
+
+When tap-level format and the legacy target flag are omitted, new tables are
+native. ``target_table_format`` accepts only ``native`` or ``iceberg``. Iceberg
+requires integer version ``3``; a version is invalid when the format is native
+or omitted.
+
+Explicit Iceberg v3 configuration is limited to ``tap-mysql`` (MariaDB/MySQL)
+and ``tap-postgres`` with ``target-snowflake``. It requires
+``data_flattening_max_level: 0`` and ``hard_delete: true``. The deprecated
+``hard_delete: false`` behaviour is rejected for this route.
+
+An explicit setting must match an existing table. PipelineWise does not convert
+a native table, change an Iceberg table's catalog, or upgrade Iceberg v2. Nested
+objects and arrays use ``VARIANT`` only with the explicit v3 configuration.
+Keep both settings while replicating to a v3 table. Removing them restores the
+legacy ``TEXT`` mapping; PipelineWise stops on existing ``VARIANT`` columns and
+asks the operator to restore the explicit v3 configuration rather than changing
+the columns automatically.
+
+Fresh LOG_BASED and INCREMENTAL RDBMS taps normally select FullSync before
+Singer. With explicit tap-level Iceberg configuration, that FullSync fails
+before target mutation and does not fall back to Singer. ``fast_sync`` and
+``partial_sync_table`` are also unavailable for that configuration in this
+release.
+
+
+Legacy target setting
+---------------------
+
+The deprecated target-level setting remains available during migration:
 
 .. code-block:: yaml
 
    db_conn:
      iceberg_create: true
 
-The setting affects new tables only. It does not convert an existing native
-table. Do not use ``fast_sync`` or ``partial_sync_table`` for a table that exists
-as Iceberg.
+When tap-level format is omitted, PipelineWise preserves this setting's current
+new-table and type-mapping behaviour. The legacy setting affects missing tables;
+an existing physical table continues to win. When both settings are present,
+they must agree. Only an explicit tap-level format must match an existing table;
+neither setting converts it.
 
 
 Convert a native table

--- a/docs/user_guide/yaml_config.rst
+++ b/docs/user_guide/yaml_config.rst
@@ -211,6 +211,16 @@ Tap configuration
      - Tap-specific or ``0``
      - Expands nested objects into columns. ``0`` keeps flattening disabled;
        higher values can create wide and changing target schemas.
+   * - ``target_table_format``
+     - Omitted
+     - Selects ``native`` or managed ``iceberg`` Snowflake tables for the
+       Singer target path. When omitted, missing tables are native unless the
+       deprecated target-level ``iceberg_create`` setting applies. The setting
+       applies to every table in the tap.
+   * - ``iceberg_version``
+     - None
+     - Must be integer ``3`` with ``target_table_format: iceberg`` and is
+       invalid otherwise.
    * - ``validate_records``
      - ``false``
      - Validates Singer records against their emitted schema before loading.
@@ -229,6 +239,18 @@ Tap configuration
    * - ``archive_load_files_s3_bucket`` / ``archive_load_files_s3_prefix``
      - None
      - Selects the archive destination when load-file archiving is enabled.
+
+.. important::
+
+   Tap-level Iceberg configuration currently provides Singer connector
+   groundwork only; it does not enable a complete RDBMS route. FullSync and
+   PartialSync with explicit Iceberg configuration fail before changing the
+   target. Explicit Iceberg v3 configuration is limited to
+   ``tap-mysql`` (MariaDB/MySQL) and ``tap-postgres`` with
+   ``target-snowflake``. It requires ``data_flattening_max_level: 0`` and
+   ``hard_delete: true``; deprecated ``hard_delete: false`` is rejected.
+   Omitting ``target_table_format`` creates native tables unless the deprecated
+   target-level ``iceberg_create`` setting applies.
 
 .. warning::
 

--- a/pipelinewise/cli/config.py
+++ b/pipelinewise/cli/config.py
@@ -11,10 +11,16 @@ from typing import Dict, List, Union
 from pipelinewise.data_diff.config import extract_check_definitions
 from pipelinewise.utils import safe_column_name
 from . import utils
+from .errors import InvalidConfigException
 
 
 class Config:
     """PipelineWise Configuration Class"""
+
+    TABLE_FORMAT_NATIVE = 'native'
+    TABLE_FORMAT_ICEBERG = 'iceberg'
+    ICEBERG_VERSION = 3
+    ICEBERG_RDBMS_TAPS = {'tap-mysql', 'tap-postgres'}
 
     def __init__(self, config_dir):
         """
@@ -105,6 +111,8 @@ class Config:
                     yaml_file,
                 )
                 sys.exit(1)
+
+            cls.validate_target_table_format(tap_data, targets[target_id])
 
             # Add generated extra keys that not available in the YAML
             tap_data['files'] = config.get_connector_files(
@@ -229,6 +237,9 @@ class Config:
                         'send_alert': tap.get('send_alert', True),
                         'enabled': True,
                     }
+                for key in ('target_table_format', 'iceberg_version'):
+                    if key in tap:
+                        tap_setting[key] = tap[key]
                 if tap.get('slack_alert_channel'):
                     tap_setting['slack_alert_channel'] = tap['slack_alert_channel']
                 taps.append(tap_setting)
@@ -486,7 +497,87 @@ class Config:
                 'archive_load_files_s3_prefix': tap.get(
                     'archive_load_files_s3_prefix', None
                 ),
+                'target_table_format': tap.get('target_table_format'),
+                'iceberg_version': tap.get('iceberg_version'),
             }
         )
 
         return tap_inheritable_config
+
+    @classmethod
+    def validate_target_table_format(cls, tap: Dict, target: Dict) -> None:
+        """Validate tap-level table format against its target configuration."""
+        table_format = tap.get('target_table_format')
+        iceberg_version_is_set = 'iceberg_version' in tap
+        iceberg_version = tap.get('iceberg_version')
+
+        if table_format is None:
+            if iceberg_version_is_set:
+                raise InvalidConfigException(
+                    f'Tap "{tap.get("id")}" sets iceberg_version without target_table_format.'
+                )
+            return
+
+        if table_format not in {cls.TABLE_FORMAT_NATIVE, cls.TABLE_FORMAT_ICEBERG}:
+            raise InvalidConfigException(
+                f'Tap "{tap.get("id")}" has unsupported target_table_format "{table_format}".'
+            )
+
+        if table_format == cls.TABLE_FORMAT_ICEBERG:
+            if iceberg_version != cls.ICEBERG_VERSION or isinstance(iceberg_version, bool):
+                raise InvalidConfigException(
+                    f'Tap "{tap.get("id")}" must set iceberg_version to integer 3 '
+                    'with target_table_format "iceberg".'
+                )
+        elif iceberg_version_is_set:
+            raise InvalidConfigException(
+                f'Tap "{tap.get("id")}" cannot set iceberg_version with '
+                'target_table_format "native".'
+            )
+
+        if target.get('type') != 'target-snowflake':
+            raise InvalidConfigException(
+                f'Tap "{tap.get("id")}" sets target_table_format but target '
+                f'"{target.get("id")}" is not target-snowflake.'
+            )
+
+        if table_format == cls.TABLE_FORMAT_ICEBERG:
+            cls._validate_iceberg_tap_settings(tap)
+
+        target_connection = target.get('db_conn') or {}
+        if 'iceberg_create' not in target_connection:
+            return
+
+        legacy_requests_iceberg = target_connection['iceberg_create']
+        new_setting_requests_iceberg = table_format == cls.TABLE_FORMAT_ICEBERG
+        if legacy_requests_iceberg != new_setting_requests_iceberg:
+            raise InvalidConfigException(
+                f'Tap "{tap.get("id")}" target_table_format conflicts with '
+                f'target "{target.get("id")}" iceberg_create.'
+            )
+
+    @classmethod
+    def _validate_iceberg_tap_settings(cls, tap: Dict) -> None:
+        """Validate tap settings supported by the initial explicit Iceberg route."""
+        if tap.get('type') not in cls.ICEBERG_RDBMS_TAPS:
+            raise InvalidConfigException(
+                f'Tap "{tap.get("id")}" type "{tap.get("type")}" does not '
+                'support target_table_format "iceberg".'
+            )
+
+        if tap.get('hard_delete', True) is not True:
+            raise InvalidConfigException(
+                f'Tap "{tap.get("id")}" must use hard_delete: true with '
+                'target_table_format "iceberg".'
+            )
+
+        flattening_level = tap.get('data_flattening_max_level')
+        if flattening_level is None:
+            flattening_level = (
+                utils.get_tap_property(tap, 'default_data_flattening_max_level') or 0
+            )
+        if flattening_level != 0 or isinstance(flattening_level, bool):
+            raise InvalidConfigException(
+                f'Tap "{tap.get("id")}" must use data_flattening_max_level: 0 '
+                'with target_table_format "iceberg".'
+            )

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1418,6 +1418,9 @@ class PipelineWise:
         selected_tables = self._get_sync_tables_setting_from_selection_file(
             tables_to_sync, self.args.replication_method_only)
 
+        if selected_tables['partial_sync'] or selected_tables['full_sync']:
+            self._check_target_table_format_supports_fastsync()
+
         processes_list = []
         if selected_tables['partial_sync']:
             self._reset_state_file_for_partial_sync(selected_tables)
@@ -1466,6 +1469,8 @@ class PipelineWise:
 
         cons_target_config = None
         try:
+            self._check_target_table_format_supports_fastsync()
+
             self._check_if_tap_is_enabled()
 
             self._check_if_complete_tap_configuration(fastsync_bin, tap_type, target_type)
@@ -1990,6 +1995,8 @@ class PipelineWise:
 
         # Continue only if tap and target is supported by partial sync
         try:
+            self._check_target_table_format_supports_fastsync()
+
             self._check_supporting_tap_and_target_for_partial_sync()
 
             tap_id = self.tap['id']
@@ -2097,8 +2104,9 @@ class PipelineWise:
         except PartialSyncNotSupportedTypeException as exc:
             self.logger.error(exc)
             raise SystemExit(1) from exc
-        except PreRunChecksException as exp:
-            raise SystemExit(1) from exp
+        except PreRunChecksException as exc:
+            self.logger.error(exc)
+            raise SystemExit(1) from exc
         except Exception as exc:
             self.send_alert(message=f'Failed to sync tables in {tap_id} tap', exc=exc)
             self.logger.exception(exc)
@@ -2198,6 +2206,14 @@ class PipelineWise:
         if ConnectorType(target_type) not in PARTIAL_SYNC_PAIRS.get(ConnectorType(tap_type), {}):
             raise PartialSyncNotSupportedTypeException(
                 f'Error! {tap_id}({tap_type})-{target_id}({target_type}) pair is not supported for the partial sync!'
+            )
+
+    def _check_target_table_format_supports_fastsync(self):
+        """Reject explicit Iceberg FastSync until its publication path is available."""
+        if self.tap.get('target_table_format') == Config.TABLE_FORMAT_ICEBERG:
+            raise PreRunChecksException(
+                'FastSync and PartialSync do not yet support explicit Snowflake Iceberg tables. '
+                'No target changes were made.'
             )
 
     def _check_if_complete_tap_configuration(self, fastsync_bin, tap_type, target_type):

--- a/pipelinewise/cli/schemas/tap.json
+++ b/pipelinewise/cli/schemas/tap.json
@@ -564,6 +564,14 @@
       "minimum": 0,
       "maximum": 2500
     },
+    "target_table_format": {
+      "type": "string",
+      "enum": ["native", "iceberg"]
+    },
+    "iceberg_version": {
+      "type": "integer",
+      "enum": [3]
+    },
     "split_large_files": {
       "type": "boolean"
     },
@@ -590,6 +598,24 @@
     },
     {
       "$ref": "#/definitions/tap_github"
+    },
+    {
+      "if": {
+        "required": ["target_table_format"],
+        "properties": {
+          "target_table_format": {
+            "const": "iceberg"
+          }
+        }
+      },
+      "then": {
+        "required": ["iceberg_version"]
+      },
+      "else": {
+        "not": {
+          "required": ["iceberg_version"]
+        }
+      }
     }
   ],
   "required": [

--- a/pipelinewise/cli/schemas/target.json
+++ b/pipelinewise/cli/schemas/target.json
@@ -147,6 +147,12 @@
       ]
     },
     "db_conn": {
+      "type": "object",
+      "properties": {
+        "iceberg_create": {
+          "type": "boolean"
+        }
+      },
       "anyOf": [
         {
           "$ref": "#/definitions/db_conn_target_snowflake"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.12.*',
-      version='0.79.1',
+      version='0.80.0',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',

--- a/singer-connectors/AGENTS.md
+++ b/singer-connectors/AGENTS.md
@@ -30,4 +30,4 @@ Report unavailable or skipped integration/E2E coverage as unverified.
 - Uppercase and double-quote identifiers; with `QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE`, DDL/DML case must match.
 - Compare generated types with Snowflake's canonical reported types; aliases can round-trip differently and trigger false column replacement.
 - Connector version prints to stderr; E2E must check exit status because `assert_command_success` treats stderr as failure.
-- Existing table type from `SHOW TERSE ICEBERG TABLES` wins; `iceberg_create` applies only to new tables. FastSync/PartialSync do not use this decision.
+- With legacy `iceberg_create`, the existing physical format wins and the flag applies only to missing tables. Explicit tap-level formats must match. Keep `target_table_format: iceberg` and `iceberg_version: 3` for the tap's lifetime; removing both restores legacy TEXT mapping and stops on existing VARIANT columns. FastSync/PartialSync reject explicit Iceberg until supported.

--- a/singer-connectors/target-snowflake/target_snowflake/db_sync.py
+++ b/singer-connectors/target-snowflake/target_snowflake/db_sync.py
@@ -12,13 +12,121 @@ from target_snowflake import flattening
 from target_snowflake import stream_utils
 from target_snowflake.file_format import FileFormat, FileFormatTypes
 
-from target_snowflake.exceptions import TooManyRecordsException, PrimaryKeyNotFoundException
+from target_snowflake.exceptions import (
+    PrimaryKeyNotFoundException,
+    TableFormatDiscoveryException,
+    TableFormatMismatchException,
+    TooManyRecordsException,
+)
 from target_snowflake.upload_clients.s3_upload_client import S3UploadClient
 from target_snowflake.upload_clients.snowflake_upload_client import SnowflakeUploadClient
 
 
 RECORD_UPDATE_MODE_SCHEMA_KEY = 'x-pipelinewise-record-update-mode'
 RECORD_UPDATE_MODE_PATCH = 'PATCH'
+
+TABLE_FORMAT_MISSING = 'missing'
+TABLE_FORMAT_NATIVE = 'native'
+TABLE_FORMAT_MANAGED_ICEBERG_V2 = 'managed_iceberg_v2'
+TABLE_FORMAT_MANAGED_ICEBERG_V3 = 'managed_iceberg_v3'
+TABLE_FORMAT_UNSUPPORTED_EXTERNAL_ICEBERG = 'unsupported_external_iceberg'
+
+ICEBERG_TABLE_FORMATS = {
+    TABLE_FORMAT_MANAGED_ICEBERG_V2,
+    TABLE_FORMAT_MANAGED_ICEBERG_V3,
+    TABLE_FORMAT_UNSUPPORTED_EXTERNAL_ICEBERG,
+}
+
+
+def _quote_identifier(identifier):
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _sql_string_literal(value):
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _row_value(row, name):
+    """Return a SHOW result value without assuming DictCursor key casing."""
+    for key in (name, name.upper()):
+        if key in row:
+            return row[key]
+    raise TableFormatDiscoveryException(f"Snowflake metadata did not return '{name}'")
+
+
+def _snowflake_boolean(value, field_name):
+    if value is True or str(value).upper() in ('Y', 'YES', 'TRUE'):
+        return True
+    if value is False or str(value).upper() in ('N', 'NO', 'FALSE'):
+        return False
+    raise TableFormatDiscoveryException(
+        f"Snowflake metadata returned invalid '{field_name}' value: {value!r}"
+    )
+
+
+def _exact_name_rows(rows, name):
+    return [row for row in rows if _row_value(row, 'name') == name]
+
+
+def _managed_iceberg_format(parameter_rows, table_fqtn):
+    version_rows = [
+        row for row in parameter_rows
+        if str(_row_value(row, 'key')).upper() == 'ICEBERG_VERSION'
+    ]
+    if len(version_rows) != 1:
+        raise TableFormatDiscoveryException(
+            f'Snowflake did not return one ICEBERG_VERSION for {table_fqtn}'
+        )
+    try:
+        iceberg_version = int(_row_value(version_rows[0], 'value'))
+    except (TypeError, ValueError) as exc:
+        raise TableFormatDiscoveryException(
+            f'Snowflake returned an invalid ICEBERG_VERSION for {table_fqtn}'
+        ) from exc
+
+    if iceberg_version == 2:
+        return TABLE_FORMAT_MANAGED_ICEBERG_V2
+    if iceberg_version == 3:
+        return TABLE_FORMAT_MANAGED_ICEBERG_V3
+    raise TableFormatDiscoveryException(
+        f'Snowflake returned unsupported ICEBERG_VERSION {iceberg_version} for {table_fqtn}'
+    )
+
+
+def _validate_table_format_config(config):
+    """Validate target-visible settings; PipelineWise owns source-route policy."""
+    errors = []
+    legacy_iceberg_create = config.get('iceberg_create')
+    if 'iceberg_create' in config and not isinstance(legacy_iceberg_create, bool):
+        errors.append("'iceberg_create' must be a boolean")
+
+    target_table_format_is_set = 'target_table_format' in config
+    target_table_format = config.get('target_table_format')
+    iceberg_version_is_set = 'iceberg_version' in config
+    iceberg_version = config.get('iceberg_version')
+    valid_iceberg_version = (
+        isinstance(iceberg_version, int)
+        and not isinstance(iceberg_version, bool)
+        and iceberg_version == 3
+    )
+    if target_table_format_is_set and target_table_format not in ('native', 'iceberg'):
+        errors.append("'target_table_format' must be either 'native' or 'iceberg'")
+    elif target_table_format == 'iceberg' and not valid_iceberg_version:
+        errors.append("'iceberg_version' must be integer 3 when 'target_table_format' is 'iceberg'")
+    elif target_table_format != 'iceberg' and iceberg_version_is_set:
+        errors.append("'iceberg_version' is only valid when 'target_table_format' is 'iceberg'")
+
+    if (
+        target_table_format in ('native', 'iceberg')
+        and isinstance(legacy_iceberg_create, bool)
+        and legacy_iceberg_create != (target_table_format == 'iceberg')
+    ):
+        errors.append("'iceberg_create' conflicts with 'target_table_format'")
+
+    if target_table_format == 'iceberg' and config.get('hard_delete') is not True:
+        errors.append("'hard_delete' must be true when 'target_table_format' is 'iceberg'")
+
+    return errors
 
 
 def validate_config(config):
@@ -73,11 +181,12 @@ def validate_config(config):
     if archive_load_files and not config.get('s3_bucket', None):
         errors.append('Archive load files option can be used only with external s3 stages. Please define s3_bucket.')
 
+    errors.extend(_validate_table_format_config(config))
+
     return errors
 
 
-def column_type(schema_property, is_iceberg_table=False):
-    """Take a specific schema property and return the snowflake equivalent column type"""
+def _native_column_type(schema_property):
     property_type = schema_property['type']
     property_format = schema_property['format'] if 'format' in schema_property else None
     col_type = 'text'
@@ -102,14 +211,53 @@ def column_type(schema_property, is_iceberg_table=False):
     elif 'boolean' in property_type:
         col_type = 'boolean'
 
-    # Adjust for Iceberg column type compatibility if required
-    if is_iceberg_table:
-        if col_type == 'variant':
-            col_type = 'text'
-        elif col_type == 'number':
-            col_type = 'number(19,0)'
-
     return col_type
+
+
+def _iceberg_column_type(col_type, iceberg_version):
+    if iceberg_version == 3 and col_type == 'time':
+        return 'time(6)'
+    if iceberg_version == 3 and col_type == 'timestamp_ntz':
+        return 'timestamp_ntz(6)'
+    if col_type == 'variant' and iceberg_version is None:
+        return 'text'
+    if col_type == 'number':
+        return 'number(19,0)'
+    return col_type
+
+
+def column_type(schema_property, is_iceberg_table=False, iceberg_version=None):
+    """Return a native, legacy Iceberg, or explicit Iceberg v3 column type."""
+    if iceberg_version not in (None, 3):
+        raise ValueError('Explicit Iceberg type mapping supports only version 3')
+    if iceberg_version is not None and not is_iceberg_table:
+        raise ValueError('An Iceberg version cannot be used for a native table')
+
+    if is_iceberg_table:
+        return _iceberg_column_type(_native_column_type(schema_property), iceberg_version)
+    return _native_column_type(schema_property)
+
+
+def _iceberg_text_variant_mismatch_reason(current_type, iceberg_version):
+    if current_type == 'VARIANT' and iceberg_version is None:
+        return (
+            'target_table_format is omitted, so the legacy mapping requires TEXT; '
+            'restore target_table_format: iceberg with iceberg_version: 3, or migrate '
+            'the column explicitly'
+        )
+    if current_type == 'TEXT' and iceberg_version == 3:
+        return (
+            'the explicit Iceberg v3 mapping requires VARIANT; '
+            'migrate the column explicitly before replication'
+        )
+    if current_type == 'VARIANT' and iceberg_version == 3:
+        return (
+            'the current Singer schema requires TEXT; '
+            'migrate the column explicitly before replication'
+        )
+    raise ValueError(
+        f'Unsupported Iceberg TEXT/VARIANT mismatch: {current_type}, version {iceberg_version}'
+    )
 
 
 def column_trans(schema_property):
@@ -134,9 +282,9 @@ def json_element_name(name):
     return f'"{name}"'
 
 
-def column_clause(name, schema_property, is_iceberg_table=False):
+def column_clause(name, schema_property, is_iceberg_table=False, iceberg_version=None):
     """Generate DDL column name with column type string"""
-    return f'{safe_column_name(name)} {column_type(schema_property, is_iceberg_table)}'
+    return f'{safe_column_name(name)} {column_type(schema_property, is_iceberg_table, iceberg_version)}'
 
 
 def primary_column_names(stream_schema_message):
@@ -328,6 +476,7 @@ class DbSync:
     def query(self, query: Union[str, List[str]], params: Dict = None, max_records=0) -> List[Dict]:
         """Run an SQL query in snowflake"""
         result = []
+        caller_supplied_params = params is not None
 
         if params is None:
             params = {}
@@ -357,7 +506,10 @@ class DbSync:
 
                     self.logger.debug("Running query: '%s' with Params %s", q, params)
 
-                    cur.execute(q, params)
+                    if caller_supplied_params or '%(LAST_QID)s' in q:
+                        cur.execute(q, params)
+                    else:
+                        cur.execute(q)
                     qid = cur.sfqid
 
                     # Raise exception if returned rows greater than max allowed records
@@ -607,14 +759,15 @@ class DbSync:
         p_extra = 'data_retention_time_in_days = 0 ' if is_temporary else 'data_retention_time_in_days = 1 '
         return f'CREATE {p_temp}TABLE IF NOT EXISTS {p_table_name} ({p_columns}) {p_extra}'
 
-    def create_iceberg_table_query(self):
+    def create_iceberg_table_query(self, iceberg_version=None):
         """Generate CREATE ICEBERG TABLE SQL (Snowflake-managed Iceberg)"""
         stream_schema_message = self.stream_schema_message
         columns = [
             column_clause(
                 name,
                 schema,
-                is_iceberg_table=True
+                is_iceberg_table=True,
+                iceberg_version=iceberg_version,
             )
             for (name, schema) in self.flatten_schema.items()
         ]
@@ -627,12 +780,22 @@ class DbSync:
         p_table_name = self.table_name(stream_schema_message['stream'], is_temporary=False)
         p_columns = ', '.join(columns + primary_key)
 
-        return (
-            f"CREATE ICEBERG TABLE IF NOT EXISTS {p_table_name} ({p_columns}) "
-            f" DATA_RETENTION_TIME_IN_DAYS=1"
-            f" TARGET_FILE_SIZE='16MB'"
-            f" ENABLE_DATA_COMPACTION=TRUE"
+        if iceberg_version is None:
+            return (
+                f"CREATE ICEBERG TABLE IF NOT EXISTS {p_table_name} ({p_columns}) "
+                f" DATA_RETENTION_TIME_IN_DAYS=1"
+                f" TARGET_FILE_SIZE='16MB'"
+                f" ENABLE_DATA_COMPACTION=TRUE"
+            )
+
+        query = f"CREATE ICEBERG TABLE IF NOT EXISTS {p_table_name} ({p_columns})"
+        query += f" CATALOG='SNOWFLAKE' ICEBERG_VERSION={iceberg_version}"
+        query += (
+            ' DATA_RETENTION_TIME_IN_DAYS=1'
+            " TARGET_FILE_SIZE='16MB'"
+            ' ENABLE_DATA_COMPACTION=TRUE'
         )
+        return query
 
     def grant_usage_on_schema(self, schema_name, grantee):
         """Grant usage on schema"""
@@ -721,17 +884,58 @@ class DbSync:
 
         return tables
 
-    def check_iceberg(self, schema_name, table_name) -> bool:
-        """Check if table is an iceberg table"""
+    def discover_table_format(self, schema_name, table_name):
+        """Return the exact physical Snowflake format of a PipelineWise table."""
         database_name = self.connection_config['dbname'].upper()
-        results = self.query(f"SHOW TERSE ICEBERG TABLES LIKE '{table_name}' IN SCHEMA {database_name}.{schema_name}")
-        if len(results) == 0:
-            is_iceberg_table = False
-        else:
-            is_iceberg_table = True
+        schema_name = schema_name.upper()
+        table_name = table_name.upper()
+        schema_fqtn = '.'.join(
+            _quote_identifier(identifier) for identifier in (database_name, schema_name)
+        )
+        table_literal = _sql_string_literal(table_name)
 
-        self.logger.info(f"{database_name}.{schema_name}.{table_name} is an Iceberg table: {is_iceberg_table}")
-        return is_iceberg_table
+        exact_tables = _exact_name_rows(
+            self.query(f'SHOW TABLES IN SCHEMA {schema_fqtn} STARTS WITH {table_literal}'),
+            table_name,
+        )
+        if not exact_tables:
+            return TABLE_FORMAT_MISSING
+        if len(exact_tables) != 1:
+            raise TableFormatDiscoveryException(
+                f'Snowflake returned multiple exact matches for {schema_fqtn}.{_quote_identifier(table_name)}'
+            )
+        if not _snowflake_boolean(_row_value(exact_tables[0], 'is_iceberg'), 'is_iceberg'):
+            return TABLE_FORMAT_NATIVE
+
+        exact_iceberg_tables = _exact_name_rows(
+            self.query(f'SHOW ICEBERG TABLES IN SCHEMA {schema_fqtn} STARTS WITH {table_literal}'),
+            table_name,
+        )
+        if len(exact_iceberg_tables) != 1:
+            raise TableFormatDiscoveryException(
+                f'Snowflake Iceberg metadata is incomplete for {schema_fqtn}.{_quote_identifier(table_name)}'
+            )
+
+        catalog_name = _row_value(exact_iceberg_tables[0], 'catalog_name')
+        if not isinstance(catalog_name, str) or not catalog_name.strip():
+            raise TableFormatDiscoveryException(
+                f'Snowflake returned an invalid catalog_name for {schema_fqtn}.{_quote_identifier(table_name)}'
+            )
+        if catalog_name.upper() != 'SNOWFLAKE':
+            return TABLE_FORMAT_UNSUPPORTED_EXTERNAL_ICEBERG
+
+        table_fqtn = '.'.join(
+            _quote_identifier(identifier)
+            for identifier in (database_name, schema_name, table_name)
+        )
+        return _managed_iceberg_format(
+            self.query(f"SHOW PARAMETERS LIKE 'ICEBERG_VERSION' IN TABLE {table_fqtn}"),
+            table_fqtn,
+        )
+
+    def check_iceberg(self, schema_name, table_name) -> bool:
+        """Return whether an exact existing table is physically Iceberg."""
+        return self.discover_table_format(schema_name, table_name) in ICEBERG_TABLE_FORMATS
 
     def get_table_columns(self, table_schemas=None):
         """Get list of columns and tables of certain schema(s) from snowflake metadata"""
@@ -792,7 +996,7 @@ class DbSync:
         """Refreshes the internal table cache"""
         self.table_cache = self.get_table_columns([self.schema_name])
 
-    def update_columns(self, is_iceberg_table=False):
+    def update_columns(self, is_iceberg_table=False, iceberg_version=None):
         """Adds required but not existing columns the target table according to the schema"""
         stream_schema_message = self.stream_schema_message
         stream = stream_schema_message['stream']
@@ -815,7 +1019,8 @@ class DbSync:
             column_clause(
                 name,
                 properties_schema,
-                is_iceberg_table
+                is_iceberg_table,
+                iceberg_version,
             )
             for (name, properties_schema) in self.flatten_schema.items()
             if name.upper() not in columns_dict
@@ -830,7 +1035,7 @@ class DbSync:
                 continue
 
             current_type = columns_dict[name_upper]['DATA_TYPE'].upper()
-            new_type = column_type(properties_schema, is_iceberg_table).upper()
+            new_type = column_type(properties_schema, is_iceberg_table, iceberg_version).upper()
             base_new_type = re.sub(r'\(.*\)', '', new_type).strip()
 
             # Skip if types match
@@ -846,9 +1051,15 @@ class DbSync:
             if new_type == 'TIMESTAMP_NTZ':
                 continue
 
+            if is_iceberg_table and {current_type, base_new_type} == {'TEXT', 'VARIANT'}:
+                raise TableFormatMismatchException(
+                    f'Iceberg column {name_upper} is {current_type}, but '
+                    f'{_iceberg_text_variant_mismatch_reason(current_type, iceberg_version)}'
+                )
+
             columns_to_replace.append((
                 safe_column_name(name),
-                column_clause(name, properties_schema, is_iceberg_table)
+                column_clause(name, properties_schema, is_iceberg_table, iceberg_version)
             ))
 
         # Note: Iceberg tables may still have column type changes automatically applied via
@@ -901,33 +1112,55 @@ class DbSync:
         """Creates or alters the target table according to the schema"""
         stream_schema_message = self.stream_schema_message
         stream = stream_schema_message['stream']
-        table_name = self.table_name(stream, False, True)
         table_name_with_schema = self.table_name(stream, False)
 
-        # Check if the table is an Iceberg table
         iceberg_stream_dict = stream_utils.stream_name_to_dict(stream)
         iceberg_table_name = iceberg_stream_dict['table_name']
         iceberg_table_name = iceberg_table_name.replace('.', '_').replace('-', '_').upper()
-        is_iceberg_table = self.check_iceberg(self.schema_name, iceberg_table_name)
+        physical_format = self.discover_table_format(self.schema_name, iceberg_table_name)
+        requested_format = self.connection_config.get('target_table_format')
 
-        if self.table_cache:
-            found_tables = list(filter(lambda x: x['SCHEMA_NAME'] == self.schema_name.upper() and
-                                                f'"{x["TABLE_NAME"].upper()}"' == table_name,
-                                    self.table_cache))
-        else:
-            found_tables = [table for table in (self.get_tables([self.schema_name.upper()]))
-                            if f'"{table["TABLE_NAME"].upper()}"' == table_name]
+        expected_format = None
+        if requested_format == 'iceberg':
+            expected_format = TABLE_FORMAT_MANAGED_ICEBERG_V3
+        elif requested_format == 'native':
+            expected_format = TABLE_FORMAT_NATIVE
 
-        if len(found_tables) == 0:
-            iceberg_create = self.connection_config.get('iceberg_create', False)
-            if iceberg_create:
-                query = self.create_iceberg_table_query()
+        if physical_format != TABLE_FORMAT_MISSING and expected_format is not None:
+            if physical_format != expected_format:
+                raise TableFormatMismatchException(
+                    f'Table {table_name_with_schema} is {physical_format}, but target_table_format '
+                    f'requires {expected_format}'
+                )
+
+        if physical_format == TABLE_FORMAT_MISSING:
+            create_iceberg = (
+                requested_format == 'iceberg'
+                if requested_format is not None
+                else self.connection_config.get('iceberg_create', False)
+            )
+            if create_iceberg:
+                iceberg_version = 3 if requested_format == 'iceberg' else None
+                query = self.create_iceberg_table_query(iceberg_version)
                 is_iceberg_table = True
                 self.logger.info('Table %s does not exist. Creating as Iceberg table...', table_name_with_schema)
             else:
                 query = self.create_table_query()
+                iceberg_version = None
+                is_iceberg_table = False
                 self.logger.info('Table %s does not exist. Creating...', table_name_with_schema)
             self.query(query)
+
+            # IF NOT EXISTS can lose a race to a table created in another format.
+            # Re-check explicit requests before granting or loading into the object.
+            if expected_format is not None:
+                created_format = self.discover_table_format(self.schema_name, iceberg_table_name)
+                if created_format != expected_format:
+                    raise TableFormatMismatchException(
+                        f'Table {table_name_with_schema} is {created_format} after creation, but '
+                        f'target_table_format requires {expected_format}'
+                    )
+
             self.grant_privilege(self.schema_name, self.grantees, self.grant_select_on_all_tables_in_schema)
 
             # Refresh columns cache if required
@@ -935,7 +1168,9 @@ class DbSync:
                 self.table_cache = self.get_table_columns(table_schemas=[self.schema_name])
         else:
             self.logger.info('Table %s exists', table_name_with_schema)
-            self.update_columns(is_iceberg_table)
+            is_iceberg_table = physical_format in ICEBERG_TABLE_FORMATS
+            iceberg_version = 3 if requested_format == 'iceberg' else None
+            self.update_columns(is_iceberg_table, iceberg_version)
 
         if not is_iceberg_table:
             self._refresh_table_pks()

--- a/singer-connectors/target-snowflake/target_snowflake/exceptions.py
+++ b/singer-connectors/target-snowflake/target_snowflake/exceptions.py
@@ -31,3 +31,11 @@ class UnexpectedMessageTypeException(Exception):
 
 class PrimaryKeyNotFoundException(Exception):
     """Exception to raise when primary key not found in the record message"""
+
+
+class TableFormatDiscoveryException(Exception):
+    """Exception to raise when Snowflake table format metadata is incomplete."""
+
+
+class TableFormatMismatchException(Exception):
+    """Exception to raise when the configured and physical table formats differ."""

--- a/singer-connectors/target-snowflake/tests/integration/test_iceberg_v3.py
+++ b/singer-connectors/target-snowflake/tests/integration/test_iceberg_v3.py
@@ -1,0 +1,262 @@
+import json
+import os
+import unittest
+import uuid
+
+import target_snowflake
+
+from target_snowflake.db_sync import (
+    DbSync,
+    TABLE_FORMAT_MANAGED_ICEBERG_V2,
+    TABLE_FORMAT_MANAGED_ICEBERG_V3,
+    TABLE_FORMAT_MISSING,
+    TABLE_FORMAT_NATIVE,
+)
+from target_snowflake.upload_clients.s3_upload_client import S3UploadClient
+
+try:
+    import tests.integration.utils as test_utils
+except ImportError:
+    import utils as test_utils
+
+
+REQUIRED_SNOWFLAKE_ENV = (
+    'TARGET_SNOWFLAKE_ACCOUNT',
+    'TARGET_SNOWFLAKE_DBNAME',
+    'TARGET_SNOWFLAKE_USER',
+    'TARGET_SNOWFLAKE_PRIVATE_KEY',
+    'TARGET_SNOWFLAKE_WAREHOUSE',
+)
+
+
+class TestManagedIcebergV3Integration(unittest.TestCase):
+    def setUp(self):
+        missing_env = [name for name in REQUIRED_SNOWFLAKE_ENV if not os.environ.get(name)]
+        if not (
+            os.environ.get('TARGET_SNOWFLAKE_FILE_FORMAT_CSV')
+            or os.environ.get('TARGET_SNOWFLAKE_FILE_FORMAT')
+        ):
+            missing_env.append('TARGET_SNOWFLAKE_FILE_FORMAT_CSV or TARGET_SNOWFLAKE_FILE_FORMAT')
+        if missing_env:
+            self.fail(f'Missing Snowflake integration environment: {", ".join(missing_env)}')
+
+        run_id = uuid.uuid4().hex[:12].upper()
+        self.schema = f'PW_ICEBERG_V3_{run_id}'
+        self.config = test_utils.get_db_config()
+        self.config.update({
+            'default_target_schema': self.schema,
+            'target_table_format': 'iceberg',
+            'iceberg_version': 3,
+            'data_flattening_max_level': 0,
+            'hard_delete': True,
+            'disable_table_cache': True,
+            'file_format': (
+                self.config.get('file_format')
+                or os.environ.get('TARGET_SNOWFLAKE_FILE_FORMAT')
+            ),
+            'client_side_encryption_master_key': (
+                self.config.get('client_side_encryption_master_key') or ''
+            ),
+        })
+
+        base_s3_prefix = self.config.get('s3_key_prefix') or ''
+        if base_s3_prefix and not base_s3_prefix.endswith('/'):
+            base_s3_prefix += '/'
+        self.s3_prefix = f'{base_s3_prefix}iceberg-v3-integration/{run_id}/'
+        self.config['s3_key_prefix'] = self.s3_prefix
+
+        self.snowflake = DbSync(self.config)
+        self.database = self.snowflake.query(
+            'SELECT CURRENT_DATABASE() AS "DATABASE_NAME"'
+        )[0]['DATABASE_NAME']
+        self.schema_fqtn = self._qualified_name(self.database, self.schema)
+
+        self.addCleanup(self._remove_s3_objects)
+        self.addCleanup(self._drop_schema)
+        self.snowflake.query(f'CREATE SCHEMA {self.schema_fqtn}')
+
+    @staticmethod
+    def _quote_identifier(identifier):
+        return '"' + identifier.replace('"', '""') + '"'
+
+    @classmethod
+    def _qualified_name(cls, *identifiers):
+        return '.'.join(cls._quote_identifier(identifier) for identifier in identifiers)
+
+    def _drop_schema(self):
+        self.snowflake.query(f'DROP SCHEMA IF EXISTS {self.schema_fqtn} CASCADE')
+
+    def _remove_s3_objects(self):
+        bucket = self.config.get('s3_bucket')
+        if not bucket:
+            return
+
+        s3_client = S3UploadClient(self.config).s3_client
+        paginator = s3_client.get_paginator('list_objects_v2')
+        for page in paginator.paginate(Bucket=bucket, Prefix=self.s3_prefix):
+            objects = [{'Key': item['Key']} for item in page.get('Contents', [])]
+            if objects:
+                s3_client.delete_objects(Bucket=bucket, Delete={'Objects': objects})
+
+    def _create_table(self, table_name, table_format=None, iceberg_version=None):
+        table_fqtn = self._qualified_name(self.database, self.schema, table_name)
+        if table_format == 'iceberg':
+            self.snowflake.query(
+                f'CREATE ICEBERG TABLE {table_fqtn} ("ID" NUMBER(19,0)) '
+                f"CATALOG='SNOWFLAKE' ICEBERG_VERSION={iceberg_version}"
+            )
+        else:
+            self.snowflake.query(f'CREATE TABLE {table_fqtn} ("ID" NUMBER(19,0))')
+
+    def test_discovers_exact_table_format_with_wildcard_like_identifiers(self):
+        missing_name = 'MISSING_%_TABLE'
+        native_name = 'NATIVE_%_TABLE'
+        iceberg_v2_name = 'ICEBERG_V2_%_TABLE'
+        iceberg_v3_name = 'ICEBERG_V3_%_TABLE'
+
+        self._create_table(f'{missing_name}_DECOY')
+        self._create_table(native_name)
+        self._create_table(iceberg_v2_name, table_format='iceberg', iceberg_version=2)
+        self._create_table(iceberg_v3_name, table_format='iceberg', iceberg_version=3)
+
+        self.assertEqual(
+            self.snowflake.discover_table_format(self.schema, missing_name),
+            TABLE_FORMAT_MISSING,
+        )
+        self.assertEqual(
+            self.snowflake.discover_table_format(self.schema, native_name),
+            TABLE_FORMAT_NATIVE,
+        )
+        self.assertEqual(
+            self.snowflake.discover_table_format(self.schema, iceberg_v2_name),
+            TABLE_FORMAT_MANAGED_ICEBERG_V2,
+        )
+        self.assertEqual(
+            self.snowflake.discover_table_format(self.schema, iceberg_v3_name),
+            TABLE_FORMAT_MANAGED_ICEBERG_V3,
+        )
+
+    def test_singer_loads_variant_values_into_explicit_managed_iceberg_v3(self):
+        stream = 'source-variant__payload'
+        large_text = 'large-json-value-' + ('x' * (70 * 1024))
+        rich_object = {
+            'nested': {'json_null': None},
+            'empty_object': {},
+            'empty_array': [],
+            'unicode': 'Καλημέρα コンニチハ 和毛泽东',
+            'escaped': 'quote " backslash \\ newline\n',
+        }
+        rich_array = [
+            None,
+            {},
+            [],
+            'Καλημέρα コンニチハ',
+            {'nested': None},
+            'quote " backslash \\',
+        ]
+        records = [
+            {
+                'id': 1,
+                'object_value': rich_object,
+                'array_value': rich_array,
+                'large_object': {'blob': large_text},
+            },
+            {
+                'id': 2,
+                'object_value': {},
+                'array_value': [],
+                'large_object': {},
+            },
+            {
+                'id': 3,
+                'object_value': None,
+                'array_value': None,
+                'large_object': None,
+            },
+        ]
+        schema_message = {
+            'type': 'SCHEMA',
+            'stream': stream,
+            'schema': {
+                'type': 'object',
+                'properties': {
+                    'id': {'type': ['integer']},
+                    'object_value': {'type': ['null', 'object']},
+                    'array_value': {'type': ['null', 'array'], 'items': {}},
+                    'large_object': {'type': ['null', 'object']},
+                },
+            },
+            'key_properties': ['id'],
+            'bookmark_properties': [],
+        }
+        singer_lines = [json.dumps(schema_message)]
+        singer_lines.extend(
+            json.dumps({
+                'type': 'RECORD',
+                'stream': stream,
+                'record': record,
+                'time_extracted': '2026-08-19T12:00:00Z',
+            }, ensure_ascii=False)
+            for record in records
+        )
+
+        target_snowflake.persist_lines(self.config, singer_lines)
+
+        table_name = 'VARIANT__PAYLOAD'
+        table_fqtn = self._qualified_name(self.database, self.schema, table_name)
+        self.assertEqual(
+            self.snowflake.discover_table_format(self.schema, table_name),
+            TABLE_FORMAT_MANAGED_ICEBERG_V3,
+        )
+        column_types = self.snowflake.query(
+            'SELECT "COLUMN_NAME", "DATA_TYPE" '
+            f'FROM {self._quote_identifier(self.database)}."INFORMATION_SCHEMA"."COLUMNS" '
+            f"WHERE \"TABLE_SCHEMA\" = '{self.schema}' "
+            f"AND \"TABLE_NAME\" = '{table_name}' "
+            'ORDER BY "ORDINAL_POSITION"'
+        )
+        self.assertEqual(
+            {column['COLUMN_NAME']: column['DATA_TYPE'] for column in column_types},
+            {
+                'ID': 'NUMBER',
+                'OBJECT_VALUE': 'VARIANT',
+                'ARRAY_VALUE': 'VARIANT',
+                'LARGE_OBJECT': 'VARIANT',
+                '_SDC_EXTRACTED_AT': 'TIMESTAMP_NTZ',
+                '_SDC_BATCHED_AT': 'TIMESTAMP_NTZ',
+                '_SDC_DELETED_AT': 'TEXT',
+            },
+        )
+
+        loaded_rows = self.snowflake.query(
+            'SELECT "ID", '
+            'TO_JSON("OBJECT_VALUE") AS "OBJECT_VALUE", '
+            'TO_JSON("ARRAY_VALUE") AS "ARRAY_VALUE", '
+            'TO_JSON("LARGE_OBJECT") AS "LARGE_OBJECT", '
+            'IS_NULL_VALUE("OBJECT_VALUE":"nested":"json_null") AS "NESTED_JSON_NULL", '
+            '"OBJECT_VALUE" IS NULL AS "OBJECT_SQL_NULL", '
+            '"ARRAY_VALUE" IS NULL AS "ARRAY_SQL_NULL" '
+            f'FROM {table_fqtn} ORDER BY "ID"'
+        )
+
+        self.assertEqual(len(loaded_rows), 3)
+        self.assertEqual([row['ID'] for row in loaded_rows], [1, 2, 3])
+        self.assertEqual(json.loads(loaded_rows[0]['OBJECT_VALUE']), rich_object)
+        self.assertEqual(json.loads(loaded_rows[0]['ARRAY_VALUE']), rich_array)
+        self.assertEqual(json.loads(loaded_rows[0]['LARGE_OBJECT']), {'blob': large_text})
+        self.assertGreater(len(large_text.encode('utf-8')), 64 * 1024)
+        self.assertTrue(loaded_rows[0]['NESTED_JSON_NULL'])
+        self.assertFalse(loaded_rows[0]['OBJECT_SQL_NULL'])
+        self.assertFalse(loaded_rows[0]['ARRAY_SQL_NULL'])
+
+        self.assertEqual(json.loads(loaded_rows[1]['OBJECT_VALUE']), {})
+        self.assertEqual(json.loads(loaded_rows[1]['ARRAY_VALUE']), [])
+        self.assertEqual(json.loads(loaded_rows[1]['LARGE_OBJECT']), {})
+        self.assertFalse(loaded_rows[1]['OBJECT_SQL_NULL'])
+        self.assertFalse(loaded_rows[1]['ARRAY_SQL_NULL'])
+
+        self.assertIsNone(loaded_rows[2]['OBJECT_VALUE'])
+        self.assertIsNone(loaded_rows[2]['ARRAY_VALUE'])
+        self.assertIsNone(loaded_rows[2]['LARGE_OBJECT'])
+        self.assertTrue(loaded_rows[2]['OBJECT_SQL_NULL'])
+        self.assertTrue(loaded_rows[2]['ARRAY_SQL_NULL'])

--- a/singer-connectors/target-snowflake/tests/unit/test_db_sync.py
+++ b/singer-connectors/target-snowflake/tests/unit/test_db_sync.py
@@ -1,10 +1,14 @@
 import json
 import unittest
 
-from unittest.mock import patch, call
+from unittest.mock import MagicMock, patch, call
 
 from target_snowflake import db_sync
-from target_snowflake.exceptions import PrimaryKeyNotFoundException
+from target_snowflake.exceptions import (
+    PrimaryKeyNotFoundException,
+    TableFormatDiscoveryException,
+    TableFormatMismatchException,
+)
 
 
 class TestDBSync(unittest.TestCase):
@@ -524,7 +528,7 @@ class TestDBSync(unittest.TestCase):
         ]
         query_patch.side_effect = [
             [{'type': 'CSV'}],           # SHOW FILE FORMATS
-            [],                           # SHOW TERSE ICEBERG TABLES (not Iceberg)
+            [{'name': 'TABLE1', 'is_iceberg': 'N'}],
             [{'column_name': 'ID'}],     # show primary keys
             None                          # ALTER TABLE
         ]
@@ -534,7 +538,7 @@ class TestDBSync(unittest.TestCase):
 
         query_patch.assert_has_calls([
             call('SHOW FILE FORMATS LIKE \'dummy-file-format\''),
-            call("SHOW TERSE ICEBERG TABLES LIKE 'TABLE1' IN SCHEMA DUMMY-DB.dummy-schema"),
+            call('SHOW TABLES IN SCHEMA "DUMMY-DB"."DUMMY-SCHEMA" STARTS WITH \'TABLE1\''),
             call('show primary keys in table dummy-db.dummy-schema."TABLE1";'),
             call(['alter table dummy-schema."TABLE1" alter column "ID" drop not null;'])
         ])
@@ -583,7 +587,7 @@ class TestDBSync(unittest.TestCase):
         ]
         query_patch.side_effect = [
             [{'type': 'CSV'}],           # SHOW FILE FORMATS
-            [],                           # SHOW TERSE ICEBERG TABLES (not Iceberg)
+            [{'name': 'TABLE1', 'is_iceberg': 'N'}],
             [{'column_name': 'ID'}],     # show primary keys
             None                          # ALTER TABLE
         ]
@@ -597,7 +601,10 @@ class TestDBSync(unittest.TestCase):
         self.assertEqual(4, len(calls))
 
         self.assertEqual('SHOW FILE FORMATS LIKE \'dummy-file-format\'', calls[0][0][0])
-        self.assertEqual("SHOW TERSE ICEBERG TABLES LIKE 'TABLE1' IN SCHEMA DUMMY-DB.dummy-schema", calls[1][0][0])
+        self.assertEqual(
+            'SHOW TABLES IN SCHEMA "DUMMY-DB"."DUMMY-SCHEMA" STARTS WITH \'TABLE1\'',
+            calls[1][0][0],
+        )
         self.assertEqual('show primary keys in table dummy-db.dummy-schema."TABLE1";', calls[2][0][0])
 
         self.assertEqual('alter table dummy-schema."TABLE1" drop primary key;', calls[3][0][0][0])
@@ -647,7 +654,7 @@ class TestDBSync(unittest.TestCase):
         ]
         query_patch.side_effect = [
             [{'type': 'CSV'}],           # SHOW FILE FORMATS
-            [],                           # SHOW TERSE ICEBERG TABLES (not Iceberg)
+            [{'name': 'TABLE1', 'is_iceberg': 'N'}],
             [{'column_name': 'ID'}],     # show primary keys
             None                          # ALTER TABLE
         ]
@@ -657,7 +664,7 @@ class TestDBSync(unittest.TestCase):
 
         query_patch.assert_has_calls([
             call('SHOW FILE FORMATS LIKE \'dummy-file-format\''),
-            call("SHOW TERSE ICEBERG TABLES LIKE 'TABLE1' IN SCHEMA DUMMY-DB.dummy-schema"),
+            call('SHOW TABLES IN SCHEMA "DUMMY-DB"."DUMMY-SCHEMA" STARTS WITH \'TABLE1\''),
             call('show primary keys in table dummy-db.dummy-schema."TABLE1";'),
             call(['alter table dummy-schema."TABLE1" drop primary key;',
                   'alter table dummy-schema."TABLE1" alter column "ID" drop not null;'])
@@ -698,7 +705,7 @@ class TestDBSync(unittest.TestCase):
         ]
         query_patch.side_effect = [
             [{'type': 'CSV'}],           # SHOW FILE FORMATS
-            [],                           # SHOW TERSE ICEBERG TABLES (not Iceberg)
+            [{'name': 'TABLE1', 'is_iceberg': 'N'}],
             [],                           # show primary keys (no existing PK)
             None                          # ALTER TABLE add PK
         ]
@@ -708,7 +715,7 @@ class TestDBSync(unittest.TestCase):
 
         query_patch.assert_has_calls([
             call('SHOW FILE FORMATS LIKE \'dummy-file-format\''),
-            call("SHOW TERSE ICEBERG TABLES LIKE 'TABLE1' IN SCHEMA DUMMY-DB.dummy-schema"),
+            call('SHOW TABLES IN SCHEMA "DUMMY-DB"."DUMMY-SCHEMA" STARTS WITH \'TABLE1\''),
             call('show primary keys in table dummy-db.dummy-schema."TABLE1";'),
             call(['alter table dummy-schema."TABLE1" add primary key("ID");',
                   'alter table dummy-schema."TABLE1" alter column "ID" drop not null;'])
@@ -769,6 +776,245 @@ class TestDBSync(unittest.TestCase):
             db_sync.column_clause('my_int', self.json_types['int']),
             '"MY_INT" number'
         )
+
+    def test_column_type_mapping_explicit_iceberg_v3(self):
+        """Only the explicit v3 mapping retains JSON-like values as VARIANT."""
+        self.assertEqual(
+            db_sync.column_type(self.json_types['obj'], is_iceberg_table=True, iceberg_version=3),
+            'variant',
+        )
+        self.assertEqual(
+            db_sync.column_type(self.json_types['arr'], is_iceberg_table=True, iceberg_version=3),
+            'variant',
+        )
+        self.assertEqual(
+            db_sync.column_type(self.json_types['int'], is_iceberg_table=True, iceberg_version=3),
+            'number(19,0)',
+        )
+        self.assertEqual(
+            db_sync.column_type(
+                self.json_types['time'],
+                is_iceberg_table=True,
+                iceberg_version=3,
+            ),
+            'time(6)',
+        )
+        self.assertEqual(
+            db_sync.column_type(
+                self.json_types['dt'],
+                is_iceberg_table=True,
+                iceberg_version=3,
+            ),
+            'timestamp_ntz(6)',
+        )
+        with self.assertRaisesRegex(ValueError, 'only version 3'):
+            db_sync.column_type(
+                self.json_types['obj'],
+                is_iceberg_table=True,
+                iceberg_version=2,
+            )
+
+        # Omitted version is the legacy route and retains its original DDL.
+        self.assertEqual(
+            db_sync.column_type(self.json_types['time'], is_iceberg_table=True),
+            'time',
+        )
+        self.assertEqual(
+            db_sync.column_type(self.json_types['dt'], is_iceberg_table=True),
+            'timestamp_ntz',
+        )
+
+    @staticmethod
+    def _format_discovery_sync(query_results):
+        sync = object.__new__(db_sync.DbSync)
+        sync.connection_config = {'dbname': 'dummy-db'}
+        sync.query = MagicMock(side_effect=query_results)
+        return sync
+
+    @staticmethod
+    def _query_sync():
+        sync = object.__new__(db_sync.DbSync)
+        sync.logger = MagicMock()
+        connection_context = MagicMock()
+        connection = connection_context.__enter__.return_value
+        cursor = connection.cursor.return_value.__enter__.return_value
+        cursor.rowcount = 0
+        cursor.sfqid = 'query-id'
+        cursor.fetchall.return_value = []
+        sync.open_connection = MagicMock(return_value=connection_context)
+        return sync, cursor
+
+    @staticmethod
+    def _table_sync_config(**overrides):
+        config = {
+            'account': 'dummy-account',
+            'dbname': 'dummy-db',
+            'user': 'dummy-user',
+            'private_key': 'dummy-key',
+            'warehouse': 'dummy-wh',
+            'default_target_schema': 'dummy-schema',
+            'file_format': 'dummy-file-format',
+            'hard_delete': True,
+        }
+        config.update(overrides)
+        return config
+
+    @staticmethod
+    def _table_sync_schema():
+        return {
+            'stream': 'public-table1',
+            'schema': {
+                'properties': {
+                    'id': {'type': ['integer']},
+                    'payload': {'type': ['object']},
+                },
+            },
+            'key_properties': ['id'],
+        }
+
+    def test_query_without_params_does_not_bind_wildcard_like_identifier(self):
+        sync, cursor = self._query_sync()
+        query = (
+            'SHOW TABLES IN SCHEMA "DUMMY-DB"."SCHEMA_1%" '
+            "STARTS WITH 'TABLE_1%'"
+        )
+
+        sync.query(query)
+
+        cursor.execute.assert_called_once_with(query)
+
+    def test_query_retains_last_query_id_binding_for_query_lists(self):
+        sync, cursor = self._query_sync()
+        queries = [
+            'SHOW TABLES IN SCHEMA "DUMMY-DB"."SCHEMA_1%"',
+            'SELECT * FROM TABLE(RESULT_SCAN(%(LAST_QID)s))',
+        ]
+
+        sync.query(queries)
+
+        self.assertEqual(cursor.execute.call_args_list[0], call('START TRANSACTION'))
+        self.assertEqual(cursor.execute.call_args_list[1], call(queries[0]))
+        self.assertEqual(cursor.execute.call_args_list[2].args[0], queries[1])
+        self.assertEqual(cursor.execute.call_args_list[2].args[1]['LAST_QID'], 'query-id')
+
+    def test_query_retains_caller_supplied_params(self):
+        sync, cursor = self._query_sync()
+        query = 'SELECT %(value)s'
+
+        sync.query(query, params={'value': 1})
+
+        cursor.execute.assert_called_once_with(
+            query,
+            {'value': 1, 'LAST_QID': None},
+        )
+
+    def test_discover_table_format_missing_and_native_use_exact_name(self):
+        missing = self._format_discovery_sync([
+            [{'name': 'TABLE10', 'is_iceberg': 'N'}],
+        ])
+        self.assertEqual(
+            missing.discover_table_format('dummy_schema', 'table1'),
+            db_sync.TABLE_FORMAT_MISSING,
+        )
+
+        native = self._format_discovery_sync([
+            [
+                {'name': 'TABLE10', 'is_iceberg': 'N'},
+                {'name': 'TABLE1', 'is_iceberg': 'N'},
+            ],
+        ])
+        self.assertEqual(
+            native.discover_table_format('dummy_schema', 'table1'),
+            db_sync.TABLE_FORMAT_NATIVE,
+        )
+        native.query.assert_called_once_with(
+            'SHOW TABLES IN SCHEMA "DUMMY-DB"."DUMMY_SCHEMA" STARTS WITH \'TABLE1\''
+        )
+
+    def test_discover_table_format_treats_wildcard_characters_as_literals(self):
+        sync = self._format_discovery_sync([
+            [
+                {'name': 'TABLE_1%_OTHER', 'is_iceberg': 'N'},
+                {'name': 'TABLE_1%', 'is_iceberg': 'N'},
+            ],
+        ])
+
+        self.assertEqual(
+            sync.discover_table_format('schema_1%', 'table_1%'),
+            db_sync.TABLE_FORMAT_NATIVE,
+        )
+        sync.query.assert_called_once_with(
+            'SHOW TABLES IN SCHEMA "DUMMY-DB"."SCHEMA_1%" STARTS WITH \'TABLE_1%\''
+        )
+
+    def test_discover_table_format_managed_v2_and_v3(self):
+        for version, expected in (
+            (2, db_sync.TABLE_FORMAT_MANAGED_ICEBERG_V2),
+            (3, db_sync.TABLE_FORMAT_MANAGED_ICEBERG_V3),
+        ):
+            with self.subTest(version=version):
+                sync = self._format_discovery_sync([
+                    [{'name': 'TABLE1', 'is_iceberg': 'Y'}],
+                    [
+                        {'name': 'TABLE10', 'catalog_name': 'SNOWFLAKE'},
+                        {'name': 'TABLE1', 'catalog_name': 'SNOWFLAKE'},
+                    ],
+                    [{'key': 'ICEBERG_VERSION', 'value': str(version)}],
+                ])
+                self.assertEqual(
+                    sync.discover_table_format('dummy_schema', 'table1'),
+                    expected,
+                )
+                self.assertEqual(
+                    sync.query.call_args_list[-1],
+                    call(
+                        "SHOW PARAMETERS LIKE 'ICEBERG_VERSION' IN TABLE "
+                        '"DUMMY-DB"."DUMMY_SCHEMA"."TABLE1"'
+                    ),
+                )
+
+    def test_discover_table_format_external_iceberg_does_not_read_version(self):
+        sync = self._format_discovery_sync([
+            [{'name': 'TABLE1', 'is_iceberg': 'YES'}],
+            [{'name': 'TABLE1', 'catalog_name': 'EXTERNAL_CATALOG'}],
+        ])
+        self.assertEqual(
+            sync.discover_table_format('dummy_schema', 'table1'),
+            db_sync.TABLE_FORMAT_UNSUPPORTED_EXTERNAL_ICEBERG,
+        )
+        self.assertEqual(sync.query.call_count, 2)
+
+    def test_discover_table_format_rejects_incomplete_or_unknown_metadata(self):
+        cases = (
+            (
+                [[{'name': 'TABLE1'}]],
+                "did not return 'is_iceberg'",
+            ),
+            (
+                [[{'name': 'TABLE1', 'is_iceberg': 'Y'}], []],
+                'Iceberg metadata is incomplete',
+            ),
+            (
+                [
+                    [{'name': 'TABLE1', 'is_iceberg': 'Y'}],
+                    [{'name': 'TABLE1', 'catalog_name': None}],
+                ],
+                'invalid catalog_name',
+            ),
+            (
+                [
+                    [{'name': 'TABLE1', 'is_iceberg': 'Y'}],
+                    [{'name': 'TABLE1', 'catalog_name': 'SNOWFLAKE'}],
+                    [{'key': 'ICEBERG_VERSION', 'value': '4'}],
+                ],
+                'unsupported ICEBERG_VERSION 4',
+            ),
+        )
+        for query_results, message in cases:
+            with self.subTest(message=message):
+                sync = self._format_discovery_sync(query_results)
+                with self.assertRaisesRegex(TableFormatDiscoveryException, message):
+                    sync.discover_table_format('dummy_schema', 'table1')
 
     @patch('target_snowflake.db_sync.DbSync.query')
     def test_version_column_sql(self, query_patch):
@@ -936,6 +1182,83 @@ class TestDBSync(unittest.TestCase):
                          msg="TEXT should not be re-altered when schema is variant on an Iceberg table")
 
     @patch('target_snowflake.db_sync.DbSync.query')
+    def test_update_columns_explicit_v3_adds_variant(self, query_patch):
+        query_patch.return_value = [{'type': 'CSV'}]
+        table_cache = [
+            {
+                'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                'TABLE_NAME': 'TABLE1',
+                'COLUMN_NAME': 'ID',
+                'DATA_TYPE': 'NUMBER',
+            },
+        ]
+        dbsync = db_sync.DbSync(
+            self._table_sync_config(target_table_format='iceberg', iceberg_version=3),
+            self._table_sync_schema(),
+            table_cache,
+        )
+        query_patch.reset_mock()
+
+        dbsync.update_columns(is_iceberg_table=True, iceberg_version=3)
+
+        add_column_calls = [
+            query_call
+            for query_call in query_patch.call_args_list
+            if 'ADD COLUMN' in str(query_call)
+        ]
+        self.assertEqual(
+            add_column_calls,
+            [call('ALTER ICEBERG TABLE dummy-schema."TABLE1" ADD COLUMN "PAYLOAD" variant')],
+        )
+
+    @patch('target_snowflake.db_sync.DbSync.query')
+    def test_update_columns_does_not_implicitly_convert_text_and_variant(self, query_patch):
+        query_patch.return_value = [{'type': 'CSV'}]
+
+        for current_type, iceberg_version, property_schema, expected_message in (
+            ('TEXT', 3, {'type': ['object']}, 'explicit Iceberg v3 mapping requires VARIANT'),
+            ('VARIANT', None, {'type': ['object']}, 'target_table_format is omitted'),
+            ('VARIANT', 3, {'type': ['string']}, 'current Singer schema requires TEXT'),
+        ):
+            with self.subTest(current_type=current_type, iceberg_version=iceberg_version):
+                table_cache = [
+                    {
+                        'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                        'TABLE_NAME': 'TABLE1',
+                        'COLUMN_NAME': 'ID',
+                        'DATA_TYPE': 'NUMBER',
+                    },
+                    {
+                        'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                        'TABLE_NAME': 'TABLE1',
+                        'COLUMN_NAME': 'PAYLOAD',
+                        'DATA_TYPE': current_type,
+                    },
+                ]
+                stream_schema = self._table_sync_schema()
+                stream_schema['schema']['properties']['payload'] = property_schema
+                dbsync = db_sync.DbSync(
+                    self._table_sync_config(),
+                    stream_schema,
+                    table_cache,
+                )
+                query_patch.reset_mock()
+
+                with self.assertRaisesRegex(
+                    TableFormatMismatchException,
+                    expected_message,
+                ):
+                    dbsync.update_columns(
+                        is_iceberg_table=True,
+                        iceberg_version=iceberg_version,
+                    )
+
+                query_patch.assert_not_called()
+
+        with self.assertRaisesRegex(ValueError, 'Unsupported Iceberg TEXT/VARIANT mismatch'):
+            db_sync._iceberg_text_variant_mismatch_reason('TEXT', None)
+
+    @patch('target_snowflake.db_sync.DbSync.query')
     def test_update_columns_iceberg_type_change_versions_and_re_adds(self, query_patch):
         """A type mismatch on Iceberg renames the old column then adds the new one via ICEBERG DDL"""
         query_patch.return_value = [{'type': 'CSV'}]
@@ -996,6 +1319,67 @@ class TestDBSync(unittest.TestCase):
         # iceberg_create=True → also no error (external volume is not required in config)
         self.assertEqual(len(db_sync.validate_config({**base, 'iceberg_create': True})), 0)
 
+    def test_config_validation_explicit_table_format(self):
+        base = self._table_sync_config()
+
+        valid_configs = (
+            {'target_table_format': 'native'},
+            {'target_table_format': 'native', 'iceberg_create': False},
+            {'target_table_format': 'iceberg', 'iceberg_version': 3},
+            {
+                'target_table_format': 'iceberg',
+                'iceberg_version': 3,
+                'iceberg_create': True,
+                'hard_delete': True,
+            },
+        )
+        for extra_config in valid_configs:
+            with self.subTest(extra_config=extra_config):
+                self.assertEqual(db_sync.validate_config({**base, **extra_config}), [])
+
+        direct_iceberg_config = {
+            **base,
+            'target_table_format': 'iceberg',
+            'iceberg_version': 3,
+        }
+        direct_iceberg_config.pop('hard_delete')
+        self.assertTrue(
+            any("'hard_delete'" in error for error in db_sync.validate_config(direct_iceberg_config))
+        )
+
+        invalid_configs = (
+            ({'target_table_format': None}, "'target_table_format'"),
+            ({'target_table_format': 'parquet'}, "'target_table_format'"),
+            ({'target_table_format': 'iceberg'}, "'iceberg_version'"),
+            ({'target_table_format': 'iceberg', 'iceberg_version': '3'}, "'iceberg_version'"),
+            ({'target_table_format': 'native', 'iceberg_version': 3}, "'iceberg_version'"),
+            ({'target_table_format': 'native', 'iceberg_version': None}, "'iceberg_version'"),
+            ({'iceberg_version': 3}, "'iceberg_version'"),
+            ({'iceberg_version': None}, "'iceberg_version'"),
+            ({'target_table_format': 'native', 'iceberg_create': True}, 'conflicts'),
+            (
+                {'target_table_format': 'iceberg', 'iceberg_version': 3, 'iceberg_create': False},
+                'conflicts',
+            ),
+            (
+                {'target_table_format': 'iceberg', 'iceberg_version': 3, 'hard_delete': False},
+                "'hard_delete'",
+            ),
+            (
+                {'target_table_format': 'iceberg', 'iceberg_version': 3, 'hard_delete': 'true'},
+                "'hard_delete'",
+            ),
+            ({'iceberg_create': 'true'}, "'iceberg_create'"),
+        )
+        for extra_config, expected_error in invalid_configs:
+            with self.subTest(extra_config=extra_config):
+                self.assertTrue(
+                    any(
+                        expected_error in error
+                        for error in db_sync.validate_config({**base, **extra_config})
+                    )
+                )
+
     def test_create_iceberg_table_query_ddl(self):
         """create_iceberg_table_query generates correct Iceberg DDL with Iceberg column types"""
         minimal_config = {
@@ -1025,6 +1409,12 @@ class TestDBSync(unittest.TestCase):
 
         ddl = dbsync.create_iceberg_table_query()
 
+        self.assertEqual(
+            ddl,
+            'CREATE ICEBERG TABLE IF NOT EXISTS dummy-schema."TABLE1" '
+            '("ID" number(19,0), "NAME" text, "PAYLOAD" text, PRIMARY KEY("ID")) '
+            " DATA_RETENTION_TIME_IN_DAYS=1 TARGET_FILE_SIZE='16MB' ENABLE_DATA_COMPACTION=TRUE",
+        )
         self.assertIn('CREATE ICEBERG TABLE IF NOT EXISTS', ddl)
         self.assertIn('DATA_RETENTION_TIME_IN_DAYS', ddl)
         self.assertIn('TARGET_FILE_SIZE', ddl)
@@ -1037,6 +1427,27 @@ class TestDBSync(unittest.TestCase):
         # Snowflake-external managed keywords must NOT appear — external volume is configured in Snowflake directly
         self.assertNotIn('EXTERNAL_VOLUME', ddl)
         self.assertNotIn('CATALOG', ddl)
+        self.assertNotIn('BASE_LOCATION', ddl)
+
+    def test_create_iceberg_table_query_explicit_v3_uses_variant(self):
+        config = self._table_sync_config(target_table_format='iceberg', iceberg_version=3)
+        stream_schema_message = self._table_sync_schema()
+        stream_schema_message['schema']['properties'].update({
+            'event_time': {'type': ['string'], 'format': 'time'},
+            'created_at': {'type': ['string'], 'format': 'date-time'},
+        })
+
+        with patch('target_snowflake.db_sync.DbSync.query', return_value=[{'type': 'CSV'}]):
+            dbsync = db_sync.DbSync(config, stream_schema_message)
+
+        ddl = dbsync.create_iceberg_table_query(iceberg_version=3)
+
+        self.assertIn('"PAYLOAD" variant', ddl)
+        self.assertIn('"EVENT_TIME" time(6)', ddl)
+        self.assertIn('"CREATED_AT" timestamp_ntz(6)', ddl)
+        self.assertIn("CATALOG='SNOWFLAKE'", ddl)
+        self.assertIn('ICEBERG_VERSION=3', ddl)
+        self.assertNotIn('EXTERNAL_VOLUME', ddl)
         self.assertNotIn('BASE_LOCATION', ddl)
 
     def test_create_iceberg_table_query_no_pk_when_no_key_properties(self):
@@ -1063,9 +1474,8 @@ class TestDBSync(unittest.TestCase):
         self.assertNotIn('PRIMARY KEY', ddl)
 
     @patch('target_snowflake.db_sync.DbSync.grant_privilege')
-    @patch('target_snowflake.db_sync.DbSync.get_tables')
     @patch('target_snowflake.db_sync.DbSync.query')
-    def test_sync_table_creates_iceberg_when_iceberg_create_true(self, query_patch, get_tables_patch, grant_patch):
+    def test_sync_table_creates_iceberg_when_iceberg_create_true(self, query_patch, grant_patch):
         """sync_table issues CREATE ICEBERG TABLE DDL when iceberg_create=True and table does not exist"""
         minimal_config = {
             'account': "dummy-account",
@@ -1082,11 +1492,9 @@ class TestDBSync(unittest.TestCase):
             "schema": {"properties": {"id": {"type": ["integer"]}}},
             "key_properties": ["id"]
         }
-        # get_tables returns [] so found_tables is empty (table doesn't exist yet)
-        get_tables_patch.return_value = []
         query_patch.side_effect = [
             [{'type': 'CSV'}],    # SHOW FILE FORMATS (during __init__)
-            [],                    # SHOW TERSE ICEBERG TABLES (not Iceberg yet)
+            [],                    # SHOW TABLES (missing)
             None,                  # CREATE ICEBERG TABLE
         ]
         dbsync = db_sync.DbSync(minimal_config, stream_schema_message)
@@ -1119,7 +1527,9 @@ class TestDBSync(unittest.TestCase):
         with patch('target_snowflake.db_sync.DbSync.query') as query_patch:
             query_patch.side_effect = [
                 [{'type': 'CSV'}],               # SHOW FILE FORMATS (__init__)
-                [{'table_name': 'TABLE1'}],       # SHOW TERSE ICEBERG TABLES → is_iceberg_table=True
+                [{'name': 'TABLE1', 'is_iceberg': 'Y'}],
+                [{'name': 'TABLE1', 'catalog_name': 'SNOWFLAKE'}],
+                [{'key': 'ICEBERG_VERSION', 'value': '2'}],
             ]
             dbsync = db_sync.DbSync(minimal_config, stream_schema_message, table_cache)
             dbsync.sync_table()
@@ -1128,9 +1538,8 @@ class TestDBSync(unittest.TestCase):
         self.assertEqual(len(create_calls), 0, msg="CREATE must not be issued for an already-existing Iceberg table")
 
     @patch('target_snowflake.db_sync.DbSync.grant_privilege')
-    @patch('target_snowflake.db_sync.DbSync.get_tables')
     @patch('target_snowflake.db_sync.DbSync.query')
-    def test_sync_table_creates_regular_table_when_iceberg_create_false(self, query_patch, get_tables_patch, grant_patch):
+    def test_sync_table_creates_regular_table_when_iceberg_create_false(self, query_patch, grant_patch):
         """sync_table issues a regular CREATE TABLE when iceberg_create is False and table does not exist"""
         minimal_config = {
             'account': "dummy-account",
@@ -1147,10 +1556,9 @@ class TestDBSync(unittest.TestCase):
             "schema": {"properties": {"id": {"type": ["integer"]}}},
             "key_properties": ["id"]
         }
-        get_tables_patch.return_value = []
         query_patch.side_effect = [
             [{'type': 'CSV'}],    # SHOW FILE FORMATS (during __init__)
-            [],     # SHOW TERSE ICEBERG TABLES
+            [],     # SHOW TABLES (missing)
             None,   # CREATE TABLE
             [],     # show primary keys
             None,   # ALTER TABLE
@@ -1161,3 +1569,150 @@ class TestDBSync(unittest.TestCase):
         create_calls = [str(c) for c in query_patch.call_args_list if 'CREATE' in str(c)]
         self.assertEqual(len(create_calls), 1)
         self.assertNotIn('ICEBERG', create_calls[0])
+
+    @patch('target_snowflake.db_sync.DbSync.grant_privilege')
+    @patch('target_snowflake.db_sync.DbSync.query')
+    def test_sync_table_explicit_v3_create_is_verified_before_grants(self, query_patch, grant_patch):
+        query_patch.return_value = [{'type': 'CSV'}]
+        dbsync = db_sync.DbSync(
+            self._table_sync_config(target_table_format='iceberg', iceberg_version=3),
+            self._table_sync_schema(),
+        )
+        query_patch.reset_mock()
+
+        with patch.object(
+            dbsync,
+            'discover_table_format',
+            side_effect=(db_sync.TABLE_FORMAT_MISSING, db_sync.TABLE_FORMAT_MANAGED_ICEBERG_V3),
+        ) as discover_format:
+            grant_patch.side_effect = (
+                lambda *args, **kwargs: self.assertEqual(discover_format.call_count, 2)
+            )
+            dbsync.sync_table()
+
+        discover_format.assert_has_calls([
+            call('dummy-schema', 'TABLE1'),
+            call('dummy-schema', 'TABLE1'),
+        ])
+        create_query = query_patch.call_args_list[0].args[0]
+        self.assertIn('CREATE ICEBERG TABLE IF NOT EXISTS', create_query)
+        self.assertIn('"PAYLOAD" variant', create_query)
+        self.assertIn("CATALOG='SNOWFLAKE'", create_query)
+        self.assertIn('ICEBERG_VERSION=3', create_query)
+        grant_patch.assert_called_once()
+
+    @patch('target_snowflake.db_sync.DbSync.grant_privilege')
+    @patch('target_snowflake.db_sync.DbSync.query')
+    def test_sync_table_explicit_create_rejects_concurrent_wrong_format(self, query_patch, grant_patch):
+        query_patch.return_value = [{'type': 'CSV'}]
+        dbsync = db_sync.DbSync(
+            self._table_sync_config(target_table_format='iceberg', iceberg_version=3),
+            self._table_sync_schema(),
+        )
+        query_patch.reset_mock()
+
+        with patch.object(
+            dbsync,
+            'discover_table_format',
+            side_effect=(db_sync.TABLE_FORMAT_MISSING, db_sync.TABLE_FORMAT_NATIVE),
+        ):
+            with self.assertRaisesRegex(
+                TableFormatMismatchException,
+                'is native after creation, but target_table_format requires managed_iceberg_v3',
+            ):
+                dbsync.sync_table()
+
+        self.assertEqual(query_patch.call_count, 1)
+        self.assertIn('CREATE ICEBERG TABLE IF NOT EXISTS', query_patch.call_args.args[0])
+        grant_patch.assert_not_called()
+
+    @patch('target_snowflake.db_sync.DbSync.query')
+    def test_sync_table_explicit_format_must_match_existing_table(self, query_patch):
+        cases = (
+            ('iceberg', db_sync.TABLE_FORMAT_NATIVE),
+            ('iceberg', db_sync.TABLE_FORMAT_MANAGED_ICEBERG_V2),
+            ('iceberg', db_sync.TABLE_FORMAT_UNSUPPORTED_EXTERNAL_ICEBERG),
+            ('native', db_sync.TABLE_FORMAT_MANAGED_ICEBERG_V3),
+        )
+        for requested_format, physical_format in cases:
+            with self.subTest(requested_format=requested_format, physical_format=physical_format):
+                config = self._table_sync_config(target_table_format=requested_format)
+                if requested_format == 'iceberg':
+                    config['iceberg_version'] = 3
+                query_patch.return_value = [{'type': 'CSV'}]
+                dbsync = db_sync.DbSync(config, self._table_sync_schema())
+                query_patch.reset_mock()
+
+                with patch.object(dbsync, 'discover_table_format', return_value=physical_format), \
+                        patch.object(dbsync, 'update_columns') as update_columns:
+                    with self.assertRaises(TableFormatMismatchException):
+                        dbsync.sync_table()
+
+                query_patch.assert_not_called()
+                update_columns.assert_not_called()
+
+    @patch('target_snowflake.db_sync.DbSync.query')
+    def test_sync_table_legacy_config_uses_existing_physical_format(self, query_patch):
+        cases = (
+            (True, db_sync.TABLE_FORMAT_NATIVE, False),
+            (False, db_sync.TABLE_FORMAT_MANAGED_ICEBERG_V2, True),
+            (False, db_sync.TABLE_FORMAT_MANAGED_ICEBERG_V3, True),
+            (False, db_sync.TABLE_FORMAT_UNSUPPORTED_EXTERNAL_ICEBERG, True),
+        )
+        for iceberg_create, physical_format, is_iceberg in cases:
+            with self.subTest(iceberg_create=iceberg_create, physical_format=physical_format):
+                query_patch.return_value = [{'type': 'CSV'}]
+                dbsync = db_sync.DbSync(
+                    self._table_sync_config(iceberg_create=iceberg_create),
+                    self._table_sync_schema(),
+                )
+                query_patch.reset_mock()
+
+                with patch.object(dbsync, 'discover_table_format', return_value=physical_format), \
+                        patch.object(dbsync, 'update_columns') as update_columns, \
+                        patch.object(dbsync, '_refresh_table_pks') as refresh_table_pks:
+                    dbsync.sync_table()
+
+                update_columns.assert_called_once_with(is_iceberg, None)
+                if is_iceberg:
+                    refresh_table_pks.assert_not_called()
+                else:
+                    refresh_table_pks.assert_called_once_with()
+                query_patch.assert_not_called()
+
+    @patch('target_snowflake.db_sync.DbSync.query')
+    def test_sync_table_v3_variant_requires_explicit_configuration(self, query_patch):
+        """An omitted v3 format reports the missing configuration before mutation."""
+        query_patch.return_value = [{'type': 'CSV'}]
+        table_cache = [
+            {
+                'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                'TABLE_NAME': 'TABLE1',
+                'COLUMN_NAME': 'ID',
+                'DATA_TYPE': 'NUMBER',
+            },
+            {
+                'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                'TABLE_NAME': 'TABLE1',
+                'COLUMN_NAME': 'PAYLOAD',
+                'DATA_TYPE': 'VARIANT',
+            },
+        ]
+        dbsync = db_sync.DbSync(
+            self._table_sync_config(),
+            self._table_sync_schema(),
+            table_cache,
+        )
+        query_patch.reset_mock()
+
+        with patch.object(
+            dbsync,
+            'discover_table_format',
+            return_value=db_sync.TABLE_FORMAT_MANAGED_ICEBERG_V3,
+        ), self.assertRaisesRegex(
+            TableFormatMismatchException,
+            'target_table_format is omitted.*restore target_table_format: iceberg',
+        ):
+            dbsync.sync_table()
+
+        query_patch.assert_not_called()

--- a/tests/units/cli/resources/test_table_format_conflict/tap_test.yml
+++ b/tests/units/cli/resources/test_table_format_conflict/tap_test.yml
@@ -1,0 +1,8 @@
+id: test_tap
+name: Test PostgreSQL tap
+type: tap-postgres
+target: test_target
+target_table_format: iceberg
+iceberg_version: 3
+db_conn: {}
+schemas: []

--- a/tests/units/cli/resources/test_table_format_conflict/target_test.yml
+++ b/tests/units/cli/resources/test_table_format_conflict/target_test.yml
@@ -1,0 +1,14 @@
+id: test_target
+name: Test Snowflake target
+type: target-snowflake
+db_conn:
+  account: account
+  dbname: database
+  user: user
+  private_key: private-key
+  warehouse: warehouse
+  s3_bucket: bucket
+  s3_key_prefix: prefix/
+  stage: schema.stage
+  file_format: file-format
+  iceberg_create: false

--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -17,7 +17,12 @@ from pipelinewise import cli
 from pipelinewise.cli.constants import ConnectorType
 from pipelinewise.cli.config import Config
 from pipelinewise.cli.pipelinewise import PipelineWise
-from pipelinewise.cli.errors import DuplicateConfigException, InvalidConfigException, InvalidTransformationException
+from pipelinewise.cli.errors import (
+    DuplicateConfigException,
+    InvalidConfigException,
+    InvalidTransformationException,
+    PreRunChecksException,
+)
 
 RESOURCES_DIR = f'{os.path.dirname(__file__)}/resources'
 CONFIG_DIR = f'{RESOURCES_DIR}/sample_json_config'
@@ -626,6 +631,17 @@ class TestCli:
         args = CliArgs(dir=f'{os.path.dirname(__file__)}/resources/test_import_command', taps='tap_one,tap_three')
         self._assert_import_command(args)
 
+    def test_import_rejects_table_format_conflict_before_saving(self):
+        """import_config applies the shared policy before generated config is changed."""
+        args = CliArgs(dir=f'{RESOURCES_DIR}/test_table_format_conflict')
+        pipelinewise = PipelineWise(args, CONFIG_DIR, VIRTUALENVS_DIR)
+
+        with patch.object(Config, 'save') as save:
+            with pytest.raises(InvalidConfigException, match='conflicts'):
+                pipelinewise.import_project()
+
+        save.assert_not_called()
+
     def test_command_status(self, capsys):
         """Test status command output"""
         # Status table should be printed to stdout
@@ -808,6 +824,70 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
 
         assert bookmarks == {'bookmarks': {'tb1': {'foo': 'bar'}}, 'currently_syncing': None}
 
+    def test_do_sync_tables_rejects_iceberg_before_state_or_process_changes(self):
+        """A real fresh-stream selection fails before state cleanup or child launch."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        pipelinewise.tap['target_table_format'] = 'iceberg'
+
+        with patch.object(
+            pipelinewise, '_reset_state_file_for_partial_sync'
+        ) as reset_state, patch(
+            'pipelinewise.cli.pipelinewise.Process'
+        ) as process:
+            with pytest.raises(PreRunChecksException, match='No target changes'):
+                pipelinewise.do_sync_tables()
+
+        reset_state.assert_not_called()
+        process.assert_not_called()
+
+    def test_do_sync_tables_allows_singer_only_iceberg_run(self):
+        """Explicit Iceberg does not block a launch with no FastSync selection."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        pipelinewise.tap['target_table_format'] = 'iceberg'
+
+        with patch.object(
+            pipelinewise,
+            '_get_sync_tables_setting_from_selection_file',
+            return_value={'full_sync': [], 'partial_sync': {}},
+        ), patch('pipelinewise.cli.pipelinewise.Process') as process:
+            pipelinewise.do_sync_tables()
+
+        process.assert_not_called()
+
+    def test_direct_fastsync_rejects_iceberg_before_state_cleanup(self):
+        """The defensive FullSync seam rejects Iceberg before bookmark cleanup."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        pipelinewise.tap['target_table_format'] = 'iceberg'
+
+        with patch.object(pipelinewise, '_cleanup_tap_state_file') as cleanup, patch.object(
+            pipelinewise, 'run_tap_fastsync'
+        ) as run_fastsync:
+            with pytest.raises(PreRunChecksException, match='No target changes'):
+                pipelinewise.sync_tables_fast_sync(['db_test_mysql.table_one'])
+
+        cleanup.assert_not_called()
+        run_fastsync.assert_not_called()
+
+    def test_direct_partial_sync_rejects_iceberg_before_command(self):
+        """The standalone PartialSync command cannot bypass the temporary guard."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        pipelinewise.tap['target_table_format'] = 'iceberg'
+
+        with patch.object(
+            pipelinewise, '_check_supporting_tap_and_target_for_partial_sync'
+        ) as check_pair, patch.object(
+            pipelinewise, 'run_tap_partialsync'
+        ) as run_partial_sync, patch.object(
+            pipelinewise.logger, 'error'
+        ) as log_error:
+            with pytest.raises(SystemExit) as raised:
+                pipelinewise.sync_tables_partial_sync()
+
+        assert raised.value.code == 1
+        assert 'No target changes were made' in str(log_error.call_args.args[0])
+        check_pair.assert_not_called()
+        run_partial_sync.assert_not_called()
+
     def test_fast_sync_tables_cleanup_state_for_selected_tables(self):
         """Testing sync_tables cleanup state if file exists and there is no table argument"""
         def _assert_state_file(*args, **kwargs):
@@ -929,6 +1009,14 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
         pipelinewise = PipelineWise(args, CONFIG_DIR, VIRTUALENVS_DIR)
 
         with pytest.raises(InvalidTransformationException):
+            pipelinewise.validate()
+
+    def test_validate_rejects_table_format_conflict(self):
+        """validate and import_config share the same cross-config format policy."""
+        args = CliArgs(dir=f'{RESOURCES_DIR}/test_table_format_conflict')
+        pipelinewise = PipelineWise(args, CONFIG_DIR, VIRTUALENVS_DIR)
+
+        with pytest.raises(InvalidConfigException, match='conflicts'):
             pipelinewise.validate()
 
     # pylint: disable=protected-access

--- a/tests/units/cli/test_config.py
+++ b/tests/units/cli/test_config.py
@@ -54,6 +54,202 @@ class TestConfig:
             'pidfile': '/var/singer-connector/pipelinewise.pid',
         }
 
+    @staticmethod
+    def _table_format_tap(**settings):
+        return {
+            'id': 'test_tap',
+            'name': 'Test tap',
+            'type': 'tap-postgres',
+            'db_conn': {},
+            'target': 'test_target',
+            'schemas': [],
+            **settings,
+        }
+
+    @staticmethod
+    def _table_format_target(**connection_settings):
+        return {
+            'id': 'test_target',
+            'name': 'Test target',
+            'type': 'target-snowflake',
+            'db_conn': {
+                'account': 'account',
+                'dbname': 'database',
+                'user': 'user',
+                'private_key': 'private-key',
+                'warehouse': 'warehouse',
+                's3_bucket': 'bucket',
+                's3_key_prefix': 'prefix/',
+                'stage': 'schema.stage',
+                'file_format': 'file-format',
+                **connection_settings,
+            },
+        }
+
+    @pytest.mark.parametrize(
+        'settings',
+        [
+            {},
+            {'target_table_format': 'native'},
+            {'target_table_format': 'iceberg', 'iceberg_version': 3},
+        ],
+    )
+    def test_target_table_format_schema_accepts_supported_settings(self, settings):
+        """The tap schema accepts omission, native, and explicit Iceberg v3."""
+        cli.utils.validate(
+            self._table_format_tap(**settings),
+            cli.utils.load_schema('tap'),
+        )
+
+    @pytest.mark.parametrize(
+        'settings',
+        [
+            {'target_table_format': 'unsupported'},
+            {'target_table_format': 'iceberg'},
+            {'target_table_format': 'native', 'iceberg_version': 3},
+            {'iceberg_version': 3},
+            {'target_table_format': 'iceberg', 'iceberg_version': 2},
+            {'target_table_format': 'iceberg', 'iceberg_version': '3'},
+        ],
+    )
+    def test_target_table_format_schema_rejects_invalid_settings(self, settings):
+        """Iceberg version 3 is valid only with an explicit Iceberg format."""
+        with pytest.raises(InvalidConfigException):
+            cli.utils.validate(
+                self._table_format_tap(**settings),
+                cli.utils.load_schema('tap'),
+            )
+
+    @pytest.mark.parametrize('iceberg_create', [True, False])
+    def test_target_schema_accepts_boolean_legacy_iceberg_create(self, iceberg_create):
+        """Legacy Iceberg creation remains available as a typed boolean."""
+        cli.utils.validate(
+            self._table_format_target(iceberg_create=iceberg_create),
+            cli.utils.load_schema('target'),
+        )
+
+    @pytest.mark.parametrize('iceberg_create', ['true', 1, None])
+    def test_target_schema_rejects_non_boolean_legacy_iceberg_create(self, iceberg_create):
+        """String, numeric, and null legacy flags must not be interpreted as booleans."""
+        with pytest.raises(InvalidConfigException):
+            cli.utils.validate(
+                self._table_format_target(iceberg_create=iceberg_create),
+                cli.utils.load_schema('target'),
+            )
+
+    @pytest.mark.parametrize(
+        ('tap_settings', 'target_settings'),
+        [
+            ({}, {}),
+            ({}, {'iceberg_create': False}),
+            ({}, {'iceberg_create': True}),
+            ({'target_table_format': 'native'}, {}),
+            ({'target_table_format': 'native'}, {'iceberg_create': False}),
+            (
+                {'target_table_format': 'iceberg', 'iceberg_version': 3},
+                {},
+            ),
+            (
+                {'target_table_format': 'iceberg', 'iceberg_version': 3},
+                {'iceberg_create': True},
+            ),
+        ],
+    )
+    def test_target_table_format_policy_accepts_legacy_compatible_settings(
+        self, tap_settings, target_settings
+    ):
+        """Omitted legacy behavior and explicitly agreeing settings remain valid."""
+        Config.validate_target_table_format(
+            self._table_format_tap(**tap_settings),
+            self._table_format_target(**target_settings),
+        )
+
+    @pytest.mark.parametrize(
+        ('tap_settings', 'target_settings'),
+        [
+            ({'target_table_format': 'native'}, {'iceberg_create': True}),
+            (
+                {'target_table_format': 'iceberg', 'iceberg_version': 3},
+                {'iceberg_create': False},
+            ),
+        ],
+    )
+    def test_target_table_format_policy_rejects_legacy_conflicts(
+        self, tap_settings, target_settings
+    ):
+        """An explicit tap format cannot contradict the legacy target setting."""
+        with pytest.raises(InvalidConfigException, match='conflicts'):
+            Config.validate_target_table_format(
+                self._table_format_tap(**tap_settings),
+                self._table_format_target(**target_settings),
+            )
+
+    def test_target_table_format_policy_rejects_non_snowflake_target(self):
+        """The tap-level destination format is meaningful only for Snowflake."""
+        target = self._table_format_target()
+        target['type'] = 'target-postgres'
+
+        with pytest.raises(InvalidConfigException, match='is not target-snowflake'):
+            Config.validate_target_table_format(
+                self._table_format_tap(target_table_format='native'),
+                target,
+            )
+
+    @pytest.mark.parametrize(
+        ('tap_settings', 'message'),
+        [
+            ({'type': 'tap-mongodb'}, 'does not support'),
+            ({'hard_delete': False}, 'hard_delete: true'),
+            ({'data_flattening_max_level': 1}, 'data_flattening_max_level: 0'),
+        ],
+    )
+    def test_explicit_iceberg_policy_rejects_unsupported_tap_settings(
+        self, tap_settings, message
+    ):
+        """The initial explicit Iceberg route is unflattened RDBMS hard-delete only."""
+        tap = self._table_format_tap(
+            target_table_format='iceberg', iceberg_version=3, **tap_settings
+        )
+
+        with pytest.raises(InvalidConfigException, match=message):
+            Config.validate_target_table_format(tap, self._table_format_target())
+
+    def test_target_table_format_is_isolated_between_taps(self, tmp_path):
+        """Two taps sharing one target get independent generated target settings."""
+        config = Config(str(tmp_path))
+        native_tap = self._table_format_tap(
+            id='native_tap', target_table_format='native'
+        )
+        iceberg_tap = self._table_format_tap(
+            id='iceberg_tap', target_table_format='iceberg', iceberg_version=3
+        )
+        target = self._table_format_target()
+        target['taps'] = [native_tap, iceberg_tap]
+        config.targets = {target['id']: target}
+
+        config.save()
+
+        target_dir = tmp_path / target['id']
+        native_config = cli.utils.load_json(
+            str(target_dir / native_tap['id'] / 'inheritable_config.json')
+        )
+        iceberg_config = cli.utils.load_json(
+            str(target_dir / iceberg_tap['id'] / 'inheritable_config.json')
+        )
+        main_config = cli.utils.load_json(str(tmp_path / 'config.json'))
+        main_taps = {
+            tap['id']: tap for tap in main_config['targets'][0]['taps']
+        }
+
+        assert native_config['target_table_format'] == 'native'
+        assert 'iceberg_version' not in native_config
+        assert iceberg_config['target_table_format'] == 'iceberg'
+        assert iceberg_config['iceberg_version'] == 3
+        assert main_taps['native_tap']['target_table_format'] == 'native'
+        assert 'iceberg_version' not in main_taps['native_tap']
+        assert main_taps['iceberg_tap']['target_table_format'] == 'iceberg'
+        assert main_taps['iceberg_tap']['iceberg_version'] == 3
+
     def test_from_yamls(self):
         """Test creating Config object using YAML configuration directory as the input"""
 


### PR DESCRIPTION
## Context

PipelineWise's existing Snowflake Iceberg support is configured at target level, uses the legacy TEXT mapping for nested Singer values, and does not support FastSync publication.

The RDBMS-to-Snowflake Iceberg work is split into four steps: (this is step one)

1. **Configuration and Singer v3 groundwork:** This PR adds tap-level configuration, exact table-format discovery, VARIANT support, and fail-fast guards for unsupported FastSync paths.
2. **Publication and recovery:** Add the shared Snowflake Iceberg publisher, durable recovery, core table-format discovery, and PipelineWise-owned manual native-to-Iceberg conversion. This remains infrastructure and does not activate FastSync routes.
3. **FastSync activation:** Connect MariaDB, MySQL, and PostgreSQL FullSync and PartialSync to the shared publisher, including recovery, Singer handover, E2E tests, and CI coverage.
4. **Optional automatic conversion:** After the explicit routes are proven stable, add guarded native-to-Iceberg conversion while keeping format mismatch as the default behaviour.

## Changes

- Add tap-level `target_table_format` and `iceberg_version` configuration with shared validation for `validate`, `import_config`, and runtime generation.
- Preserve native defaults and legacy target-level `iceberg_create` behaviour when tap-level format is omitted.
- Discover exact Snowflake native, managed Iceberg v2/v3, missing, and unsupported external-Iceberg states.
- Preserve nested Singer values as VARIANT for explicitly configured managed Iceberg v3 tables.
- Reject incompatible existing formats and unsupported Iceberg FastSync routes before mutation.
- Fix unparameterized Snowflake SQL containing literal `%` identifiers.
- Document the configuration, current limitations, and compatibility requirements.

## Type of change

- [x] Bug fix
- [x] New functionality
- [x] Documentation

## Compatibility and operations

Native Snowflake remains the default and its existing FastSync path is unchanged. Legacy `iceberg_create` behaviour remains available when the new tap settings are omitted.

Explicit Iceberg v3 currently supports Singer only and requires an unflattened, hard-delete MariaDB/MySQL/PostgreSQL-to-Snowflake tap. FullSync and PartialSync fail before state reset, process launch, or target mutation until the follow-up FastSync PR.

No automatic table conversion or Iceberg v2 upgrade is performed. Existing tables must match the explicitly requested format. Keep both explicit v3 settings for the tap's lifetime: removing them restores the legacy TEXT mapping and rejects existing VARIANT columns. Rolling back after creating v3 VARIANT tables therefore requires retaining a compatible release or explicitly migrating those columns.

## Validation

All validation ran in the `dev-project` Docker environment.

| Command or check | Result |
|---|---|
| `ruff check pipelinewise tests` | Passed |
| `pylint pipelinewise tests` | Passed, 10.00/10 |
| `flake8 pipelinewise --count --select=E9,F63,F7,F82 --show-source --statistics` | Passed |
| `flake8 pipelinewise --count --max-complexity=15 --max-line-length=120 --statistics` | Passed |
| `pytest --cov=pipelinewise --cov-fail-under=77 -v tests/units` | 633 passed, 122 subtests passed; 82% coverage |
| `pipelinewise validate --dir dev-project/pipelinewise-config` | Passed |
| `cd singer-connectors/target-snowflake && make unit_test` | 125 passed, 44 subtests passed; 80.94% coverage |
| `pytest tests/integration/test_iceberg_v3.py -q` in the target-snowflake test environment | 2 passed, 1 warning |
| `pytest tests/end_to_end/target_snowflake/tap_mariadb -vx --timer-top-n 10` | 18 passed |
| `pytest tests/end_to_end/target_snowflake/tap_postgres -vx --timer-top-n 10` | 15 passed |
| `cd docs && make check` | Passed: 6 documentation tests and strict Sphinx build of 45 sources |
| `git diff --check` | Passed |
| `cd singer-connectors/target-snowflake && make pylint` | Fails on the connector's pre-existing Pylint 4 configuration and findings; this change adds no remaining finding |
| Full legacy target-snowflake integration target | Unavailable because the development environment lacks its additional encryption, profile, and file-format settings; the two new credentialed v3 tests passed |
| Genuine MySQL E2E | Unavailable because `dev-project` currently provides MariaDB rather than MySQL |

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] This pull request is focused and can be reviewed and reverted independently.
- [x] Behavioural changes have regression tests, or I explained why tests are not applicable.
- [x] Relevant documentation and changelog entries are updated, or I explained why they are not applicable.
- [x] Applicable local checks pass; failures, skips, and unavailable checks are documented above.
- [x] The change contains no credentials, private keys, production identifiers, or source records.
- [x] Breaking and compatibility impacts are identified above.
