### PR TITLE
Update required E2E checks before parallel test rollout

### DIFF
--- a/.github/tw-rules.yaml
+++ b/.github/tw-rules.yaml
@@ -24,15 +24,21 @@ actions:
             type: tests
           - name: e2e_tests_target_pg
             type: tests
-          - name: e2e_tests_mariadb_to_sf
+          - name: e2e_tests_sf_conversion
             type: tests
-          - name: e2e_tests_pg_to_sf
+          - name: e2e_tests_sf_publication
             type: tests
-          - name: e2e_tests_mg_to_sf
+          - name: e2e_tests_sf_pg_partial
             type: tests
-          - name: e2e_tests_s3_to_sf
+          - name: e2e_tests_sf_mariadb_partial
             type: tests
-          - name: e2e_tests_target_pg
+          - name: e2e_tests_sf_pg_iceberg
+            type: tests
+          - name: e2e_tests_sf_mariadb_iceberg
+            type: tests
+          - name: e2e_tests_sf_mysql_iceberg
+            type: tests
+          - name: e2e_tests_sf_mariadb_native
             type: tests
 
   sync-codeowners:


### PR DESCRIPTION
## Context

This is the prerequisite for #1330. Merging the branch-protection configuration first lets the Wise bot require the new status names before the workflow reshuffle is merged.

## What changed

- Replaces the retired Snowflake E2E required-status names with the eight new shard names.
- Removes the duplicate e2e_tests_target_pg entry.
- Changes only .github/tw-rules.yaml.

## Validation

- Parsed the YAML successfully in the dev-project Docker container.
- Confirmed all 12 configured check names are unique and typed as tests.
- Confirmed the PR diff contains only .github/tw-rules.yaml.

After merge, the Wise bot should synchronize branch protection automatically. We can then update #1330 from master and let its new E2E jobs satisfy the required checks.