### PR TITLE
[AP-2520] Parallelize tests, especially E2E, to speed up CI

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: e2e_tests-${{ github.head_ref }}
+  group: e2e_tests-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 env:
@@ -59,11 +59,17 @@ jobs:
         if: steps.check.outcome == 'failure'
         run: |
           readiness_started_at=$(date +%s)
-          until docker logs pipelinewise 2>&1 | grep -Fq "PipelineWise Dev environment is ready"
+          until docker logs --tail 50 pipelinewise 2>&1 | grep -Fq "PipelineWise Dev environment is ready"
           do
+            container_status=$(docker inspect --format '{{.State.Status}}' pipelinewise)
+            if [ "$container_status" != "running" ]; then
+              echo "PipelineWise container stopped with status ${container_status}"
+              docker logs pipelinewise
+              exit 1
+            fi
             elapsed_seconds=$(($(date +%s) - readiness_started_at))
             echo "Waiting for PipelineWise dev environment (${elapsed_seconds}s elapsed)"
-            sleep 30
+            sleep 5
           done
           elapsed_seconds=$(($(date +%s) - readiness_started_at))
           echo "PipelineWise dev environment became ready after ${elapsed_seconds}s"
@@ -175,11 +181,17 @@ jobs:
         timeout-minutes: 10
         run: |
           readiness_started_at=$(date +%s)
-          until docker logs pipelinewise 2>&1 | grep -Fq "PipelineWise Dev environment is ready"
+          until docker logs --tail 50 pipelinewise 2>&1 | grep -Fq "PipelineWise Dev environment is ready"
           do
+            container_status=$(docker inspect --format '{{.State.Status}}' pipelinewise)
+            if [ "$container_status" != "running" ]; then
+              echo "PipelineWise container stopped with status ${container_status}"
+              docker logs pipelinewise
+              exit 1
+            fi
             elapsed_seconds=$(($(date +%s) - readiness_started_at))
             echo "Waiting for PipelineWise dev environment (${elapsed_seconds}s elapsed)"
-            sleep 30
+            sleep 5
           done
           elapsed_seconds=$(($(date +%s) - readiness_started_at))
           echo "PipelineWise dev environment became ready after ${elapsed_seconds}s"

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -31,6 +31,9 @@ jobs:
   e2e_tests_target_pg:
     runs-on: ubuntu-24.04
     environment: ci_tests
+    env:
+      PIPELINEWISE_E2E_NAMESPACE: >-
+        run-${{ github.run_id }}-attempt-${{ github.run_attempt }}-target-pg
 
     steps:
       - name: Checking out repo
@@ -72,6 +75,7 @@ jobs:
           -e TAP_S3_CSV_AWS_KEY=$TAP_S3_CSV_AWS_KEY \
           -e TAP_S3_CSV_AWS_SECRET_ACCESS_KEY=$TAP_S3_CSV_AWS_SECRET_ACCESS_KEY \
           -e TAP_S3_CSV_BUCKET=$TAP_S3_CSV_BUCKET \
+          -e PIPELINEWISE_E2E_NAMESPACE=$PIPELINEWISE_E2E_NAMESPACE \
           pipelinewise pytest \
           tests/end_to_end/test_target_postgres.py \
           tests/end_to_end/test_postgres_stream_buffer_recovery.py \
@@ -79,9 +83,55 @@ jobs:
           tests/end_to_end/data_diff/test_mysql_to_postgres.py \
           -vx --timer-top-n 10
 
-  e2e_tests_mariadb_to_sf:
+  e2e_tests_snowflake:
+    name: ${{ matrix.check_name }}
     runs-on: ubuntu-24.04
     environment: ci_tests
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        include:
+          - shard: pg-core
+            check_name: e2e_tests_sf_pg_core
+            test_paths: >-
+              tests/end_to_end/target_snowflake/tap_postgres/test_partial_sync_pg_to_sf.py
+              tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf.py
+              tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_table_size_check.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_replica_to_sf.py
+              tests/end_to_end/data_diff/test_postgres_to_snowflake.py
+              tests/end_to_end/target_snowflake/tap_s3/test_replicate_s3_to_sf.py
+          - shard: mariadb-core
+            check_name: e2e_tests_sf_mariadb_core
+            test_paths: >-
+              tests/end_to_end/target_snowflake/tap_mariadb/test_partial_sync_mariadb_to_sf.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_soft_delete.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_table_size_check.py
+              tests/end_to_end/target_snowflake/tap_mysql/test_iceberg_v3_mysql_to_sf.py
+          - shard: publication-conversion
+            check_name: e2e_tests_sf_publication_conversion
+            test_paths: >-
+              tests/end_to_end/target_snowflake/test_native_to_iceberg_converter.py
+              tests/end_to_end/target_snowflake/tap_postgres/test_snowflake_iceberg_publisher.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_with_custom_buffer_size.py
+          - shard: formats-aux
+            check_name: e2e_tests_sf_formats_aux
+            test_paths: >-
+              tests/end_to_end/target_snowflake/tap_postgres/test_iceberg_v3_postgres_to_sf.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_iceberg_v3_mariadb_to_sf.py
+              tests/end_to_end/target_snowflake/tap_postgres/test_defined_partial_sync_pg_to_sf.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_defined_partial_sync_mariadb_to_sf.py
+              tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf_with_archive_load_files.py
+              tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_with_split_large_files.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_with_split_large_files.py
+              tests/end_to_end/data_diff/test_mysql_to_snowflake.py
+              tests/end_to_end/target_snowflake/tap_mongodb/test_replicate_mongodb_to_sf.py
+    env:
+      E2E_TEST_PATHS: ${{ matrix.test_paths }}
+      PIPELINEWISE_E2E_NAMESPACE: >-
+        run-${{ github.run_id }}-attempt-${{ github.run_attempt }}-${{ matrix.shard }}
 
     steps:
       - name: Checking out repo
@@ -134,7 +184,7 @@ jobs:
           elapsed_seconds=$(($(date +%s) - readiness_started_at))
           echo "PipelineWise dev environment became ready after ${elapsed_seconds}s"
 
-      - name: Run target snowflake end-to-end tests
+      - name: Run Snowflake end-to-end shard
         if: steps.check.outcome == 'failure'
         run: |
           docker exec -t \
@@ -150,284 +200,8 @@ jobs:
           -e TARGET_SNOWFLAKE_STAGE=$TARGET_SNOWFLAKE_STAGE \
           -e TARGET_SNOWFLAKE_USER=$TARGET_SNOWFLAKE_USER \
           -e TARGET_SNOWFLAKE_WAREHOUSE=$TARGET_SNOWFLAKE_WAREHOUSE \
