### PR TITLE
AP-2830 Release PipelineWise 0.81.1 with direct data-diff coverage queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,9 @@ Also follow scoped checks:
 - CHANGELOG bullets are atomic and outcome-focused: start with an action verb,
   name the component and operational result, and include implementation detail
   only to explain risk. Group related bullets under headings.
+- Before creating a PR, compare the complete branch diff with the current
+  release CHANGELOG entry. Do not create the PR while the CHANGELOG omits,
+  misstates, or claims changes that are not present in the diff.
 - PipelineWise stays in `0.x` and must never publish `1.0.0` or above. Use a
   patch for compatible fixes and the next `0.x` minor for features or intentional
   compatibility changes. Document material operator impact and keep `setup.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
-Documentation only
-------------------
+0.81.1 (2026-09-02)
+-------------------
 
 **Data-diff**
+
+- Read current coverage directly from `dd_coverage_state` so data-diff commands
+  no longer require the `dd_current_coverage` view
+- Stop creating the unused `dd_current_coverage` and
+  `dd_remediation_history` views in new backend databases
+
+**Documentation**
 
 - Add a dedicated backend database page with configuration, an embedded Mermaid
   ERD, and direct coverage and remediation reporting queries

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.12.*',
-      version='0.81.0',
+      version='0.81.1',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
## Context

PipelineWise 0.81.0 reads current data-diff coverage through `dd_current_coverage`. A backend initialized without that
view fails data-diff commands with `UndefinedTable`, even though the underlying `dd_coverage_state` table is present.

This PR releases the current master implementation as 0.81.1. It reads coverage directly from the table and documents
the backend schema and equivalent reporting queries.

Refer to [0.81.1 CHANGELOG](https://github.com/transferwise/pipelinewise/blob/d73445ee02bfbc6523108068a08d327c5c751573/CHANGELOG.md#0811-2026-09-02) for full details.

## Changes

- Release the direct `dd_coverage_state` implementation as PipelineWise 0.81.1.
- Document the data-diff backend schema and direct coverage and remediation queries.
- Require future PRs to verify their complete change set against the CHANGELOG before creation.

## Type of change

- [x] Bug fix
- [x] Maintenance, dependency, or CI
- [x] Documentation

## Compatibility and operations

Existing monitoring views are not dropped and may remain unused. Fresh 0.81.1 backends do not create them. Rolling a
fresh backend back to 0.81.0 would require recreating `dd_current_coverage` because that older runtime depends on it.

Deploy the 0.81.1 runtime used by the actual Cicada schedule; updating a native installation does not update an older
Docker image, and vice versa.

## Validation

| Command or check | Result |
|---|---|
| `python setup.py --version` | Passed: `0.81.1` |
| `pytest -q tests/units/data_diff/test_repository.py tests/units/backend_db/test_database.py` | Passed: 26, failed: 0, skipped: 0 |
| `git diff --check` | Passed |
| Full unit and E2E suites | Not rerun locally; this PR changes release metadata, CHANGELOG, and repository guidance. GitHub CI remains authoritative. |

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] This pull request is focused and can be reviewed and reverted
      independently.
- [x] Behavioural changes have regression tests, or I explained why tests are not
      applicable.
- [x] Relevant documentation and changelog entries are updated, or I explained
      why they are not applicable.
- [x] Applicable local checks pass; failures, skips, and unavailable checks are
      documented above.
- [x] The change contains no credentials, private keys, production identifiers,
      or source records.
- [x] Breaking and compatibility impacts are identified above.
