### PR TITLE
AP-3278: Preserve S3 ACL on Snowflake archive copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 **Fixes**
 
 - Execute unparameterized Snowflake SQL containing literal `%` without parameter-binding errors
+- Apply configured S3 ACLs to archived Snowflake load-file copies
 
 **Test hardening**
 

--- a/singer-connectors/target-snowflake/target_snowflake/upload_clients/s3_upload_client.py
+++ b/singer-connectors/target-snowflake/target_snowflake/upload_clients/s3_upload_client.py
@@ -1,6 +1,7 @@
 """
 S3 Upload Client
 """
+
 import os
 import boto3
 import datetime
@@ -23,61 +24,50 @@ class S3UploadClient(BaseUploadClient):
             config = self.connection_config
 
         # Get the required parameters from config file and/or environment variables
-        aws_profile = config.get('aws_profile') or os.environ.get('AWS_PROFILE')
-        aws_access_key_id = config.get('aws_access_key_id') or os.environ.get('AWS_ACCESS_KEY_ID')
-        aws_secret_access_key = config.get('aws_secret_access_key') or os.environ.get('AWS_SECRET_ACCESS_KEY')
-        aws_session_token = config.get('aws_session_token') or os.environ.get('AWS_SESSION_TOKEN')
+        aws_profile = config.get("aws_profile") or os.environ.get("AWS_PROFILE")
+        aws_access_key_id = config.get("aws_access_key_id") or os.environ.get("AWS_ACCESS_KEY_ID")
+        aws_secret_access_key = config.get("aws_secret_access_key") or os.environ.get("AWS_SECRET_ACCESS_KEY")
+        aws_session_token = config.get("aws_session_token") or os.environ.get("AWS_SESSION_TOKEN")
 
         # AWS credentials based authentication
         if aws_access_key_id and aws_secret_access_key:
             aws_session = boto3.session.Session(
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
-                aws_session_token=aws_session_token
+                aws_session_token=aws_session_token,
             )
         # AWS Profile based authentication
         else:
             aws_session = boto3.session.Session(profile_name=aws_profile)
 
         # Create the s3 client
-        return aws_session.client('s3',
-                                  region_name=config.get('s3_region_name'),
-                                  endpoint_url=config.get('s3_endpoint_url'))
+        return aws_session.client("s3", region_name=config.get("s3_region_name"), endpoint_url=config.get("s3_endpoint_url"))
 
     def upload_file(self, file, stream, temp_dir=None):
         """Upload file to an external snowflake stage on s3"""
         # Generating key in S3 bucket
-        bucket = self.connection_config['s3_bucket']
-        s3_acl = self.connection_config.get('s3_acl')
-        s3_key_prefix = self.connection_config.get('s3_key_prefix', '')
+        bucket = self.connection_config["s3_bucket"]
+        s3_acl = self.connection_config.get("s3_acl")
+        s3_key_prefix = self.connection_config.get("s3_key_prefix", "")
         timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S-%f")
 
         s3_key = f"{s3_key_prefix}pipelinewise_{stream}_{timestamp}_{os.path.basename(file)}"
-        self.logger.info('Target S3 bucket: %s, local file: %s, S3 key: %s', bucket, file, s3_key)
+        self.logger.info("Target S3 bucket: %s, local file: %s, S3 key: %s", bucket, file, s3_key)
 
         # Encrypt csv if client side encryption enabled
-        master_key = self.connection_config.get('client_side_encryption_master_key', '')
-        if master_key != '':
+        master_key = self.connection_config.get("client_side_encryption_master_key", "")
+        if master_key != "":
             # Encrypt the file
-            encryption_material = SnowflakeFileEncryptionMaterial(
-                query_stage_master_key=master_key,
-                query_id='',
-                smk_id=0
-            )
+            encryption_material = SnowflakeFileEncryptionMaterial(query_stage_master_key=master_key, query_id="", smk_id=0)
             encryption_metadata, encrypted_file = SnowflakeEncryptionUtil.encrypt_file(
-                encryption_material,
-                file,
-                tmp_dir=temp_dir
+                encryption_material, file, tmp_dir=temp_dir
             )
 
             # Upload to s3
-            extra_args = {'ACL': s3_acl} if s3_acl else {}
+            extra_args = {"ACL": s3_acl} if s3_acl else {}
 
             # Send key and iv in the metadata, that will be required to decrypt and upload the encrypted file
-            extra_args['Metadata'] = {
-                'x-amz-key': encryption_metadata.key,
-                'x-amz-iv': encryption_metadata.iv
-            }
+            extra_args["Metadata"] = {"x-amz-key": encryption_metadata.key, "x-amz-iv": encryption_metadata.iv}
             self.s3_client.upload_file(encrypted_file, bucket, s3_key, ExtraArgs=extra_args)
 
             # Remove the uploaded encrypted file
@@ -85,23 +75,32 @@ class S3UploadClient(BaseUploadClient):
 
         # Upload to S3 without encrypting
         else:
-            extra_args = {'ACL': s3_acl} if s3_acl else None
+            extra_args = {"ACL": s3_acl} if s3_acl else None
             self.s3_client.upload_file(file, bucket, s3_key, ExtraArgs=extra_args)
 
         return s3_key
 
     def delete_object(self, stream: str, key: str) -> None:
         """Delete object from an external snowflake stage on S3"""