-          pipelinewise pytest \
-          tests/end_to_end/target_snowflake/tap_mariadb \
-          tests/end_to_end/data_diff/test_mysql_to_snowflake.py \
-          -vx --timer-top-n 10
-
-  e2e_tests_mysql_to_sf:
-    needs: e2e_tests_mariadb_to_sf
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-24.04
-    environment: ci_tests
-
-    steps:
-      - name: Checking out repo
-        uses: actions/checkout@v7
-
-      - name: Check if python changes are present
-        id: check
-        env:
-          GITHUB_REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        continue-on-error: true
-        run: ./scripts/ci_check_no_file_changes.sh python config e2e
-
-      - name: Validate required Snowflake end-to-end configuration
-        if: steps.check.outcome == 'failure'
-        run: |
-          ./scripts/ci_require_env.sh \
-            TARGET_SNOWFLAKE_ACCOUNT \
-            TARGET_SNOWFLAKE_AWS_ACCESS_KEY \
-            TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY \
-            TARGET_SNOWFLAKE_DBNAME \
-            TARGET_SNOWFLAKE_FILE_FORMAT \
-            TARGET_SNOWFLAKE_PRIVATE_KEY \
-            TARGET_SNOWFLAKE_S3_BUCKET \
-            TARGET_SNOWFLAKE_S3_KEY_PREFIX \
-            TARGET_SNOWFLAKE_STAGE \
-            TARGET_SNOWFLAKE_USER \
-            TARGET_SNOWFLAKE_WAREHOUSE
-
-      - name: Setup test containers
-        if: steps.check.outcome == 'failure'
-        run: |
-          cp dev-project/.env.template dev-project/.env
-          echo "$TARGET_SNOWFLAKE_PRIVATE_KEY" > dev-project/snowflake.pem
-          chmod 600 dev-project/snowflake.pem
-          docker compose -f dev-project/docker-compose.yml up -d
-
-      - name: Wait for test containers to be ready
-        if: steps.check.outcome == 'failure'
-        timeout-minutes: 10
-        run: |
-          readiness_started_at=$(date +%s)
-          until docker logs pipelinewise 2>&1 | grep -Fq "PipelineWise Dev environment is ready"
-          do
-            elapsed_seconds=$(($(date +%s) - readiness_started_at))
-            echo "Waiting for PipelineWise dev environment (${elapsed_seconds}s elapsed)"
-            sleep 30
-          done
-          elapsed_seconds=$(($(date +%s) - readiness_started_at))
-          echo "PipelineWise dev environment became ready after ${elapsed_seconds}s"
-
-      - name: Run MySQL and native-conversion Snowflake Iceberg end-to-end tests
-        if: steps.check.outcome == 'failure'
-        run: |
-          docker exec -t \
-          -e TARGET_SNOWFLAKE_ACCOUNT=$TARGET_SNOWFLAKE_ACCOUNT \
-          -e TARGET_SNOWFLAKE_AWS_ACCESS_KEY=$TARGET_SNOWFLAKE_AWS_ACCESS_KEY \
-          -e TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY=$TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY \
-          -e TARGET_SNOWFLAKE_DBNAME=$TARGET_SNOWFLAKE_DBNAME \
-          -e TARGET_SNOWFLAKE_FILE_FORMAT=$TARGET_SNOWFLAKE_FILE_FORMAT \
-          -e TARGET_SNOWFLAKE_PRIVATE_KEY=/opt/pipelinewise/.ssh/snowflake.pem \
-          -e TARGET_SNOWFLAKE_S3_BUCKET=$TARGET_SNOWFLAKE_S3_BUCKET \
-          -e TARGET_SNOWFLAKE_S3_KEY_PREFIX=$TARGET_SNOWFLAKE_S3_KEY_PREFIX \
-          -e TARGET_SNOWFLAKE_SCHEMA=$TARGET_SNOWFLAKE_SCHEMA \
-          -e TARGET_SNOWFLAKE_STAGE=$TARGET_SNOWFLAKE_STAGE \
-          -e TARGET_SNOWFLAKE_USER=$TARGET_SNOWFLAKE_USER \
-          -e TARGET_SNOWFLAKE_WAREHOUSE=$TARGET_SNOWFLAKE_WAREHOUSE \
-          pipelinewise pytest \
-          tests/end_to_end/target_snowflake/tap_mysql \
-          tests/end_to_end/target_snowflake/test_native_to_iceberg_converter.py \
-          -vx --timer-top-n 10
-
-  e2e_tests_pg_to_sf:
-    needs: e2e_tests_mysql_to_sf
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-24.04
-    environment: ci_tests
-
-    steps:
-      - name: Checking out repo
-        uses: actions/checkout@v7
-
-      - name: Check if python changes are present
-        id: check
-        env:
-          GITHUB_REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        continue-on-error: true
-        run: ./scripts/ci_check_no_file_changes.sh python config e2e
-
-      - name: Validate required Snowflake end-to-end configuration
-        if: steps.check.outcome == 'failure'
-        run: |
-          ./scripts/ci_require_env.sh \
-            TARGET_SNOWFLAKE_ACCOUNT \
-            TARGET_SNOWFLAKE_AWS_ACCESS_KEY \
-            TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY \
-            TARGET_SNOWFLAKE_DBNAME \
-            TARGET_SNOWFLAKE_FILE_FORMAT \
-            TARGET_SNOWFLAKE_PRIVATE_KEY \
-            TARGET_SNOWFLAKE_S3_BUCKET \
-            TARGET_SNOWFLAKE_S3_KEY_PREFIX \
-            TARGET_SNOWFLAKE_STAGE \
-            TARGET_SNOWFLAKE_USER \
-            TARGET_SNOWFLAKE_WAREHOUSE
-
-      - name: Setup test containers
-        if: steps.check.outcome == 'failure'
-        run: |
-          cp dev-project/.env.template dev-project/.env
-          echo "$TARGET_SNOWFLAKE_PRIVATE_KEY" > dev-project/snowflake.pem
-          chmod 600 dev-project/snowflake.pem
-          docker compose -f dev-project/docker-compose.yml up -d
-
-      - name: Wait for test containers to be ready
-        if: steps.check.outcome == 'failure'
-        timeout-minutes: 10
-        run: |
-          readiness_started_at=$(date +%s)
-          until docker logs pipelinewise 2>&1 | grep -Fq "PipelineWise Dev environment is ready"
-          do
-            elapsed_seconds=$(($(date +%s) - readiness_started_at))
-            echo "Waiting for PipelineWise dev environment (${elapsed_seconds}s elapsed)"
-            sleep 30
-          done
-          elapsed_seconds=$(($(date +%s) - readiness_started_at))
-          echo "PipelineWise dev environment became ready after ${elapsed_seconds}s"
-
-      - name: Run target snowflake end-to-end tests
-        if: steps.check.outcome == 'failure'
-        run: |
-          docker exec -t \
-          -e TARGET_SNOWFLAKE_ACCOUNT=$TARGET_SNOWFLAKE_ACCOUNT \
-          -e TARGET_SNOWFLAKE_AWS_ACCESS_KEY=$TARGET_SNOWFLAKE_AWS_ACCESS_KEY \
-          -e TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY=$TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY \
-          -e TARGET_SNOWFLAKE_DBNAME=$TARGET_SNOWFLAKE_DBNAME \
-          -e TARGET_SNOWFLAKE_FILE_FORMAT=$TARGET_SNOWFLAKE_FILE_FORMAT \
-          -e TARGET_SNOWFLAKE_PRIVATE_KEY=/opt/pipelinewise/.ssh/snowflake.pem \
-          -e TARGET_SNOWFLAKE_S3_BUCKET=$TARGET_SNOWFLAKE_S3_BUCKET \
-          -e TARGET_SNOWFLAKE_S3_KEY_PREFIX=$TARGET_SNOWFLAKE_S3_KEY_PREFIX \
-          -e TARGET_SNOWFLAKE_SCHEMA=$TARGET_SNOWFLAKE_SCHEMA \
-          -e TARGET_SNOWFLAKE_STAGE=$TARGET_SNOWFLAKE_STAGE \
-          -e TARGET_SNOWFLAKE_USER=$TARGET_SNOWFLAKE_USER \
-          -e TARGET_SNOWFLAKE_WAREHOUSE=$TARGET_SNOWFLAKE_WAREHOUSE \
-          pipelinewise pytest \
-          tests/end_to_end/target_snowflake/tap_postgres \
-          tests/end_to_end/data_diff/test_postgres_to_snowflake.py \
-          -vx --timer-top-n 10
-
-  e2e_tests_mg_to_sf:
-    needs: e2e_tests_pg_to_sf
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-24.04
-    environment: ci_tests
-
-    steps:
-      - name: Checking out repo
-        uses: actions/checkout@v7
-
-      - name: Check if python changes are present
-        id: check
-        env:
-          GITHUB_REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        continue-on-error: true
-        run: ./scripts/ci_check_no_file_changes.sh python config e2e
-
-      - name: Setup test containers
-        if: steps.check.outcome == 'failure'
-        run: |
-          cp dev-project/.env.template dev-project/.env
-          echo "$TARGET_SNOWFLAKE_PRIVATE_KEY" > dev-project/snowflake.pem
-          chmod 600 dev-project/snowflake.pem
-          docker compose -f dev-project/docker-compose.yml up -d
-
-      - name: Wait for test containers to be ready
-        if: steps.check.outcome == 'failure'
-        timeout-minutes: 10
-        run: |
-          readiness_started_at=$(date +%s)
-          until docker logs pipelinewise 2>&1 | grep -Fq "PipelineWise Dev environment is ready"
-          do
-            elapsed_seconds=$(($(date +%s) - readiness_started_at))
-            echo "Waiting for PipelineWise dev environment (${elapsed_seconds}s elapsed)"
-            sleep 30
-          done
-          elapsed_seconds=$(($(date +%s) - readiness_started_at))
-          echo "PipelineWise dev environment became ready after ${elapsed_seconds}s"
-
-      - name: Run target snowflake end-to-end tests
-        if: steps.check.outcome == 'failure'
-        run: |
-          docker exec -t \
-          -e TARGET_SNOWFLAKE_ACCOUNT=$TARGET_SNOWFLAKE_ACCOUNT \
-          -e TARGET_SNOWFLAKE_AWS_ACCESS_KEY=$TARGET_SNOWFLAKE_AWS_ACCESS_KEY \
-          -e TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY=$TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY \
-          -e TARGET_SNOWFLAKE_DBNAME=$TARGET_SNOWFLAKE_DBNAME \
-          -e TARGET_SNOWFLAKE_FILE_FORMAT=$TARGET_SNOWFLAKE_FILE_FORMAT \
-          -e TARGET_SNOWFLAKE_PRIVATE_KEY=/opt/pipelinewise/.ssh/snowflake.pem \
-          -e TARGET_SNOWFLAKE_S3_BUCKET=$TARGET_SNOWFLAKE_S3_BUCKET \
-          -e TARGET_SNOWFLAKE_S3_KEY_PREFIX=$TARGET_SNOWFLAKE_S3_KEY_PREFIX \
-          -e TARGET_SNOWFLAKE_SCHEMA=$TARGET_SNOWFLAKE_SCHEMA \
-          -e TARGET_SNOWFLAKE_STAGE=$TARGET_SNOWFLAKE_STAGE \
-          -e TARGET_SNOWFLAKE_USER=$TARGET_SNOWFLAKE_USER \
-          -e TARGET_SNOWFLAKE_WAREHOUSE=$TARGET_SNOWFLAKE_WAREHOUSE \
-          pipelinewise pytest tests/end_to_end/target_snowflake/tap_mongodb -vx --timer-top-n 10
-
-  e2e_tests_s3_to_sf:
-    needs: e2e_tests_mg_to_sf
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-24.04
-    environment: ci_tests
-
-    steps:
-      - name: Checking out repo
-        uses: actions/checkout@v7
-
-      - name: Check if python changes are present
-        id: check
-        env:
-          GITHUB_REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        continue-on-error: true
-        run: ./scripts/ci_check_no_file_changes.sh python config e2e
-
-      - name: Setup test containers
-        if: steps.check.outcome == 'failure'
-        run: |
-          cp dev-project/.env.template dev-project/.env
-          echo "$TARGET_SNOWFLAKE_PRIVATE_KEY" > dev-project/snowflake.pem
-          chmod 600 dev-project/snowflake.pem
-          docker compose -f dev-project/docker-compose.yml up -d
-
-      - name: Wait for test containers to be ready
-        if: steps.check.outcome == 'failure'
-        timeout-minutes: 10
-        run: |
-          readiness_started_at=$(date +%s)
-          until docker logs pipelinewise 2>&1 | grep -Fq "PipelineWise Dev environment is ready"
-          do
-            elapsed_seconds=$(($(date +%s) - readiness_started_at))
-            echo "Waiting for PipelineWise dev environment (${elapsed_seconds}s elapsed)"
-            sleep 30
-          done
-          elapsed_seconds=$(($(date +%s) - readiness_started_at))
-          echo "PipelineWise dev environment became ready after ${elapsed_seconds}s"
-
-      - name: Run target snowflake end-to-end tests
-        if: steps.check.outcome == 'failure'
-        run: |
-          docker exec -t \
-          -e TARGET_SNOWFLAKE_ACCOUNT=$TARGET_SNOWFLAKE_ACCOUNT \
-          -e TARGET_SNOWFLAKE_AWS_ACCESS_KEY=$TARGET_SNOWFLAKE_AWS_ACCESS_KEY \
-          -e TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY=$TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY \
-          -e TARGET_SNOWFLAKE_DBNAME=$TARGET_SNOWFLAKE_DBNAME \
-          -e TARGET_SNOWFLAKE_FILE_FORMAT=$TARGET_SNOWFLAKE_FILE_FORMAT \
-          -e TARGET_SNOWFLAKE_PRIVATE_KEY=/opt/pipelinewise/.ssh/snowflake.pem \
-          -e TARGET_SNOWFLAKE_S3_BUCKET=$TARGET_SNOWFLAKE_S3_BUCKET \
-          -e TARGET_SNOWFLAKE_S3_KEY_PREFIX=$TARGET_SNOWFLAKE_S3_KEY_PREFIX \
-          -e TARGET_SNOWFLAKE_SCHEMA=$TARGET_SNOWFLAKE_SCHEMA \
-          -e TARGET_SNOWFLAKE_STAGE=$TARGET_SNOWFLAKE_STAGE \
-          -e TARGET_SNOWFLAKE_USER=$TARGET_SNOWFLAKE_USER \
-          -e TARGET_SNOWFLAKE_WAREHOUSE=$TARGET_SNOWFLAKE_WAREHOUSE \
+          -e PIPELINEWISE_E2E_NAMESPACE=$PIPELINEWISE_E2E_NAMESPACE \
           -e TAP_S3_CSV_AWS_KEY=$TAP_S3_CSV_AWS_KEY \
           -e TAP_S3_CSV_AWS_SECRET_ACCESS_KEY=$TAP_S3_CSV_AWS_SECRET_ACCESS_KEY \
           -e TAP_S3_CSV_BUCKET=$TAP_S3_CSV_BUCKET \
-          pipelinewise pytest tests/end_to_end/target_snowflake/tap_s3 -vx --timer-top-n 10
+          pipelinewise pytest $E2E_TEST_PATHS -vx --timer-top-n 10

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -95,45 +95,56 @@ jobs:
     environment: ci_tests
     strategy:
       fail-fast: false
-      max-parallel: 4
       matrix:
         include:
-          - shard: pg-core
-            check_name: e2e_tests_sf_pg_core
-            test_paths: >-
-              tests/end_to_end/target_snowflake/tap_postgres/test_partial_sync_pg_to_sf.py
-              tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf.py
-              tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_table_size_check.py
-              tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_replica_to_sf.py
-              tests/end_to_end/data_diff/test_postgres_to_snowflake.py
-              tests/end_to_end/target_snowflake/tap_s3/test_replicate_s3_to_sf.py
-          - shard: mariadb-core
-            check_name: e2e_tests_sf_mariadb_core
-            test_paths: >-
-              tests/end_to_end/target_snowflake/tap_mariadb/test_partial_sync_mariadb_to_sf.py
-              tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf.py
-              tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_soft_delete.py
-              tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf.py
-              tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_table_size_check.py
-              tests/end_to_end/target_snowflake/tap_mysql/test_iceberg_v3_mysql_to_sf.py
-          - shard: publication-conversion
-            check_name: e2e_tests_sf_publication_conversion
+          - shard: conversion
+            check_name: e2e_tests_sf_conversion
             test_paths: >-
               tests/end_to_end/target_snowflake/test_native_to_iceberg_converter.py
