### PR TITLE
AP-3278: Preserve S3 ACL when archiving Snowflake load files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 **Fixes**
 
 - Execute unparameterized Snowflake SQL containing literal `%` without parameter-binding errors
+- Preserve configured S3 ACLs when archiving Snowflake load files through `target-snowflake`
 
 **Test hardening**
 

--- a/singer-connectors/target-snowflake/target_snowflake/upload_clients/s3_upload_client.py
+++ b/singer-connectors/target-snowflake/target_snowflake/upload_clients/s3_upload_client.py
@@ -102,6 +102,16 @@ class S3UploadClient(BaseUploadClient):
         source_bucket, source_key = copy_source.split("/", 1)
         metadata = self.s3_client.head_object(Bucket=source_bucket, Key=source_key).get('Metadata', {})
         metadata.update(target_metadata)
+        copy_args = {}
+        s3_acl = self.connection_config.get('s3_acl')
+        if s3_acl:
+            copy_args['ACL'] = s3_acl
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.copy_object
-        self.s3_client.copy_object(CopySource=copy_source, Bucket=target_bucket, Key=target_key,
-                                   Metadata=metadata, MetadataDirective="REPLACE")
+        self.s3_client.copy_object(
+            CopySource=copy_source,
+            Bucket=target_bucket,
+            Key=target_key,
+            Metadata=metadata,
+            MetadataDirective="REPLACE",
+            **copy_args,
+        )

--- a/singer-connectors/target-snowflake/tests/unit/test_s3_upload_client.py
+++ b/singer-connectors/target-snowflake/tests/unit/test_s3_upload_client.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from target_snowflake.upload_clients.s3_upload_client import S3UploadClient
+
+
+class TestS3UploadClient(unittest.TestCase):
+    """Test S3 upload client behavior."""
+
+    def create_client(self, config):
+        """Create an S3 upload client with a mocked boto3 client."""
+        with patch("boto3.session.Session") as session:
+            s3_client = MagicMock()
+            session.return_value.client.return_value = s3_client
+            upload_client = S3UploadClient(config)
+
+        return upload_client, s3_client
+
+    def test_copy_object_without_acl(self):
+        """Do not pass an ACL argument unless one is configured."""
+        upload_client, s3_client = self.create_client({})
+        s3_client.head_object.return_value = {"Metadata": {"x-amz-key": "key"}}
+
+        upload_client.copy_object("source-bucket/source-key", "target-bucket", "target-key", {"x-amz-iv": "iv"})
+
+        s3_client.copy_object.assert_called_once_with(
+            CopySource="source-bucket/source-key",
+            Bucket="target-bucket",
+            Key="target-key",
+            Metadata={"x-amz-key": "key", "x-amz-iv": "iv"},
+            MetadataDirective="REPLACE",
+        )
+
+    def test_copy_object_with_s3_acl(self):
+        """Pass the configured ACL through to S3 copy_object."""
+        upload_client, s3_client = self.create_client({"s3_acl": "bucket-owner-full-control"})
+        s3_client.head_object.return_value = {"Metadata": {"x-amz-key": "key"}}
+
+        upload_client.copy_object("source-bucket/source-key", "target-bucket", "target-key", {"x-amz-iv": "iv"})
+
+        s3_client.copy_object.assert_called_once_with(
+            CopySource="source-bucket/source-key",
+            Bucket="target-bucket",
+            Key="target-key",
+            Metadata={"x-amz-key": "key", "x-amz-iv": "iv"},
+            MetadataDirective="REPLACE",
+            ACL="bucket-owner-full-control",
+        )


### PR DESCRIPTION
## Context

When `target-snowflake` is configured with `s3_acl`, uploads already pass that ACL to S3. The archive copy path did not, so archived files could still be copied without `bucket-owner-full-control`.

This passes the configured ACL to `copy_object` only when `s3_acl` is set. Existing targets without `s3_acl` keep the same copy call behavior.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) [optional]
- [ ] New feature (non-breaking change which adds functionality) [optional]
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) [optional]
- [ ] Documentation Update (if none of the other choices apply) [optional]

## Rollout

Deploy this before enabling the FINDB config switch in `analytics-platform-config`; otherwise staging uploads can be fixed while archive copies still miss the ACL.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Relevant documentation is updated including usage instructions

## Validation

- `ruff format --check target_snowflake/upload_clients/s3_upload_client.py tests/unit/test_s3_upload_client.py`
- `ruff check target_snowflake/upload_clients/s3_upload_client.py tests/unit/test_s3_upload_client.py`
- `make unit_test` -> 127 passed, coverage 81.32% / required 67%
- `git diff --check`

Not run: live S3/Snowflake E2E.