-        self.logger.info('Deleting %s from external snowflake stage on S3', key)
-        bucket = self.connection_config['s3_bucket']
+        self.logger.info("Deleting %s from external snowflake stage on S3", key)
+        bucket = self.connection_config["s3_bucket"]
         self.s3_client.delete_object(Bucket=bucket, Key=key)
 
     def copy_object(self, copy_source: str, target_bucket: str, target_key: str, target_metadata: dict) -> None:
         """Copy object to another location on S3"""
-        self.logger.info('Copying %s to %s/%s', copy_source, target_bucket, target_key)
+        self.logger.info("Copying %s to %s/%s", copy_source, target_bucket, target_key)
         source_bucket, source_key = copy_source.split("/", 1)
-        metadata = self.s3_client.head_object(Bucket=source_bucket, Key=source_key).get('Metadata', {})
+        metadata = self.s3_client.head_object(Bucket=source_bucket, Key=source_key).get("Metadata", {})
         metadata.update(target_metadata)
-        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.copy_object
-        self.s3_client.copy_object(CopySource=copy_source, Bucket=target_bucket, Key=target_key,
-                                   Metadata=metadata, MetadataDirective="REPLACE")
+        copy_args = {
+            "CopySource": copy_source,
+            "Bucket": target_bucket,
+            "Key": target_key,
+            "Metadata": metadata,
+            "MetadataDirective": "REPLACE",
+        }
+        s3_acl = self.connection_config.get("s3_acl")
+        if s3_acl:
+            copy_args["ACL"] = s3_acl
+
+        self.s3_client.copy_object(**copy_args)

--- a/singer-connectors/target-snowflake/tests/unit/test_s3_upload_client.py
+++ b/singer-connectors/target-snowflake/tests/unit/test_s3_upload_client.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import MagicMock
+
+from target_snowflake.upload_clients.s3_upload_client import S3UploadClient
+
+
+class TestS3UploadClient(unittest.TestCase):
+    def make_client(self, config):
+        client = S3UploadClient.__new__(S3UploadClient)
+        client.connection_config = config
+        client.logger = MagicMock()
+        client.s3_client = MagicMock()
+        client.s3_client.head_object.return_value = {"Metadata": {"existing": "metadata"}}
+        return client
+
+    def test_copy_object_uses_configured_acl(self):
+        client = self.make_client({"s3_acl": "bucket-owner-full-control"})
+
+        client.copy_object("source-bucket/source-key", "target-bucket", "target-key", {"new": "metadata"})
+
+        client.s3_client.copy_object.assert_called_once_with(
+            ACL="bucket-owner-full-control",
+            Bucket="target-bucket",
+            CopySource="source-bucket/source-key",
+            Key="target-key",
+            Metadata={"existing": "metadata", "new": "metadata"},
+            MetadataDirective="REPLACE",
+        )
+
+    def test_copy_object_omits_acl_by_default(self):
+        client = self.make_client({})
+
+        client.copy_object("source-bucket/source-key", "target-bucket", "target-key", {"new": "metadata"})
+
+        self.assertNotIn("ACL", client.s3_client.copy_object.call_args.kwargs)


### PR DESCRIPTION
## Context

FINDB PipelineWise writes use `s3_acl: bucket-owner-full-control` so Finance can read objects written cross-account by the AP PipelineWise role. Initial staging uploads already pass the configured ACL, but archived load-file copies did not.

## Changes

- Pass configured `s3_acl` through S3 `copy_object` for archived load files.
- Cover ACL and no-ACL copy behavior with a target-snowflake unit test.
- Add a changelog note.

## Type of change

- [x] Bug fix
- [ ] New functionality
- [ ] Maintenance, dependency, or CI
- [ ] Documentation
- [ ] Breaking change

## Compatibility and operations

Backward compatible. The new copy ACL is only sent when `s3_acl` is configured. This needs to be deployed before enabling the FINDB target config that archives into the Finance bucket with bucket-owner ACLs.

## Validation

| Command or check | Result |
|---|---|
| `uvx ruff==0.16.1 format --check singer-connectors/target-snowflake/target_snowflake/upload_clients/s3_upload_client.py singer-connectors/target-snowflake/tests/unit/test_s3_upload_client.py` | Passed |
| `uvx ruff==0.16.1 check singer-connectors/target-snowflake/target_snowflake/upload_clients/s3_upload_client.py singer-connectors/target-snowflake/tests/unit/test_s3_upload_client.py` | Passed |
| `pytest tests/unit/test_s3_upload_client.py -vv` | 2 passed |
| `pytest tests/unit -vv --cov target_snowflake --cov-fail-under=67` | 127 passed, 81% coverage |
| `git diff --check` | Passed |
| Full root `ruff format --check .` | Not used as PR gate evidence: current master has many unrelated unformatted files, so focused Ruff was used for changed Python files. |

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] This pull request is focused and can be reviewed and reverted independently.
- [x] Behavioural changes have regression tests, or I explained why tests are not applicable.
- [x] Relevant documentation and changelog entries are updated, or I explained why they are not applicable.
- [x] Applicable local checks pass; failures, skips, and unavailable checks are documented above.
- [x] The change contains no credentials, private keys, production identifiers, or source records.
- [x] Breaking and compatibility impacts are identified above.