+              tests/end_to_end/data_diff/test_mysql_to_snowflake.py
+          - shard: publication
+            check_name: e2e_tests_sf_publication
+            test_paths: >-
               tests/end_to_end/target_snowflake/tap_postgres/test_snowflake_iceberg_publisher.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_replica_to_sf.py
+          - shard: pg-partial
+            check_name: e2e_tests_sf_pg_partial
+            test_paths: >-
+              tests/end_to_end/target_snowflake/tap_postgres/test_partial_sync_pg_to_sf.py
               tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_with_custom_buffer_size.py
-          - shard: formats-aux
-            check_name: e2e_tests_sf_formats_aux
+              tests/end_to_end/data_diff/test_postgres_to_snowflake.py
+          - shard: mariadb-partial
+            check_name: e2e_tests_sf_mariadb_partial
+            test_paths: >-
+              tests/end_to_end/target_snowflake/tap_mariadb/test_partial_sync_mariadb_to_sf.py
+              tests/end_to_end/target_snowflake/tap_postgres/test_defined_partial_sync_pg_to_sf.py
+              tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_with_split_large_files.py
+          - shard: pg-iceberg
+            check_name: e2e_tests_sf_pg_iceberg
             test_paths: >-
               tests/end_to_end/target_snowflake/tap_postgres/test_iceberg_v3_postgres_to_sf.py
+              tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf.py
+              tests/end_to_end/target_snowflake/tap_s3/test_replicate_s3_to_sf.py
+          - shard: mariadb-iceberg
+            check_name: e2e_tests_sf_mariadb_iceberg
+            test_paths: >-
               tests/end_to_end/target_snowflake/tap_mariadb/test_iceberg_v3_mariadb_to_sf.py
-              tests/end_to_end/target_snowflake/tap_postgres/test_defined_partial_sync_pg_to_sf.py
-              tests/end_to_end/target_snowflake/tap_mariadb/test_defined_partial_sync_mariadb_to_sf.py
-              tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf_with_archive_load_files.py
-              tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_with_split_large_files.py
-              tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_with_split_large_files.py
-              tests/end_to_end/data_diff/test_mysql_to_snowflake.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_soft_delete.py
               tests/end_to_end/target_snowflake/tap_mongodb/test_replicate_mongodb_to_sf.py
+          - shard: mysql-iceberg
+            check_name: e2e_tests_sf_mysql_iceberg
+            test_paths: >-
+              tests/end_to_end/target_snowflake/tap_mysql/test_iceberg_v3_mysql_to_sf.py
+              tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_table_size_check.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf.py
+              tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf_with_archive_load_files.py
+          - shard: mariadb-native
+            check_name: e2e_tests_sf_mariadb_native
+            test_paths: >-
+              tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_table_size_check.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_defined_partial_sync_mariadb_to_sf.py
+              tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_with_split_large_files.py
     env:
       E2E_TEST_PATHS: ${{ matrix.test_paths }}
       PIPELINEWISE_E2E_NAMESPACE: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+Unversioned
+-----------
+
+**Test infrastructure**
+
+- Run Snowflake E2E coverage in four parallel, non-fail-fast CI shards instead
+  of serial source jobs
+- Namespace each shard's remote Snowflake and S3 fixtures and scope config
+  imports to one tap so concurrent jobs cannot interfere
+- Reduce dev-container startup time with bounded parallel connector installs,
+  and fail readiness polling early when the container stops
+
 0.81.0 (2026-08-24)
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@ Unversioned
 
 **Test infrastructure**
 
-- Run Snowflake E2E coverage in four parallel, non-fail-fast CI shards instead
-  of serial source jobs
+- Reduce dev-container startup time with bounded parallel connector installs
+  and fail readiness polling early when the container stops
+- Run Snowflake E2E coverage in eight runtime-balanced, non-fail-fast CI shards
+  instead of serial source jobs
 - Namespace each shard's remote Snowflake and S3 fixtures and scope config
   imports to one tap so concurrent jobs cannot interfere
-- Reduce dev-container startup time with bounded parallel connector installs,
-  and fail readiness polling early when the container stops
 
 0.81.0 (2026-08-24)
 -------------------

--- a/dev-project/entrypoint.sh
+++ b/dev-project/entrypoint.sh
@@ -42,23 +42,17 @@ net_retry() {
 }
 
 apt-get update
-apt_retry apt-get install -y software-properties-common apt-utils
-
 echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 apt_retry apt-get install -y --no-install-recommends \
   wget \
-  gnupg \
   git \
-  alien \
   gettext-base \
-  libaio1t64 \
+  make \
   mariadb-client \
   mbuffer \
   postgresql-client \
-  python3.12-dev python3.12-venv
-
-apt_retry apt-get upgrade -y
+  python3 python3.12-venv
 
 # Do a bunch of Mongo things
 MONGOSH_DEB=mongodb-mongosh_${MONGOSH_VERSION}_amd64.deb
@@ -83,12 +77,92 @@ tests/db/tap_postgres_db.sh
 tests/db/tap_mongodb.sh
 tests/db/target_postgres.sh
 
-# Install PipelineWise and connectors in the container
-if ! make pipelinewise connectors -e pw_acceptlicenses=y -e pw_connector=target-snowflake,target-postgres,tap-mysql,tap-postgres,tap-mongodb,transform-field,tap-s3-csv; then
+# Install PipelineWise before the connectors so their concurrent pip installs
+# can reuse its warmed download cache. Each connector has its own virtualenv.
+if ! make pipelinewise -e pw_acceptlicenses=y; then
     echo
-    echo "ERROR: Docker container not started. Failed to install one or more PipelineWise components."
+    echo "ERROR: Docker container not started. Failed to install PipelineWise."
     exit 1
 fi
+
+CONNECTORS=(
+  target-snowflake
+  target-postgres
+  tap-mysql
+  tap-postgres
+  tap-mongodb
+  transform-field
+  tap-s3-csv
+)
+CONNECTOR_INSTALL_PARALLELISM=4
+CONNECTOR_INSTALL_LOG_DIR=${DOWNLOAD_DIR}/pipelinewise-connector-install
+CONNECTOR_INSTALL_PIDS=()
+
+stop_connector_installs() {
+  local pid
+  for pid in "${CONNECTOR_INSTALL_PIDS[@]}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  for pid in "${CONNECTOR_INSTALL_PIDS[@]}"; do
+    wait "$pid" 2>/dev/null || true
+  done
+}
+
+install_connector_batch() {
+  local connector
+  local failed=0
+  local index
+  local log_file
+  local -a batch_connectors=("$@")
+  local -a batch_logs=()
+
+  CONNECTOR_INSTALL_PIDS=()
+  for connector in "${batch_connectors[@]}"; do
+    log_file=${CONNECTOR_INSTALL_LOG_DIR}/${connector}.log
+    batch_logs+=("$log_file")
+    echo "Starting ${connector} connector installation..."
+    make connectors \
+      -e pw_acceptlicenses=y \
+      -e pw_connector="$connector" >"$log_file" 2>&1 &
+    CONNECTOR_INSTALL_PIDS+=("$!")
+  done
+
+  for index in "${!CONNECTOR_INSTALL_PIDS[@]}"; do
+    connector=${batch_connectors[$index]}
+    if wait "${CONNECTOR_INSTALL_PIDS[$index]}"; then
+      echo "Finished ${connector} connector installation."
+    else
+      echo "ERROR: Failed to install ${connector} connector."
+      failed=1
+    fi
+  done
+
+  for index in "${!batch_logs[@]}"; do
+    connector=${batch_connectors[$index]}
+    echo
+    echo "----- ${connector} connector install log -----"
+    sed "s/^/[${connector}] /" "${batch_logs[$index]}"
+  done
+
+  CONNECTOR_INSTALL_PIDS=()
+  return "$failed"
+}
+
+mkdir -p "$CONNECTOR_INSTALL_LOG_DIR"
+trap 'stop_connector_installs; exit 130' INT
+trap 'stop_connector_installs; exit 143' TERM
+
+connector_count=${#CONNECTORS[@]}
+for ((batch_start = 0; batch_start < connector_count; batch_start += CONNECTOR_INSTALL_PARALLELISM)); do
+  if ! install_connector_batch \
+    "${CONNECTORS[@]:batch_start:CONNECTOR_INSTALL_PARALLELISM}"; then
+    echo
+    echo "ERROR: Docker container not started. Failed to install one or more PipelineWise connectors."
+    exit 1
+  fi
+done
+
+trap - INT TERM
 
 # Activate CLI virtual environment at every login
 sed -i '/motd/d' ~/.bashrc  # Delete any existing old DO_AT_LOGIN line from bashrc

--- a/tests/end_to_end/AGENTS.md
+++ b/tests/end_to_end/AGENTS.md
@@ -34,7 +34,7 @@ step ran and report pass/skip/fail counts.
 ## E2E matrix
 
 These groups mirror `.github/workflows/e2e_tests.yml`; update both together. CI
-runs the four Snowflake groups concurrently on isolated runners. Local groups
+runs the eight Snowflake groups concurrently on isolated runners. Local groups
 share/reset fixtures and config, so run them serially:
 
 ```bash
@@ -47,39 +47,47 @@ run_e2e \
   tests/end_to_end/data_diff/test_mysql_to_postgres.py
 
 run_e2e \
+  tests/end_to_end/target_snowflake/test_native_to_iceberg_converter.py \
+  tests/end_to_end/data_diff/test_mysql_to_snowflake.py
+
+run_e2e \
+  tests/end_to_end/target_snowflake/tap_postgres/test_snowflake_iceberg_publisher.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_replica_to_sf.py
+
+run_e2e \
   tests/end_to_end/target_snowflake/tap_postgres/test_partial_sync_pg_to_sf.py \
-  tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf.py \
-  tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_table_size_check.py \
-  tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_replica_to_sf.py \
-  tests/end_to_end/data_diff/test_postgres_to_snowflake.py \
-  tests/end_to_end/target_snowflake/tap_s3/test_replicate_s3_to_sf.py
+  tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_with_custom_buffer_size.py \
+  tests/end_to_end/data_diff/test_postgres_to_snowflake.py
 
 run_e2e \
   tests/end_to_end/target_snowflake/tap_mariadb/test_partial_sync_mariadb_to_sf.py \
-  tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf.py \
-  tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_soft_delete.py \
-  tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf.py \
-  tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_table_size_check.py \
-  tests/end_to_end/target_snowflake/tap_mysql/test_iceberg_v3_mysql_to_sf.py
-
-run_e2e \
-  tests/end_to_end/target_snowflake/test_native_to_iceberg_converter.py \
-  tests/end_to_end/target_snowflake/tap_postgres/test_snowflake_iceberg_publisher.py \
-  tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_with_custom_buffer_size.py
+  tests/end_to_end/target_snowflake/tap_postgres/test_defined_partial_sync_pg_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_with_split_large_files.py
 
 run_e2e \
   tests/end_to_end/target_snowflake/tap_postgres/test_iceberg_v3_postgres_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_s3/test_replicate_s3_to_sf.py
+
+run_e2e \
   tests/end_to_end/target_snowflake/tap_mariadb/test_iceberg_v3_mariadb_to_sf.py \
-  tests/end_to_end/target_snowflake/tap_postgres/test_defined_partial_sync_pg_to_sf.py \
-  tests/end_to_end/target_snowflake/tap_mariadb/test_defined_partial_sync_mariadb_to_sf.py \
-  tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf_with_archive_load_files.py \
-  tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_with_split_large_files.py \
-  tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_with_split_large_files.py \
-  tests/end_to_end/data_diff/test_mysql_to_snowflake.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_soft_delete.py \
   tests/end_to_end/target_snowflake/tap_mongodb/test_replicate_mongodb_to_sf.py
+
+run_e2e \
+  tests/end_to_end/target_snowflake/tap_mysql/test_iceberg_v3_mysql_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_table_size_check.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf_with_archive_load_files.py
+
+run_e2e \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_table_size_check.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_defined_partial_sync_mariadb_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_with_split_large_files.py
 ```
 
-Run all five only for a full suite; otherwise run every affected group. MariaDB
+Run all nine only for a full suite; otherwise run every affected group. MariaDB
 and PostgreSQL cover native and explicit v3; genuine MySQL covers explicit v3.
 Do not infer one format from the other. `SHOW PRIMARY KEYS` does not prove
 Iceberg identifier fields; inspect raw metadata and compare

--- a/tests/end_to_end/AGENTS.md
+++ b/tests/end_to_end/AGENTS.md
@@ -34,8 +34,8 @@ step ran and report pass/skip/fail counts.
 ## E2E matrix
 
 These groups mirror `.github/workflows/e2e_tests.yml`; update both together. CI
-isolates jobs, but local groups share/reset fixtures, config, Snowflake, and S3,
-so run serially:
+runs the four Snowflake groups concurrently on isolated runners. Local groups
+share/reset fixtures and config, so run them serially:
 
 ```bash
 run_e2e() { docker exec -t pipelinewise pytest "$@" -vx --timer-top-n 10; }
@@ -47,22 +47,39 @@ run_e2e \
   tests/end_to_end/data_diff/test_mysql_to_postgres.py
 
 run_e2e \
-  tests/end_to_end/target_snowflake/tap_mariadb \
-  tests/end_to_end/data_diff/test_mysql_to_snowflake.py
+  tests/end_to_end/target_snowflake/tap_postgres/test_partial_sync_pg_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_table_size_check.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_replica_to_sf.py \
+  tests/end_to_end/data_diff/test_postgres_to_snowflake.py \
+  tests/end_to_end/target_snowflake/tap_s3/test_replicate_s3_to_sf.py
 
 run_e2e \
-  tests/end_to_end/target_snowflake/tap_mysql \
-  tests/end_to_end/target_snowflake/test_native_to_iceberg_converter.py
+  tests/end_to_end/target_snowflake/tap_mariadb/test_partial_sync_mariadb_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_soft_delete.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_table_size_check.py \
+  tests/end_to_end/target_snowflake/tap_mysql/test_iceberg_v3_mysql_to_sf.py
 
 run_e2e \
-  tests/end_to_end/target_snowflake/tap_postgres \
-  tests/end_to_end/data_diff/test_postgres_to_snowflake.py
+  tests/end_to_end/target_snowflake/test_native_to_iceberg_converter.py \
+  tests/end_to_end/target_snowflake/tap_postgres/test_snowflake_iceberg_publisher.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_with_custom_buffer_size.py
 
-run_e2e tests/end_to_end/target_snowflake/tap_mongodb
-run_e2e tests/end_to_end/target_snowflake/tap_s3
+run_e2e \
+  tests/end_to_end/target_snowflake/tap_postgres/test_iceberg_v3_postgres_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_iceberg_v3_mariadb_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_postgres/test_defined_partial_sync_pg_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_defined_partial_sync_mariadb_to_sf.py \
+  tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf_with_archive_load_files.py \
+  tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_with_split_large_files.py \
+  tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_with_split_large_files.py \
+  tests/end_to_end/data_diff/test_mysql_to_snowflake.py \
+  tests/end_to_end/target_snowflake/tap_mongodb/test_replicate_mongodb_to_sf.py
 ```
 
-Run all six only for a full suite; otherwise run every affected group. MariaDB
+Run all five only for a full suite; otherwise run every affected group. MariaDB
 and PostgreSQL cover native and explicit v3; genuine MySQL covers explicit v3.
 Do not infer one format from the other. `SHOW PRIMARY KEYS` does not prove
 Iceberg identifier fields; inspect raw metadata and compare
@@ -75,13 +92,14 @@ Iceberg identifier fields; inspect raw metadata and compare
   `TARGET_SNOWFLAKE_PRIVATE_KEY=/opt/pipelinewise/.ssh/snowflake.pem`,
   `helpers/env.py` fields, and staging credentials. Teardown drops only unique
   run schemas; never use production credentials.
+- CI sets `PIPELINEWISE_E2E_NAMESPACE` from the run, attempt, and shard. It must
+  contain only letters, digits, underscores, and hyphens. The namespace scopes
+  Snowflake staging, archive keys, and tap-S3 fixtures; local runs leave it unset.
 - Tap-S3 needs dedicated `TAP_S3_CSV_AWS_KEY`,
-  `TAP_S3_CSV_AWS_SECRET_ACCESS_KEY`, and `TAP_S3_CSV_BUCKET`. Fixtures overwrite
-  `ppw_e2e_tap_s3_csv/mock_data_{1,2}.csv`; pre-seed both in an empty bucket
-  because discovery precedes upload.
-- The archive route deletes
-  `archive_folder/postgres_to_sf_archive_load_files/` in
-  `TARGET_SNOWFLAKE_S3_BUCKET`; reserve it and avoid concurrent runs.
+  `TAP_S3_CSV_AWS_SECRET_ACCESS_KEY`, and `TAP_S3_CSV_BUCKET`. Setup uploads both
+  namespaced fixture objects before discovery, and teardown removes them.
+- The archive route removes its namespaced files after every test. Use only the
+  dedicated `TARGET_SNOWFLAKE_S3_BUCKET`.
 - Target-PostgreSQL includes S3 and may skip despite healthy databases;
   credential skips are not passes.
 

--- a/tests/end_to_end/data_diff/test_mysql_to_postgres.py
+++ b/tests/end_to_end/data_diff/test_mysql_to_postgres.py
@@ -101,7 +101,9 @@ class TestMySqlToPostgresDataDiff:
         assert source_count > 0
 
         self._run_success(f'pipelinewise validate --dir {PROJECT_DIR}')
-        self._run_success(f'pipelinewise import_config --dir {PROJECT_DIR}')
+        self._run_success(
+            f'pipelinewise import_config --dir {PROJECT_DIR} --taps {TAP_ID}'
+        )
 
         checks = self._run_json(
             'pipelinewise list_data_diff_checks '
@@ -137,7 +139,9 @@ class TestMySqlToPostgresDataDiff:
             f'UPDATE {SOURCE_TABLE} SET date_updated = NOW() - INTERVAL 1 HOUR'
         )
 
-        self._run_success(f'pipelinewise import_config --dir {PROJECT_DIR}')
+        self._run_success(
+            f'pipelinewise import_config --dir {PROJECT_DIR} --taps {TAP_ID}'
+        )
         # FULL_TABLE is handled entirely by FastSync, so no singer log is produced.
         assertions.assert_run_tap_success(TAP_ID, TARGET_ID, ['fastsync'])
 

--- a/tests/end_to_end/data_diff/test_mysql_to_snowflake.py
+++ b/tests/end_to_end/data_diff/test_mysql_to_snowflake.py
@@ -120,7 +120,9 @@ class TestMySqlToSnowflakeDataDiff:
             f'WHERE weight_unit_id = (SELECT MIN(weight_unit_id) FROM '
             f'(SELECT weight_unit_id FROM {SOURCE_TABLE}) inner_rows)'
         )
-        self._run_success(f'pipelinewise import_config --dir {PROJECT_DIR}')
+        self._run_success(
+            f'pipelinewise import_config --dir {PROJECT_DIR} --taps {TAP_ID}'
+        )
         self._run_success(
             f'pipelinewise run_tap --tap {TAP_ID} --target {TARGET_ID}'
         )

--- a/tests/end_to_end/data_diff/test_postgres_to_postgres.py
+++ b/tests/end_to_end/data_diff/test_postgres_to_postgres.py
@@ -88,7 +88,9 @@ class TestPostgresToPostgresDataDiff:
         assert source_count == 4
 
         self._run_success(f'pipelinewise validate --dir {PROJECT_DIR}')
-        self._run_success(f'pipelinewise import_config --dir {PROJECT_DIR}')
+        self._run_success(
+            f'pipelinewise import_config --dir {PROJECT_DIR} --taps {TAP_ID}'
+        )
 
         checks = self._run_json(
             'pipelinewise list_data_diff_checks '
@@ -481,7 +483,9 @@ class TestPostgresToPostgresDataDiff:
                 " WHERE table_schema = 'public' AND table_name LIKE 'dd_%'"
             )[0][0] == 0
 
-            self._run_success(f'pipelinewise import_config --dir {PROJECT_DIR}')
+            self._run_success(
+                f'pipelinewise import_config --dir {PROJECT_DIR} --taps {TAP_ID}'
+            )
 
             tables = {
                 row[0] for row in self.run_backend_query(
@@ -503,7 +507,9 @@ class TestPostgresToPostgresDataDiff:
             assert self.run_backend_query(
                 'SELECT COUNT(*) FROM public.alembic_version'
             )[0][0] == 1
-            self._run_success(f'pipelinewise import_config --dir {PROJECT_DIR}')
+            self._run_success(
+                f'pipelinewise import_config --dir {PROJECT_DIR} --taps {TAP_ID}'
+            )
         finally:
             self.e2e.run_ddl_pipelinewise_backend(
                 f'DROP SCHEMA IF EXISTS {ddl_schema} CASCADE'

--- a/tests/end_to_end/data_diff/test_postgres_to_snowflake.py
+++ b/tests/end_to_end/data_diff/test_postgres_to_snowflake.py
@@ -93,7 +93,9 @@ class TestPostgresToSnowflakeDataDiff:
         )
 
         self._run_success(f'pipelinewise validate --dir {PROJECT_DIR}')
-        self._run_success(f'pipelinewise import_config --dir {PROJECT_DIR}')
+        self._run_success(
+            f'pipelinewise import_config --dir {PROJECT_DIR} --taps {TAP_ID}'
+        )
         self._run_success(
             f'pipelinewise run_tap --tap {TAP_ID} --target {TARGET_ID}'
         )
@@ -136,7 +138,9 @@ class TestPostgresToSnowflakeDataDiff:
             "SET updated_at = date_trunc('hour', CURRENT_TIMESTAMP) - interval '1 hour'"
         )
 
-        self._run_success(f'pipelinewise import_config --dir {PROJECT_DIR}')
+        self._run_success(
+            f'pipelinewise import_config --dir {PROJECT_DIR} --taps {TAP_ID}'
+        )
         self._run_success(
             f'pipelinewise run_tap --tap {TAP_ID} --target {TARGET_ID}'
         )

--- a/tests/end_to_end/helpers/env.py
+++ b/tests/end_to_end/helpers/env.py
@@ -14,6 +14,25 @@ from . import db
 USER_HOME = os.path.expanduser('~')
 CONFIG_DIR = os.path.join(USER_HOME, '.pipelinewise')
 DIR = os.path.dirname(os.path.realpath(__file__))
+E2E_NAMESPACE_ENV = 'PIPELINEWISE_E2E_NAMESPACE'
+TAP_S3_CSV_KEY_PREFIX = 'ppw_e2e_tap_s3_csv'
+SNOWFLAKE_ARCHIVE_S3_PREFIX = 'archive_folder'
+
+
+def _load_e2e_namespace():
+    """Return an optional S3-safe namespace for concurrent E2E jobs."""
+    namespace = os.environ.get(E2E_NAMESPACE_ENV, '')
+    if namespace and re.fullmatch(r'[A-Za-z0-9_-]+', namespace) is None:
+        raise ValueError(
+            f'{E2E_NAMESPACE_ENV} must contain only letters, digits, underscores, '
+            'and hyphens'
+        )
+    return namespace
+
+
+def _namespaced_s3_path(base_prefix, namespace):
+    """Append a namespace as one path segment without duplicating slashes."""
+    return f'{base_prefix.rstrip("/")}/{namespace}'
 
 
 # pylint: disable=too-many-public-methods
@@ -54,6 +73,23 @@ class E2EEnv:
         schema_postfix_override = os.environ.get('TARGET_SNOWFLAKE_SCHEMA_POSTFIX')
         self.sf_schema_postfix_is_override = bool(schema_postfix_override)
         self.sf_schema_postfix = schema_postfix_override or self.sf_schema_postfix
+        self.e2e_namespace = _load_e2e_namespace()
+        tap_s3_csv_key_prefix = TAP_S3_CSV_KEY_PREFIX
+        snowflake_archive_s3_prefix = SNOWFLAKE_ARCHIVE_S3_PREFIX
+        snowflake_s3_key_prefix = os.environ.get('TARGET_SNOWFLAKE_S3_KEY_PREFIX')
+        if self.e2e_namespace:
+            tap_s3_csv_key_prefix = _namespaced_s3_path(
+                tap_s3_csv_key_prefix,
+                self.e2e_namespace,
+            )
+            snowflake_archive_s3_prefix = _namespaced_s3_path(
+                snowflake_archive_s3_prefix,
+                self.e2e_namespace,
+            )
+            if snowflake_s3_key_prefix:
+                snowflake_s3_key_prefix = (
+                    f'{_namespaced_s3_path(snowflake_s3_key_prefix, self.e2e_namespace)}/'
+                )
         self.env = {
             # ------------------------------------------------------------------
             # Tap Postgres is a REQUIRED test connector and test database with test data available
@@ -173,6 +209,10 @@ class E2EEnv:
                         'value': os.environ.get('TAP_S3_CSV_AWS_SECRET_ACCESS_KEY')
                     },
                     'BUCKET': {'value': os.environ.get('TAP_S3_CSV_BUCKET')},
+                    'KEY_PREFIX': {
+                        'value': tap_s3_csv_key_prefix,
+                        'optional': True,
+                    },
                 },
             },
             # ------------------------------------------------------------------
@@ -259,7 +299,7 @@ class E2EEnv:
                         'value': os.environ.get('TARGET_SNOWFLAKE_S3_BUCKET')
                     },
                     'S3_KEY_PREFIX': {
-                        'value': os.environ.get('TARGET_SNOWFLAKE_S3_KEY_PREFIX')
+                        'value': snowflake_s3_key_prefix
                     },
                     'S3_ACL': {
                         'value': os.environ.get('TARGET_SNOWFLAKE_S3_ACL'),
@@ -278,7 +318,11 @@ class E2EEnv:
                     'SCHEMA_POSTFIX': {
                         'value': self.sf_schema_postfix,
                         'optional': True,
-                    }
+                    },
+                    'ARCHIVE_LOAD_FILES_S3_PREFIX': {
+                        'value': snowflake_archive_s3_prefix,
+                        'optional': True,
+                    },
                 },
             },
         }
@@ -582,6 +626,7 @@ class E2EEnv:
         )
 
         bucket = self.get_conn_env_var('TAP_S3_CSV', 'BUCKET')
+        key_prefix = self.get_conn_env_var('TAP_S3_CSV', 'KEY_PREFIX')
         s3 = boto3.client(
             's3',
             aws_access_key_id=self.get_conn_env_var('TAP_S3_CSV', 'AWS_KEY'),
@@ -590,8 +635,33 @@ class E2EEnv:
             ),
         )
 
-        s3.upload_file(mock_data_1, bucket, 'ppw_e2e_tap_s3_csv/mock_data_1.csv')
-        s3.upload_file(mock_data_2, bucket, 'ppw_e2e_tap_s3_csv/mock_data_2.csv')
+        s3.upload_file(mock_data_1, bucket, f'{key_prefix}/mock_data_1.csv')
+        s3.upload_file(mock_data_2, bucket, f'{key_prefix}/mock_data_2.csv')
+
+    def cleanup_tap_s3_csv(self):
+        """Delete this CI run's exact tap S3 CSV fixture objects."""
+        if not self.e2e_namespace:
+            return
+
+        bucket = self.get_conn_env_var('TAP_S3_CSV', 'BUCKET')
+        key_prefix = self.get_conn_env_var('TAP_S3_CSV', 'KEY_PREFIX')
+        s3 = boto3.client(
+            's3',
+            aws_access_key_id=self.get_conn_env_var('TAP_S3_CSV', 'AWS_KEY'),
+            aws_secret_access_key=self.get_conn_env_var(
+                'TAP_S3_CSV', 'AWS_SECRET_ACCESS_KEY'
+            ),
+        )
+        s3.delete_objects(
+            Bucket=bucket,
+            Delete={
+                'Objects': [
+                    {'Key': f'{key_prefix}/mock_data_1.csv'},
+                    {'Key': f'{key_prefix}/mock_data_2.csv'},
+                ],
+                'Quiet': True,
+            },
+        )
 
     def setup_target_postgres(self):
         """Clean postgres target database and prepare for test run"""

--- a/tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_table_size_check.py
+++ b/tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_table_size_check.py
@@ -14,8 +14,11 @@ def _create_ppw_config_file(table_mb):
         config_file.write('allowed_resync_max_size:\n')
         config_file.write(f'  table_mb: {table_mb}\n')
 
-    [return_code, _, _] = tasks.run_command(f'pipelinewise import_config --dir {TEST_PROJECTS_DIR_PATH}')
-    assert return_code == 0
+    return_code, stdout, stderr = tasks.run_command(
+        f'pipelinewise import_config --dir {TEST_PROJECTS_DIR_PATH} '
+        f'--taps {TAP_ID}'
+    )
+    assert return_code == 0, f'import_config failed\n{stdout}\n{stderr}'
 
 
 class TestResyncMariaDBToSF(TapMariaDB):

--- a/tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf_with_archive_load_files.py
+++ b/tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf_with_archive_load_files.py
@@ -15,7 +15,6 @@ ARCHIVE_STATE_EXPECTATIONS = {
 
 TAP_ID = 'postgres_to_sf_archive_load_files'
 TARGET_ID = 'snowflake'
-ARCHIVE_S3_PREFIX = 'archive_folder'
 
 
 class TestReplicatePGToSFWithArchiveLoadFiles(TapPostgres):
@@ -29,7 +28,13 @@ class TestReplicatePGToSFWithArchiveLoadFiles(TapPostgres):
 
         # pylint: disable=protected-access
         self.s3_bucket = self.e2e_env.get_conn_env_var('TARGET_SNOWFLAKE', 'S3_BUCKET')
+        self.archive_s3_prefix = self.e2e_env.get_conn_env_var(
+            'TARGET_SNOWFLAKE',
+            'ARCHIVE_LOAD_FILES_S3_PREFIX',
+        )
         self.s3_client = self.e2e_env.get_aws_session().client('s3')
+        if self.e2e_env.e2e_namespace:
+            self.addCleanup(self.delete_dangling_files_from_archive)
 
     def delete_dangling_files_from_archive(self):
         """
@@ -38,7 +43,7 @@ class TestReplicatePGToSFWithArchiveLoadFiles(TapPostgres):
 
         files_in_s3_archive = self.s3_client.list_objects(
             Bucket=self.s3_bucket,
-            Prefix=f'{ARCHIVE_S3_PREFIX}/postgres_to_sf_archive_load_files/',
+            Prefix=f'{self.archive_s3_prefix}/postgres_to_sf_archive_load_files/',
         ).get('Contents', [])
         for file_in_archive in files_in_s3_archive:
             self.s3_client.delete_object(
@@ -52,7 +57,9 @@ class TestReplicatePGToSFWithArchiveLoadFiles(TapPostgres):
 
         return self.s3_client.list_objects(
             Bucket=self.s3_bucket,
-            Prefix=(f'{ARCHIVE_S3_PREFIX}/postgres_to_sf_archive_load_files/{table}'),
+            Prefix=(
+                f'{self.archive_s3_prefix}/postgres_to_sf_archive_load_files/{table}'
+            ),
         ).get('Contents')
 
     def test_replicate_pg_to_sf_with_archive_load_files(self):

--- a/tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_table_size_check.py
+++ b/tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_table_size_check.py
@@ -14,9 +14,12 @@ def _create_ppw_config_file(table_mb):
         config_file.write('allowed_resync_max_size:\n')
         config_file.write(f'  table_mb: {table_mb}\n')
 
-    [return_code, _, _] = tasks.run_command(f'pipelinewise import_config --dir {TEST_PROJECTS_DIR_PATH}')
+    return_code, stdout, stderr = tasks.run_command(
+        f'pipelinewise import_config --dir {TEST_PROJECTS_DIR_PATH} '
+        f'--taps {TAP_ID}'
+    )
 
-    assert return_code == 0
+    assert return_code == 0, f'import_config failed\n{stdout}\n{stderr}'
 
 
 class TestResyncPGToSF(TapPostgres):

--- a/tests/end_to_end/target_snowflake/tap_s3/__init__.py
+++ b/tests/end_to_end/target_snowflake/tap_s3/__init__.py
@@ -9,4 +9,8 @@ class TapS3(TargetSnowflake):
     # pylint: disable=arguments-differ
     def setUp(self, tap_id: str, target_id: str):
         super().setUp(tap_id=tap_id, target_id=target_id, tap_type='TAP_S3_CSV')
+
+    def prepare_source(self):
+        """Upload source fixtures before discovery and remove CI-owned keys later."""
+        self.addCleanup(self.e2e_env.cleanup_tap_s3_csv)
         self.e2e_env.setup_tap_s3_csv()

--- a/tests/end_to_end/test-project/tap_postgres_to_sf_archive_load_files.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf_archive_load_files.yml.template
@@ -29,7 +29,7 @@ target: "snowflake"                           # ID of the target connector where
 batch_size_rows: 1000                         # Batch size for the stream to optimise load performance
 stream_buffer_size: 0                         # In-memory buffer size (MB) between taps and targets for asynchronous data pipes
 archive_load_files: True                      # Archive the load files in dedicated S3 folder
-archive_load_files_s3_prefix: archive_folder  # Archive folder
+archive_load_files_s3_prefix: "${TARGET_SNOWFLAKE_ARCHIVE_LOAD_FILES_S3_PREFIX}"
 
 
 # ------------------------------------------------------------------------------

--- a/tests/end_to_end/test-project/tap_s3_csv_to_pg.yml.template
+++ b/tests/end_to_end/test-project/tap_s3_csv_to_pg.yml.template
@@ -49,7 +49,7 @@ schemas:
       - table_name: "people"
         replication_method: "FULL_TABLE"
         s3_csv_mapping:
-          search_pattern: "^ppw_e2e_tap_s3_csv/mock_data_1.csv$"
+          search_pattern: "^${TAP_S3_CSV_KEY_PREFIX}/mock_data_1.csv$"
           date_overrides:
             - birth_date
         transformations:
@@ -62,5 +62,5 @@ schemas:
 
       - table_name: "countries"
         s3_csv_mapping:
-          search_pattern: "^ppw_e2e_tap_s3_csv/mock_data_2.csv$"
+          search_pattern: "^${TAP_S3_CSV_KEY_PREFIX}/mock_data_2.csv$"
           key_properties: ["id"]

--- a/tests/end_to_end/test-project/tap_s3_csv_to_sf.yml.template
+++ b/tests/end_to_end/test-project/tap_s3_csv_to_sf.yml.template
@@ -50,7 +50,7 @@ schemas:
       - table_name: "people"
         replication_method: "FULL_TABLE"
         s3_csv_mapping:
-          search_pattern: "^ppw_e2e_tap_s3_csv/mock_data_1.csv$"
+          search_pattern: "^${TAP_S3_CSV_KEY_PREFIX}/mock_data_1.csv$"
           date_overrides:
             - birth_date
         transformations:
@@ -63,5 +63,5 @@ schemas:
 
       - table_name: "countries"
         s3_csv_mapping:
-          search_pattern: "^ppw_e2e_tap_s3_csv/mock_data_2.csv$"
+          search_pattern: "^${TAP_S3_CSV_KEY_PREFIX}/mock_data_2.csv$"
           key_properties: ["id"]

--- a/tests/end_to_end/test_target_postgres.py
+++ b/tests/end_to_end/test_target_postgres.py
@@ -29,6 +29,8 @@ class TestTargetPostgres:
     End to end tests for Target Postgres
     """
 
+    tap_s3_cleanup_env = None
+
     def setup_method(self):
         """Initialise test project by generating YAML files from
         templates for all the configured connectors"""
@@ -36,14 +38,20 @@ class TestTargetPostgres:
 
         # Init query runner methods
         self.e2e = E2EEnv(self.project_dir)
+        type(self).tap_s3_cleanup_env = self.e2e
         self.run_query_tap_mysql = self.e2e.run_query_tap_mysql
         self.run_query_tap_mysql_2 = self.e2e.run_query_tap_mysql_2
         self.run_query_tap_postgres = self.e2e.run_query_tap_postgres
         self.run_query_target_postgres = self.e2e.run_query_target_postgres
         self.mongodb_con = self.e2e.get_tap_mongodb_connection()
 
-    def teardown_method(self):
-        """Delete test directories and database objects"""
+    @classmethod
+    def teardown_class(cls):
+        """Delete namespaced tap S3 fixtures after dependent tests finish."""
+        e2e = cls.tap_s3_cleanup_env
+        cls.tap_s3_cleanup_env = None
+        if e2e and e2e.env['TAP_S3_CSV']['is_configured']:
+            e2e.cleanup_tap_s3_csv()
 
     @pytest.mark.dependency(name='validate')
     def test_validate(self):

--- a/tests/units/test_ci_check_no_file_changes.py
+++ b/tests/units/test_ci_check_no_file_changes.py
@@ -184,7 +184,7 @@ def test_e2e_workflow_triggers_checks(tmp_path):
 
 
 def test_snowflake_e2e_matrix_contract():
-    """Snowflake shards cover every route with bounded parallelism."""
+    """Snowflake shards cover every route exactly once with full parallelism."""
     workflow = yaml.safe_load(E2E_WORKFLOW.read_text(encoding='utf-8'))
     jobs = workflow['jobs']
     job = jobs['e2e_tests_snowflake']
@@ -197,52 +197,72 @@ def test_snowflake_e2e_matrix_contract():
     assert 'needs' not in job
     assert job['name'] == '${{ matrix.check_name }}'
     assert strategy['fail-fast'] is False
-    assert strategy['max-parallel'] == 4
-    assert len(shards) == 4
+    assert 'max-parallel' not in strategy
+    assert len(shards) == 8
 
     expected_shards = {
-        'pg-core': (
-            'e2e_tests_sf_pg_core',
+        'conversion': (
+            'e2e_tests_sf_conversion',
+            (
+                'tests/end_to_end/target_snowflake/test_native_to_iceberg_converter.py',
+                'tests/end_to_end/data_diff/test_mysql_to_snowflake.py',
+            ),
+        ),
+        'publication': (
+            'e2e_tests_sf_publication',
+            (
+                'tests/end_to_end/target_snowflake/tap_postgres/test_snowflake_iceberg_publisher.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_replica_to_sf.py',
+            ),
+        ),
+        'pg-partial': (
+            'e2e_tests_sf_pg_partial',
             (
                 'tests/end_to_end/target_snowflake/tap_postgres/test_partial_sync_pg_to_sf.py',
-                'tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf.py',
-                'tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_table_size_check.py',
-                'tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_replica_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_with_custom_buffer_size.py',
                 'tests/end_to_end/data_diff/test_postgres_to_snowflake.py',
+            ),
+        ),
+        'mariadb-partial': (
+            'e2e_tests_sf_mariadb_partial',
+            (
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_partial_sync_mariadb_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_postgres/test_defined_partial_sync_pg_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_with_split_large_files.py',
+            ),
+        ),
+        'pg-iceberg': (
+            'e2e_tests_sf_pg_iceberg',
+            (
+                'tests/end_to_end/target_snowflake/tap_postgres/test_iceberg_v3_postgres_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf.py',
                 'tests/end_to_end/target_snowflake/tap_s3/test_replicate_s3_to_sf.py',
             ),
         ),
-        'mariadb-core': (
-            'e2e_tests_sf_mariadb_core',
+        'mariadb-iceberg': (
+            'e2e_tests_sf_mariadb_iceberg',
             (
-                'tests/end_to_end/target_snowflake/tap_mariadb/test_partial_sync_mariadb_to_sf.py',
-                'tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf.py',
-                'tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_soft_delete.py',
-                'tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf.py',
-                'tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_table_size_check.py',
-                'tests/end_to_end/target_snowflake/tap_mysql/test_iceberg_v3_mysql_to_sf.py',
-            ),
-        ),
-        'publication-conversion': (
-            'e2e_tests_sf_publication_conversion',
-            (
-                'tests/end_to_end/target_snowflake/test_native_to_iceberg_converter.py',
-                'tests/end_to_end/target_snowflake/tap_postgres/test_snowflake_iceberg_publisher.py',
-                'tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_with_custom_buffer_size.py',
-            ),
-        ),
-        'formats-aux': (
-            'e2e_tests_sf_formats_aux',
-            (
-                'tests/end_to_end/target_snowflake/tap_postgres/test_iceberg_v3_postgres_to_sf.py',
                 'tests/end_to_end/target_snowflake/tap_mariadb/test_iceberg_v3_mariadb_to_sf.py',
-                'tests/end_to_end/target_snowflake/tap_postgres/test_defined_partial_sync_pg_to_sf.py',
-                'tests/end_to_end/target_snowflake/tap_mariadb/test_defined_partial_sync_mariadb_to_sf.py',
-                'tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf_with_archive_load_files.py',
-                'tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_with_split_large_files.py',
-                'tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_with_split_large_files.py',
-                'tests/end_to_end/data_diff/test_mysql_to_snowflake.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_soft_delete.py',
                 'tests/end_to_end/target_snowflake/tap_mongodb/test_replicate_mongodb_to_sf.py',
+            ),
+        ),
+        'mysql-iceberg': (
+            'e2e_tests_sf_mysql_iceberg',
+            (
+                'tests/end_to_end/target_snowflake/tap_mysql/test_iceberg_v3_mysql_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_table_size_check.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf_with_archive_load_files.py',
+            ),
+        ),
+        'mariadb-native': (
+            'e2e_tests_sf_mariadb_native',
+            (
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_table_size_check.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_defined_partial_sync_mariadb_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_with_split_large_files.py',
             ),
         ),
     }

--- a/tests/units/test_ci_check_no_file_changes.py
+++ b/tests/units/test_ci_check_no_file_changes.py
@@ -183,67 +183,135 @@ def test_e2e_workflow_triggers_checks(tmp_path):
     assert 'Detected changes in following file: .github/workflows/e2e_tests.yml' in result.stdout
 
 
-def test_snowflake_e2e_jobs_are_serial():
-    """Credentialed routes run serially even after an earlier route fails."""
+def test_snowflake_e2e_matrix_contract():
+    """Snowflake shards cover every route with bounded parallelism."""
     workflow = yaml.safe_load(E2E_WORKFLOW.read_text(encoding='utf-8'))
     jobs = workflow['jobs']
-    chain = (
-        (
-            'e2e_tests_mariadb_to_sf',
-            None,
-            'tests/end_to_end/target_snowflake/tap_mariadb',
+    job = jobs['e2e_tests_snowflake']
+    strategy = job['strategy']
+    shards = strategy['matrix']['include']
+
+    assert 'needs' not in job
+    assert job['name'] == '${{ matrix.check_name }}'
+    assert strategy['fail-fast'] is False
+    assert strategy['max-parallel'] == 4
+    assert len(shards) == 4
+
+    expected_shards = {
+        'pg-core': (
+            'e2e_tests_sf_pg_core',
+            (
+                'tests/end_to_end/target_snowflake/tap_postgres/test_partial_sync_pg_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_table_size_check.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_replica_to_sf.py',
+                'tests/end_to_end/data_diff/test_postgres_to_snowflake.py',
+                'tests/end_to_end/target_snowflake/tap_s3/test_replicate_s3_to_sf.py',
+            ),
         ),
-        (
-            'e2e_tests_mysql_to_sf',
-            'e2e_tests_mariadb_to_sf',
-            'tests/end_to_end/target_snowflake/tap_mysql',
+        'mariadb-core': (
+            'e2e_tests_sf_mariadb_core',
+            (
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_partial_sync_mariadb_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_soft_delete.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_table_size_check.py',
+                'tests/end_to_end/target_snowflake/tap_mysql/test_iceberg_v3_mysql_to_sf.py',
+            ),
         ),
-        (
-            'e2e_tests_pg_to_sf',
-            'e2e_tests_mysql_to_sf',
-            'tests/end_to_end/target_snowflake/tap_postgres',
+        'publication-conversion': (
+            'e2e_tests_sf_publication_conversion',
+            (
+                'tests/end_to_end/target_snowflake/test_native_to_iceberg_converter.py',
+                'tests/end_to_end/target_snowflake/tap_postgres/test_snowflake_iceberg_publisher.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_replicate_mariadb_to_sf_with_custom_buffer_size.py',
+            ),
         ),
-        (
-            'e2e_tests_mg_to_sf',
-            'e2e_tests_pg_to_sf',
-            'tests/end_to_end/target_snowflake/tap_mongodb',
+        'formats-aux': (
+            'e2e_tests_sf_formats_aux',
+            (
+                'tests/end_to_end/target_snowflake/tap_postgres/test_iceberg_v3_postgres_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_iceberg_v3_mariadb_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_postgres/test_defined_partial_sync_pg_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_defined_partial_sync_mariadb_to_sf.py',
+                'tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf_with_archive_load_files.py',
+                'tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_with_split_large_files.py',
+                'tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf_with_split_large_files.py',
+                'tests/end_to_end/data_diff/test_mysql_to_snowflake.py',
+                'tests/end_to_end/target_snowflake/tap_mongodb/test_replicate_mongodb_to_sf.py',
+            ),
         ),
-        (
-            'e2e_tests_s3_to_sf',
-            'e2e_tests_mg_to_sf',
-            'tests/end_to_end/target_snowflake/tap_s3',
-        ),
+    }
+    actual_shards = {
+        shard['shard']: (shard['check_name'], tuple(shard['test_paths'].split()))
+        for shard in shards
+    }
+    assert actual_shards == expected_shards
+
+    configured_paths = [
+        test_path
+        for _, test_paths in actual_shards.values()
+        for test_path in test_paths
+    ]
+    expected_paths = {
+        str(path.relative_to(REPOSITORY_ROOT))
+        for path in (
+            REPOSITORY_ROOT / 'tests' / 'end_to_end' / 'target_snowflake'
+        ).rglob('test_*.py')
+    }
+    expected_paths.update(
+        {
+            'tests/end_to_end/data_diff/test_mysql_to_snowflake.py',
+            'tests/end_to_end/data_diff/test_postgres_to_snowflake.py',
+        }
     )
+    assert len(configured_paths) == len(set(configured_paths))
+    assert set(configured_paths) == expected_paths
 
-    for job_name, dependency, route_path in chain:
-        job = jobs[job_name]
-        if dependency is None:
-            assert 'needs' not in job
-        else:
-            assert job['needs'] == dependency
-            assert job['if'] == '${{ !cancelled() }}'
-        commands = '\n'.join(step.get('run', '') for step in job['steps'])
-        assert route_path in commands
+    commands = '\n'.join(step.get('run', '') for step in job['steps'])
+    assert job['env']['E2E_TEST_PATHS'] == '${{ matrix.test_paths }}'
+    assert 'pipelinewise pytest $E2E_TEST_PATHS' in commands
+    assert '-e PIPELINEWISE_E2E_NAMESPACE=$PIPELINEWISE_E2E_NAMESPACE' in commands
+    assert '${{ github.run_id }}' in job['env']['PIPELINEWISE_E2E_NAMESPACE']
+    assert '${{ github.run_attempt }}' in job['env']['PIPELINEWISE_E2E_NAMESPACE']
+    assert '${{ matrix.shard }}' in job['env']['PIPELINEWISE_E2E_NAMESPACE']
 
-
-def test_rdbms_snowflake_preflight_once():
-    """Each credentialed RDBMS route runs one complete preflight command."""
-    workflow = yaml.safe_load(E2E_WORKFLOW.read_text(encoding='utf-8'))
-    jobs = workflow['jobs']
-
-    for job_name in (
+    retired_jobs = {
         'e2e_tests_mariadb_to_sf',
         'e2e_tests_mysql_to_sf',
         'e2e_tests_pg_to_sf',
-    ):
-        preflight_steps = [
-            step
-            for step in jobs[job_name]['steps']
-            if step.get('name')
-            == 'Validate required Snowflake end-to-end configuration'
-        ]
-        assert len(preflight_steps) == 1
-        assert preflight_steps[0]['run'].count('./scripts/ci_require_env.sh') == 1
+        'e2e_tests_mg_to_sf',
+        'e2e_tests_s3_to_sf',
+    }
+    assert retired_jobs.isdisjoint(jobs)
+
+    target_pg_job = jobs['e2e_tests_target_pg']
+    target_pg_commands = '\n'.join(
+        step.get('run', '') for step in target_pg_job['steps']
+    )
+    assert '${{ github.run_id }}' in target_pg_job['env']['PIPELINEWISE_E2E_NAMESPACE']
+    assert '${{ github.run_attempt }}' in target_pg_job['env']['PIPELINEWISE_E2E_NAMESPACE']
+    assert (
+        '-e PIPELINEWISE_E2E_NAMESPACE=$PIPELINEWISE_E2E_NAMESPACE'
+        in target_pg_commands
+    )
+
+
+def test_snowflake_e2e_matrix_preflight_once():
+    """Every Snowflake shard runs one complete preflight command."""
+    workflow = yaml.safe_load(E2E_WORKFLOW.read_text(encoding='utf-8'))
+    job = workflow['jobs']['e2e_tests_snowflake']
+    preflight_steps = [
+        step
+        for step in job['steps']
+        if step.get('name')
+        == 'Validate required Snowflake end-to-end configuration'
+    ]
+
+    assert len(preflight_steps) == 1
+    assert preflight_steps[0]['if'] == "steps.check.outcome == 'failure'"
+    assert preflight_steps[0]['run'].count('./scripts/ci_require_env.sh') == 1
 
 
 def test_api_failure_triggers_checks(tmp_path):

--- a/tests/units/test_ci_check_no_file_changes.py
+++ b/tests/units/test_ci_check_no_file_changes.py
@@ -8,6 +8,7 @@ import yaml
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 DETECTOR = REPOSITORY_ROOT / 'scripts' / 'ci_check_no_file_changes.sh'
 E2E_WORKFLOW = REPOSITORY_ROOT / '.github' / 'workflows' / 'e2e_tests.yml'
+TW_RULES = REPOSITORY_ROOT / '.github' / 'tw-rules.yaml'
 
 FAKE_CURL = r'''#!/usr/bin/env bash
 set -u
@@ -336,6 +337,28 @@ def test_snowflake_e2e_matrix_contract():
         )
         assert 'PipelineWise container stopped with status' in readiness_step['run']
         assert 'exit 1' in readiness_step['run']
+
+
+def test_required_e2e_status_contract():
+    """Repository rules require every current Snowflake shard exactly once."""
+    workflow = yaml.safe_load(E2E_WORKFLOW.read_text(encoding='utf-8'))
+    rules = yaml.safe_load(TW_RULES.read_text(encoding='utf-8'))
+    shards = workflow['jobs']['e2e_tests_snowflake']['strategy']['matrix']['include']
+    expected_statuses = {shard['check_name'] for shard in shards}
+    configured_checks = rules['actions']['branch-protection-settings']['branches'][0]['checks']
+    configured_names = [check['name'] for check in configured_checks]
+    required_statuses = {
+        name for name in configured_names if name.startswith('e2e_tests_sf_')
+    }
+
+    assert len(configured_names) == len(set(configured_names))
+    assert required_statuses == expected_statuses
+    assert not {
+        'e2e_tests_mariadb_to_sf',
+        'e2e_tests_mg_to_sf',
+        'e2e_tests_pg_to_sf',
+        'e2e_tests_s3_to_sf',
+    }.intersection(configured_names)
 
 
 def test_snowflake_e2e_matrix_preflight_once():

--- a/tests/units/test_ci_check_no_file_changes.py
+++ b/tests/units/test_ci_check_no_file_changes.py
@@ -191,6 +191,9 @@ def test_snowflake_e2e_matrix_contract():
     strategy = job['strategy']
     shards = strategy['matrix']['include']
 
+    assert workflow['concurrency']['group'] == (
+        'e2e_tests-${{ github.event.pull_request.number || github.ref_name }}'
+    )
     assert 'needs' not in job
     assert job['name'] == '${{ matrix.check_name }}'
     assert strategy['fail-fast'] is False
@@ -296,6 +299,23 @@ def test_snowflake_e2e_matrix_contract():
         '-e PIPELINEWISE_E2E_NAMESPACE=$PIPELINEWISE_E2E_NAMESPACE'
         in target_pg_commands
     )
+    readiness_steps = [
+        step
+        for configured_job in jobs.values()
+        for step in configured_job['steps']
+        if step.get('name') == 'Wait for test containers to be ready'
+    ]
+    assert len(readiness_steps) == 2
+    for readiness_step in readiness_steps:
+        assert 'docker logs --tail 50 pipelinewise' in readiness_step['run']
+        assert 'sleep 5' in readiness_step['run']
+        assert 'sleep 30' not in readiness_step['run']
+        assert (
+            "container_status=$(docker inspect --format '{{.State.Status}}' pipelinewise)"
+            in readiness_step['run']
+        )
+        assert 'PipelineWise container stopped with status' in readiness_step['run']
+        assert 'exit 1' in readiness_step['run']
 
 
 def test_snowflake_e2e_matrix_preflight_once():

--- a/tests/units/test_end_to_end_s3_namespaces.py
+++ b/tests/units/test_end_to_end_s3_namespaces.py
@@ -1,0 +1,337 @@
+"""Tests for remote-object isolation between concurrent E2E jobs."""
+
+from pathlib import Path
+from unittest import TestCase, mock
+
+from tests.end_to_end.helpers import env as env_module
+from tests.end_to_end.helpers.env import E2EEnv
+from tests.end_to_end.target_snowflake.tap_postgres import TapPostgres
+from tests.end_to_end.target_snowflake.tap_postgres import (
+    test_replicate_pg_to_sf_with_archive_load_files as archive_module,
+)
+from tests.end_to_end.target_snowflake.tap_s3 import TapS3
+from tests.end_to_end.test_target_postgres import (
+    TestTargetPostgres as TargetPostgresCase,
+)
+
+
+class EndToEndS3NamespaceTestCase(TestCase):
+    """Validate local defaults and optional CI namespace isolation."""
+
+    @staticmethod
+    def _load_environment(environment):
+        e2e = object.__new__(E2EEnv)
+        e2e.sf_schema_postfix = '_generated'
+        with mock.patch.object(env_module, 'load_dotenv'), mock.patch.object(
+            E2EEnv, '_is_env_connector_configured', return_value=True
+        ), mock.patch.dict(env_module.os.environ, environment, clear=True):
+            e2e._load_env()  # pylint: disable=protected-access
+        return e2e
+
+    def test_keeps_default_s3_paths_without_an_e2e_namespace(self):
+        """Local E2E runs retain the established shared fixture paths."""
+        e2e = self._load_environment({
+            'TARGET_SNOWFLAKE_S3_KEY_PREFIX': 'staging/base/',
+        })
+
+        self.assertEqual(
+            e2e.get_conn_env_var('TARGET_SNOWFLAKE', 'S3_KEY_PREFIX'),
+            'staging/base/',
+        )
+        self.assertEqual(
+            e2e.get_conn_env_var(
+                'TARGET_SNOWFLAKE',
+                'ARCHIVE_LOAD_FILES_S3_PREFIX',
+            ),
+            'archive_folder',
+        )
+        self.assertEqual(
+            e2e.get_conn_env_var('TAP_S3_CSV', 'KEY_PREFIX'),
+            'ppw_e2e_tap_s3_csv',
+        )
+
+    def test_namespaces_each_remote_e2e_s3_path(self):
+        """Concurrent CI shards receive disjoint staging and fixture paths."""
+        e2e = self._load_environment({
+            'PIPELINEWISE_E2E_NAMESPACE': 'run_42_pg-shard',
+            'TARGET_SNOWFLAKE_S3_KEY_PREFIX': 'staging/base/',
+        })
+
+        self.assertEqual(
+            e2e.get_conn_env_var('TARGET_SNOWFLAKE', 'S3_KEY_PREFIX'),
+            'staging/base/run_42_pg-shard/',
+        )
+        self.assertEqual(
+            e2e.get_conn_env_var(
+                'TARGET_SNOWFLAKE',
+                'ARCHIVE_LOAD_FILES_S3_PREFIX',
+            ),
+            'archive_folder/run_42_pg-shard',
+        )
+        self.assertEqual(
+            e2e.get_conn_env_var('TAP_S3_CSV', 'KEY_PREFIX'),
+            'ppw_e2e_tap_s3_csv/run_42_pg-shard',
+        )
+
+    def test_rejects_an_unsafe_e2e_namespace(self):
+        """A namespace cannot escape the one S3 path segment allocated to it."""
+        with self.assertRaisesRegex(
+            ValueError,
+            'PIPELINEWISE_E2E_NAMESPACE must contain only',
+        ):
+            self._load_environment({
+                'PIPELINEWISE_E2E_NAMESPACE': '../another-run',
+            })
+
+    def test_s3_fixture_setup_uses_the_rendered_key_prefix(self):
+        """Fixture uploads use the namespaced prefix rendered into tap config."""
+        e2e = mock.Mock(spec=E2EEnv)
+        values = {
+            ('TAP_S3_CSV', 'BUCKET'): 'source-bucket',
+            ('TAP_S3_CSV', 'AWS_KEY'): 'access-key',
+            ('TAP_S3_CSV', 'AWS_SECRET_ACCESS_KEY'): 'secret-key',
+            ('TAP_S3_CSV', 'KEY_PREFIX'): 'ppw_e2e_tap_s3_csv/run_42_s3',
+        }
+        e2e.get_conn_env_var.side_effect = (
+            lambda connector, key: values[(connector, key)]
+        )
+        s3_client = mock.Mock()
+
+        with mock.patch.object(
+            env_module.boto3,
+            'client',
+            return_value=s3_client,
+        ):
+            E2EEnv.setup_tap_s3_csv(e2e)
+
+        self.assertEqual(
+            [call.args[2] for call in s3_client.upload_file.call_args_list],
+            [
+                'ppw_e2e_tap_s3_csv/run_42_s3/mock_data_1.csv',
+                'ppw_e2e_tap_s3_csv/run_42_s3/mock_data_2.csv',
+            ],
+        )
+
+    def test_s3_fixture_cleanup_deletes_only_the_namespaced_fixture_keys(self):
+        """CI cleanup removes the two exact keys uploaded by that run."""
+        e2e = mock.Mock(spec=E2EEnv)
+        e2e.e2e_namespace = 'run_42_s3'
+        values = {
+            ('TAP_S3_CSV', 'BUCKET'): 'source-bucket',
+            ('TAP_S3_CSV', 'AWS_KEY'): 'access-key',
+            ('TAP_S3_CSV', 'AWS_SECRET_ACCESS_KEY'): 'secret-key',
+            ('TAP_S3_CSV', 'KEY_PREFIX'): 'ppw_e2e_tap_s3_csv/run_42_s3',
+        }
+        e2e.get_conn_env_var.side_effect = (
+            lambda connector, key: values[(connector, key)]
+        )
+        s3_client = mock.Mock()
+
+        with mock.patch.object(
+            env_module.boto3,
+            'client',
+            return_value=s3_client,
+        ):
+            E2EEnv.cleanup_tap_s3_csv(e2e)
+
+        s3_client.delete_objects.assert_called_once_with(
+            Bucket='source-bucket',
+            Delete={
+                'Objects': [
+                    {
+                        'Key': (
+                            'ppw_e2e_tap_s3_csv/run_42_s3/mock_data_1.csv'
+                        )
+                    },
+                    {
+                        'Key': (
+                            'ppw_e2e_tap_s3_csv/run_42_s3/mock_data_2.csv'
+                        )
+                    },
+                ],
+                'Quiet': True,
+            },
+        )
+
+    def test_s3_fixture_cleanup_retains_legacy_local_fixture_keys(self):
+        """An unset namespace keeps the fixed objects used by older branches."""
+        e2e = mock.Mock(spec=E2EEnv)
+        e2e.e2e_namespace = ''
+
+        with mock.patch.object(env_module.boto3, 'client') as boto_client:
+            E2EEnv.cleanup_tap_s3_csv(e2e)
+
+        boto_client.assert_not_called()
+
+    def test_tap_s3_upload_precedes_discovery_and_cleans_up_after_failure(self):
+        """A fresh namespace exists for discovery and is cleaned on failure."""
+        events = []
+
+        def fail_import():
+            events.append('import')
+            raise RuntimeError('discovery failed')
+
+        e2e = mock.Mock(spec=E2EEnv)
+        e2e.env = {'TAP_S3_CSV': {'is_configured': True}}
+        e2e.sf_schema_postfix_is_override = False
+        e2e.setup_tap_s3_csv.side_effect = lambda: events.append('upload')
+        e2e.cleanup_tap_s3_csv.side_effect = lambda: events.append('cleanup')
+        target = TapS3(methodName='runTest')
+        target.get_e2e_env = mock.Mock(return_value=e2e)
+        target.remove_dir_from_config_dir = mock.Mock()
+        target.check_validate_taps = mock.Mock(
+            side_effect=lambda: events.append('validate')
+        )
+        target.check_import_config = mock.Mock(side_effect=fail_import)
+
+        with mock.patch.object(
+            target,
+            'check_snowflake_credentials_provided',
+        ), mock.patch.object(target, '_current_run_schemas', return_value=[]):
+            with self.assertRaisesRegex(RuntimeError, 'discovery failed'):
+                target.setUp(tap_id='s3_csv_to_sf', target_id='snowflake')
+
+            self.assertEqual(events, ['upload', 'validate', 'import'])
+            target.doCleanups()
+            self.assertEqual(events, ['upload', 'validate', 'import', 'cleanup'])
+
+    def test_remote_s3_templates_use_the_rendered_prefixes(self):
+        """Tap discovery and archive config consume the derived namespace."""
+        test_project = Path(__file__).resolve().parents[1] / 'end_to_end' / 'test-project'
+        for target in ('pg', 'sf'):
+            with self.subTest(target=target):
+                template = Path(
+                    test_project,
+                    f'tap_s3_csv_to_{target}.yml.template',
+                ).read_text(encoding='utf-8')
+                self.assertIn(
+                    '^${TAP_S3_CSV_KEY_PREFIX}/mock_data_1.csv$',
+                    template,
+                )
+                self.assertIn(
+                    '^${TAP_S3_CSV_KEY_PREFIX}/mock_data_2.csv$',
+                    template,
+                )
+
+        archive_template = Path(
+            test_project,
+            'tap_postgres_to_sf_archive_load_files.yml.template',
+        ).read_text(encoding='utf-8')
+        self.assertIn(
+            'archive_load_files_s3_prefix: '
+            '"${TARGET_SNOWFLAKE_ARCHIVE_LOAD_FILES_S3_PREFIX}"',
+            archive_template,
+        )
+
+    def test_archive_helpers_use_the_rendered_s3_prefix(self):
+        """Archive cleanup and lookup stay inside the current CI namespace."""
+        target = archive_module.TestReplicatePGToSFWithArchiveLoadFiles(
+            methodName='runTest'
+        )
+        target.s3_bucket = 'staging-bucket'
+        target.archive_s3_prefix = 'archive_folder/run_42_pg'
+        target.s3_client = mock.Mock()
+        target.s3_client.list_objects.side_effect = [
+            {'Contents': [{'Key': 'archive_folder/run_42_pg/dangling.csv.gz'}]},
+            {'Contents': [{'Key': 'archive_folder/run_42_pg/current.csv.gz'}]},
+        ]
+
+        target.delete_dangling_files_from_archive()
+        result = target.get_files_from_s3_for_table('city')
+
+        self.assertEqual(
+            target.s3_client.list_objects.call_args_list,
+            [
+                mock.call(
+                    Bucket='staging-bucket',
+                    Prefix=(
+                        'archive_folder/run_42_pg/'
+                        'postgres_to_sf_archive_load_files/'
+                    ),
+                ),
+                mock.call(
+                    Bucket='staging-bucket',
+                    Prefix=(
+                        'archive_folder/run_42_pg/'
+                        'postgres_to_sf_archive_load_files/city'
+                    ),
+                ),
+            ],
+        )
+        target.s3_client.delete_object.assert_called_once_with(
+            Bucket='staging-bucket',
+            Key='archive_folder/run_42_pg/dangling.csv.gz',
+        )
+        self.assertEqual(
+            result,
+            [{'Key': 'archive_folder/run_42_pg/current.csv.gz'}],
+        )
+
+    def test_archive_test_registers_namespaced_cleanup(self):
+        """Unittest cleanup removes archive files even after a test failure."""
+        target = archive_module.TestReplicatePGToSFWithArchiveLoadFiles(
+            methodName='runTest'
+        )
+        e2e = mock.Mock(spec=E2EEnv)
+        e2e.e2e_namespace = 'run_42_pg'
+        values = {
+            ('TARGET_SNOWFLAKE', 'S3_BUCKET'): 'staging-bucket',
+            (
+                'TARGET_SNOWFLAKE',
+                'ARCHIVE_LOAD_FILES_S3_PREFIX',
+            ): 'archive_folder/run_42_pg',
+        }
+        e2e.get_conn_env_var.side_effect = (
+            lambda connector, key: values[(connector, key)]
+        )
+        cleanup = mock.Mock()
+        target.e2e_env = e2e
+
+        with mock.patch.object(TapPostgres, 'setUp'), mock.patch.object(
+            target,
+            'delete_dangling_files_from_archive',
+            cleanup,
+        ):
+            target.setUp()
+            target.doCleanups()
+            cleanup.assert_called_once_with()
+
+    def test_archive_test_retains_legacy_local_archive_files(self):
+        """An unset namespace retains the archive behavior used by local runs."""
+        target = archive_module.TestReplicatePGToSFWithArchiveLoadFiles(
+            methodName='runTest'
+        )
+        e2e = mock.Mock(spec=E2EEnv)
+        e2e.e2e_namespace = ''
+        values = {
+            ('TARGET_SNOWFLAKE', 'S3_BUCKET'): 'staging-bucket',
+            (
+                'TARGET_SNOWFLAKE',
+                'ARCHIVE_LOAD_FILES_S3_PREFIX',
+            ): 'archive_folder',
+        }
+        e2e.get_conn_env_var.side_effect = (
+            lambda connector, key: values[(connector, key)]
+        )
+        cleanup = mock.Mock()
+        target.e2e_env = e2e
+
+        with mock.patch.object(TapPostgres, 'setUp'), mock.patch.object(
+            target,
+            'delete_dangling_files_from_archive',
+            cleanup,
+        ):
+            target.setUp()
+            target.doCleanups()
+            cleanup.assert_not_called()
+
+    def test_target_postgres_cleans_s3_fixtures_at_class_teardown(self):
+        """Dependent pytest methods retain fixtures until the class completes."""
+        e2e = mock.Mock(spec=E2EEnv)
+        e2e.env = {'TAP_S3_CSV': {'is_configured': True}}
+        TargetPostgresCase.tap_s3_cleanup_env = e2e
+
+        TargetPostgresCase.teardown_class()
+
+        e2e.cleanup_tap_s3_csv.assert_called_once_with()
+        self.assertIsNone(TargetPostgresCase.tap_s3_cleanup_env)


### PR DESCRIPTION
## Context

The Snowflake E2E suite previously ran as five serial source-specific jobs. As
coverage grew, a successful workflow took 1h39m24s, delaying PR feedback even
though isolated runners can safely execute these tests concurrently.

## Summary

- replace five serial Snowflake jobs with eight runtime-balanced matrix shards
  that all start when runners are available
- isolate Snowflake staging, archive output, and tap-S3 fixtures by run,
  attempt, and shard
- scope E2E config imports to the tap under test so parallel shards do not
  discover unrelated sources
- retain target-Postgres coverage and enforce exact E2E path coverage with
  contract tests
- install independent connector environments four at a time and tighten
  readiness polling
- change only CI, test infrastructure, tests, and contributor guidance; no
  application or connector code

## Performance

Measured GitHub Actions workflow wall time, from run creation to completion:

- [serial baseline](https://github.com/transferwise/pipelinewise/actions/runs/33064584619): 1h39m24s
- [four-shard intermediate run](https://github.com/transferwise/pipelinewise/actions/runs/33159074815): 23m14s
- [eight-shard final run](https://github.com/transferwise/pipelinewise/actions/runs/33166696503): 12m22s

The final layout is 87m02s faster than the serial baseline, an 87.6% reduction
in wall time and about an 8x speed-up. It is also 10m52s, or 46.8%, faster than
the four-shard layout.

## Validation

- final GitHub E2E workflow: 64 passed, 0 failed, 0 skipped across all nine jobs
- full local dev-project E2E suite: 64 passed, 0 failed, 0 skipped in 77m34s
- exact matrix contract proves every Snowflake E2E file is assigned once, with
  no missing or duplicate paths
- Ruff passed
- Pylint passed at 10.00/10
- both Flake8 gates passed
- 1,306 unit tests and 147 subtests passed with 86% coverage
- PipelineWise config validation passed
- all branch commits have valid GPG signatures
