### PR TITLE
AP-2830 Reconcile data-diff definitions in spite of unrelated failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,10 @@ Also follow scoped checks:
 - CHANGELOG bullets are atomic and outcome-focused: start with an action verb,
   name the component and operational result, and include implementation detail
   only to explain risk. Group related bullets under headings.
-- Before creating a PR, compare the complete branch diff with the current
-  release CHANGELOG entry. Do not create the PR while the CHANGELOG omits,
-  misstates, or claims changes that are not present in the diff.
+- Before creating a PR or pushing changes to an existing PR, compare the
+  complete branch diff with the current release CHANGELOG entry. Do not create
+  or update the PR while the CHANGELOG omits, misstates, or claims changes that
+  are not present in the diff.
 - PipelineWise stays in `0.x` and must never publish `1.0.0` or above. Use a
   patch for compatible fixes and the next `0.x` minor for features or intentional
   compatibility changes. Document material operator impact and keep `setup.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,39 @@
 0.81.2 (2026-09-02)
 -------------------
 
-**Data-diff**
+**Import and data-diff**
 
-- Reconcile data-diff definitions for taps that import successfully even when
+- Reconcile data-diff definitions for taps whose discovery succeeds even when
   other selected taps fail discovery
 - Preserve existing data-diff definitions for taps that fail discovery
-- Deactivate definitions for selected taps no longer present in project YAML
+- Deactivate definitions for explicitly selected taps no longer present in
+  project YAML
 - Keep the import summary and non-zero exit when backend definition
   reconciliation fails
-- Treat `*` combined with named tap filters as a full import so discovery
-  and data-diff reconciliation use the same scope
+- Fail the import before data-diff reconciliation when parallel discovery
+  returns incomplete results
+- Treat `*` combined with named tap filters as a full import across generated
+  configuration, discovery, and data-diff reconciliation
 
 **Tests**
 
-- Cover mixed successful, failed, missing, and deleted taps during data-diff
-  definition imports
+- Cover successful and failed tap discovery in the same import
+- Cover explicitly selected taps missing from project YAML
 - Cover removal of a successful tap's data-diff definition when another tap
   fails discovery
 - Cover wildcard and named tap filters used together
-- Cover backend reconciliation failures and incomplete discovery results
+- Cover backend reconciliation failures
+- Cover incomplete parallel discovery results
 - Verify failed-tap exclusion and deleted-tap deactivation against PostgreSQL
 
 **Documentation**
 
 - Document partial reconciliation, missing-tap cleanup, and backend failures
+
+**Contributor guidance**
+
+- Require verifying the complete branch diff against the CHANGELOG before
+  creating or updating a pull request
 
 0.81.1 (2026-09-02)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 
 - Reconcile data-diff definitions for taps that import successfully even when
   other selected taps fail discovery
-- Preserve existing data-diff definitions for taps that fail discovery or are
-  not found
+- Preserve existing data-diff definitions for taps that fail discovery
+- Deactivate definitions for selected taps no longer present in project YAML
+- Keep the import summary and non-zero exit when backend definition
+  reconciliation fails
 - Treat `*` combined with named tap filters as a full import so discovery
   and data-diff reconciliation use the same scope
 
@@ -17,10 +19,12 @@
 - Cover removal of a successful tap's data-diff definition when another tap
   fails discovery
 - Cover wildcard and named tap filters used together
+- Cover backend reconciliation failures and incomplete discovery results
+- Verify failed-tap exclusion and deleted-tap deactivation against PostgreSQL
 
 **Documentation**
 
-- Document per-tap data-diff reconciliation during partially failed imports
+- Document partial reconciliation, missing-tap cleanup, and backend failures
 
 0.81.1 (2026-09-02)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+0.81.2 (2026-09-02)
+-------------------
+
+**Data-diff**
+
+- Reconcile data-diff definitions for taps that import successfully even when
+  other selected taps fail discovery
+- Preserve existing data-diff definitions for taps that fail discovery or are
+  not found
+- Treat `*` combined with named tap filters as a full import so discovery
+  and data-diff reconciliation use the same scope
+
+**Tests**
+
+- Cover mixed successful, failed, missing, and deleted taps during data-diff
+  definition imports
+- Cover removal of a successful tap's data-diff definition when another tap
+  fails discovery
+- Cover wildcard and named tap filters used together
+
+**Documentation**
+
+- Document per-tap data-diff reconciliation during partially failed imports
+
 0.81.1 (2026-09-02)
 -------------------
 
@@ -12,9 +36,6 @@
 
 - Add a dedicated backend database page with configuration, an embedded Mermaid
   ERD, and direct coverage and remediation reporting queries
-
-Tests only
-----------
 
 **Test infrastructure**
 

--- a/docs/user_guide/cli.rst
+++ b/docs/user_guide/cli.rst
@@ -125,8 +125,10 @@ Useful options:
 The command validates, connects to sources, performs discovery, and writes
 generated files below ``~/.pipelinewise``. Data-diff definitions are reconciled
 for each tap only after its connector generation and discovery succeed. A failed
-tap retains its existing definitions while successful taps are reconciled, but
-the command still exits non-zero when any selected tap fails. ``import`` remains
+tap retains its existing definitions while successful taps are reconciled. An
+explicitly selected tap missing from the project YAML is treated as removed, so
+its definitions are deactivated. The command prints its summary and exits
+non-zero when a selected tap or backend reconciliation fails. ``import`` remains
 a deprecated alias.
 
 .. warning::

--- a/docs/user_guide/cli.rst
+++ b/docs/user_guide/cli.rst
@@ -123,9 +123,11 @@ Useful options:
      - Reads the Ansible Vault password needed by encrypted YAML values.
 
 The command validates, connects to sources, performs discovery, and writes
-generated files below ``~/.pipelinewise``. Data-diff definitions are versioned
-only after connector generation and discovery succeed. ``import`` remains a
-deprecated alias.
+generated files below ``~/.pipelinewise``. Data-diff definitions are reconciled
+for each tap only after its connector generation and discovery succeed. A failed
+tap retains its existing definitions while successful taps are reconciled, but
+the command still exits non-zero when any selected tap fails. ``import`` remains
+a deprecated alias.
 
 .. warning::
 

--- a/docs/user_guide/data_diff.rst
+++ b/docs/user_guide/data_diff.rst
@@ -211,8 +211,10 @@ historical one — see `Coverage and remediation`_.
 
 Definitions are reconciled independently for taps whose discovery succeeds. If
 another selected tap fails discovery, successful taps are still reconciled and
-the failed tap's existing definitions remain unchanged. The import still exits
-non-zero so automation can report the discovery failure.
+the failed tap's existing definitions remain unchanged. Definitions for an
+explicitly selected tap absent from the project YAML are deactivated. Discovery
+and backend reconciliation failures retain the import summary and a non-zero
+exit so automation can report them.
 
 A mismatch exits non-zero and sends an alert. See :ref:`data_diff_alerts`.
 

--- a/docs/user_guide/data_diff.rst
+++ b/docs/user_guide/data_diff.rst
@@ -209,6 +209,11 @@ deactivates removed ones; unchanged definitions are skipped. ``--force`` creates
 another attempt for the current slot, while ``rerun_data_diff_check`` repairs a
 historical one — see `Coverage and remediation`_.
 
+Definitions are reconciled independently for taps whose discovery succeeds. If
+another selected tap fails discovery, successful taps are still reconciled and
+the failed tap's existing definitions remain unchanged. The import still exits
+non-zero so automation can report the discovery failure.
+
 A mismatch exits non-zero and sends an alert. See :ref:`data_diff_alerts`.
 
 

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1680,6 +1680,8 @@ class PipelineWise:
         # JSON files in a common directory structure
         config = Config.from_yamls(self.config_dir, self.args.dir, self.args.secret)
         selected_taps_id = self.args.taps.split(',')
+        if '*' in selected_taps_id:
+            selected_taps_id = ['*']
         data_diff_definitions = config.get_data_diff_definitions(selected_taps_id)
         config.save(selected_taps_id)
 
@@ -1698,6 +1700,7 @@ class PipelineWise:
         total_taps = 0
         discover_excs = []
         found_selected_taps = set()
+        failed_tap_ids = set()
 
         # Import every tap from every target
         start_time = datetime.now()
@@ -1715,24 +1718,25 @@ class PipelineWise:
                         found_selected_taps.add(tap['id'])
 
             with parallel_backend('threading', n_jobs=-1):
-                # Discover taps in parallel and return the list of exception of the failed ones
-                discover_excs.extend(
-                    list(
-                        filter(
-                            None,
-                            Parallel(verbose=100)(
-                                delayed(self._discover_tap)(tap=tap, target=target)
-                                for tap in selected_taps
-                            ),
-                        )
-                    )
+                discovery_results = Parallel(verbose=100)(
+                    delayed(self._discover_tap)(tap=tap, target=target)
+                    for tap in selected_taps
                 )
+
+            for tap, error in zip(selected_taps, discovery_results):
+                if error:
+                    self.logger.error('Tap discovery failed: %s', error)
+                    discover_excs.append(error)
+                    failed_tap_ids.add(tap['id'])
 
         if selected_taps_id != ['*']:
             total_taps = len(selected_taps_id)
             not_found_taps = set(selected_taps_id) - found_selected_taps
             for tap in not_found_taps:
-                discover_excs.append(f'tap "{tap}" not found!')
+                error = f'tap "{tap}" not found!'
+                self.logger.error('Tap discovery failed: %s', error)
+                discover_excs.append(error)
+                failed_tap_ids.add(tap)
 
         # reloading the new config
         self.load_config()
@@ -1740,13 +1744,14 @@ class PipelineWise:
 
         end_time = datetime.now()
 
-        if not discover_excs and config.global_config.get('backend_db'):
+        if config.global_config.get('backend_db'):
             with DataDiffRepository.from_backend_config(
                 config.global_config['backend_db']
             ) as repository:
                 sync_stats = repository.sync_definitions(
                     data_diff_definitions,
                     selected_taps=selected_taps_id,
+                    excluded_taps=failed_tap_ids,
                 )
             self.logger.info(
                 'Persisted data-diff definitions: %s',

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1723,7 +1723,7 @@ class PipelineWise:
                     for tap in selected_taps
                 )
 
-            for tap, error in zip(selected_taps, discovery_results):
+            for tap, error in zip(selected_taps, discovery_results, strict=True):
                 if error:
                     self.logger.error('Tap discovery failed: %s', error)
                     discover_excs.append(error)
@@ -1734,29 +1734,36 @@ class PipelineWise:
             not_found_taps = set(selected_taps_id) - found_selected_taps
             for tap in not_found_taps:
                 error = f'tap "{tap}" not found!'
-                self.logger.error('Tap discovery failed: %s', error)
+                self.logger.error('Tap not found in project YAML: %s', tap)
                 discover_excs.append(error)
-                failed_tap_ids.add(tap)
 
         # reloading the new config
         self.load_config()
         deleted_taps_count = self.cleanup_after_deleted_config(old_config)
 
-        end_time = datetime.now()
-
+        data_diff_sync_failed = False
         if config.global_config.get('backend_db'):
-            with DataDiffRepository.from_backend_config(
-                config.global_config['backend_db']
-            ) as repository:
-                sync_stats = repository.sync_definitions(
-                    data_diff_definitions,
-                    selected_taps=selected_taps_id,
-                    excluded_taps=failed_tap_ids,
+            try:
+                with DataDiffRepository.from_backend_config(
+                    config.global_config['backend_db']
+                ) as repository:
+                    sync_stats = repository.sync_definitions(
+                        data_diff_definitions,
+                        selected_taps=selected_taps_id,
+                        excluded_taps=failed_tap_ids,
+                    )
+            except Exception as exc:  # pylint: disable=broad-except
+                data_diff_sync_failed = True
+                self.logger.exception(
+                    'Failed to reconcile data-diff definitions: %s', exc
                 )
-            self.logger.info(
-                'Persisted data-diff definitions: %s',
-                sync_stats,
-            )
+            else:
+                self.logger.info(
+                    'Persisted data-diff definitions: %s',
+                    sync_stats,
+                )
+
+        end_time = datetime.now()
 
         # Log summary
         # pylint: disable=logging-too-many-args
@@ -1780,7 +1787,7 @@ class PipelineWise:
             str(discover_excs),
             end_time - start_time,
         )
-        if len(discover_excs) > 0:
+        if discover_excs or data_diff_sync_failed:
             sys.exit(1)
 
     def _data_diff_repository(self):

--- a/pipelinewise/data_diff/repository.py
+++ b/pipelinewise/data_diff/repository.py
@@ -49,9 +49,15 @@ class DataDiffRepository:
         definitions: Iterable[CheckDefinition],
         *,
         selected_taps: Optional[Iterable[str]] = None,
+        excluded_taps: Optional[Iterable[str]] = None,
     ) -> dict:
-        """Version definitions and deactivate YAML entries removed from this scope."""
-        definitions = list(definitions)
+        """Reconcile definitions in scope while preserving excluded taps."""
+        excluded = set(excluded_taps or [])
+        definitions = [
+            definition
+            for definition in definitions
+            if definition.tap_id not in excluded
+        ]
         selected = set(selected_taps or ["*"])
         include_all = "*" in selected
         now = datetime.now(timezone.utc)
@@ -104,7 +110,10 @@ class DataDiffRepository:
                 stats["created"] += 1
 
             for full_check_name, active in current.items():
-                in_scope = include_all or active["tap_id"] in selected
+                in_scope = (
+                    active["tap_id"] not in excluded
+                    and (include_all or active["tap_id"] in selected)
+                )
                 if in_scope and full_check_name not in incoming_keys:
                     cursor.execute(
                         f"""

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.12.*',
-      version='0.81.1',
+      version='0.81.2',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',

--- a/tests/end_to_end/data_diff/test_postgres_to_postgres.py
+++ b/tests/end_to_end/data_diff/test_postgres_to_postgres.py
@@ -10,9 +10,11 @@ import json
 import os
 import shutil
 
+from dataclasses import replace
 from datetime import timedelta
 from pathlib import Path
 
+from pipelinewise.data_diff.config import CheckDefinition
 from pipelinewise.data_diff.repository import DataDiffRepository
 from pipelinewise.data_diff.runner import run_due_checks
 from pipelinewise.data_diff.runtime import RuntimeConnectorConfigLoader
@@ -39,6 +41,33 @@ EXPECTED_CHECKS = {
 }
 
 
+def _repository_definition(tap_id, source_table, *, frequency='0 * * * *'):
+    return CheckDefinition(
+        full_check_name=f'{TARGET_ID}/{tap_id}/logical1/{source_table}',
+        target_id=TARGET_ID,
+        tap_id=tap_id,
+        source_type='tap-postgres',
+        target_type='target-postgres',
+        source_database='postgres_source_db',
+        target_database='postgres_dwh',
+        source_schema='logical1',
+        source_table=source_table,
+        target_schema=TARGET_SCHEMA,
+        target_table=source_table,
+        source_key_column='cid',
+        target_key_column='cid',
+        source_timestamp_column='updated_at',
+        target_timestamp_column='updated_at',
+        source_compare_columns=(),
+        target_compare_columns=(),
+        checks=('row_count',),
+        frequency=frequency,
+        window_start_seconds=3600,
+        window_end_seconds=0,
+        statement_timeout_seconds=60,
+    )
+
+
 # pylint: disable=attribute-defined-outside-init
 class TestPostgresToPostgresDataDiff:
     """Exercise persisted checks, failures, remediation, and coverage."""
@@ -49,6 +78,25 @@ class TestPostgresToPostgresDataDiff:
         self.run_source_query = self.e2e.run_query_tap_postgres
         self.run_target_query = self.e2e.run_query_target_postgres
         self.run_backend_query = self.e2e.run_query_pipelinewise_backend
+
+    def _backend_config(self):
+        return {
+            'host': self.e2e.get_conn_env_var('PIPELINEWISE_BACKEND', 'HOST'),
+            'port': int(
+                self.e2e.get_conn_env_var('PIPELINEWISE_BACKEND', 'PORT')
+            ),
+            'user': self.e2e.get_conn_env_var('PIPELINEWISE_BACKEND', 'USER'),
+            'password': self.e2e.get_conn_env_var(
+                'PIPELINEWISE_BACKEND', 'PASSWORD'
+            ),
+            'dbname': self.e2e.get_conn_env_var('PIPELINEWISE_BACKEND', 'DB'),
+            'ddl_user': self.e2e.get_conn_env_var(
+                'PIPELINEWISE_BACKEND', 'DDL_USER'
+            ),
+            'ddl_password': self.e2e.get_conn_env_var(
+                'PIPELINEWISE_BACKEND', 'DDL_PASSWORD'
+            ),
+        }
 
     @staticmethod
     def _run_success(command):
@@ -406,18 +454,9 @@ class TestPostgresToPostgresDataDiff:
             'SELECT COUNT(*) FROM public.dd_runs'
         )[0][0] == 3
 
-        backend_config = {
-            'host': self.e2e.get_conn_env_var('PIPELINEWISE_BACKEND', 'HOST'),
-            'port': int(self.e2e.get_conn_env_var('PIPELINEWISE_BACKEND', 'PORT')),
-            'user': self.e2e.get_conn_env_var('PIPELINEWISE_BACKEND', 'USER'),
-            'password': self.e2e.get_conn_env_var('PIPELINEWISE_BACKEND', 'PASSWORD'),
-            'dbname': self.e2e.get_conn_env_var('PIPELINEWISE_BACKEND', 'DB'),
-            'ddl_user': self.e2e.get_conn_env_var('PIPELINEWISE_BACKEND', 'DDL_USER'),
-            'ddl_password': self.e2e.get_conn_env_var(
-                'PIPELINEWISE_BACKEND', 'DDL_PASSWORD'
-            ),
-        }
-        with DataDiffRepository.from_backend_config(backend_config) as repository:
+        with DataDiffRepository.from_backend_config(
+            self._backend_config()
+        ) as repository:
             appended = run_due_checks(
                 repository,
                 RuntimeConnectorConfigLoader(Path.home() / '.pipelinewise'),
@@ -460,6 +499,48 @@ class TestPostgresToPostgresDataDiff:
         assert self.run_backend_query(
             'SELECT COUNT(*) FROM public.dd_runs'
         )[0][0] == 4
+
+    def test_definition_sync_preserves_excluded_tap_in_postgres(self):
+        """Prove exclusion and deactivation against the real backend schema."""
+        self.e2e.setup_pipelinewise_backend()
+        failed = _repository_definition('failed', 'failed_table')
+        deleted = _repository_definition('deleted', 'deleted_table')
+        successful = _repository_definition('successful', 'successful_table')
+        changed_failed = replace(failed, frequency='30 * * * *')
+
+        with DataDiffRepository.from_backend_config(
+            self._backend_config()
+        ) as repository:
+            assert repository.sync_definitions([failed, deleted]) == {
+                'created': 2,
+                'unchanged': 0,
+                'superseded': 0,
+                'deactivated': 0,
+            }
+            stats = repository.sync_definitions(
+                [changed_failed, successful],
+                selected_taps=['*'],
+                excluded_taps=['failed'],
+            )
+
+        assert stats == {
+            'created': 1,
+            'unchanged': 0,
+            'superseded': 0,
+            'deactivated': 1,
+        }
+        assert self.run_backend_query(
+            """
+            SELECT tap_id, revision, config_hash, current,
+                   superseded_at IS NOT NULL
+              FROM public.dd_checks
+             ORDER BY tap_id, revision
+            """
+        ) == [
+            ('deleted', 1, deleted.config_hash, False, True),
+            ('failed', 1, failed.config_hash, True, False),
+            ('successful', 1, successful.config_hash, True, False),
+        ]
 
     def test_migrations_build_the_schema_on_an_empty_backend(self):
         """Prove Alembic pins its objects and version table to public."""

--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -114,7 +114,7 @@ class TestCli:
         mocked_fastsync.assert_called_once()
 
     def _assert_import_command(self, args):
-        if args.taps == '*':
+        if '*' in args.taps.split(','):
             expected_taps = ['tap_one', 'tap_two', 'tap_three']
             expected_save_arg = ['*']
         else:
@@ -633,6 +633,14 @@ class TestCli:
     def test_command_import_selected_taps(self):
         """Test import_config command for selected taps"""
         args = CliArgs(dir=f'{os.path.dirname(__file__)}/resources/test_import_command', taps='tap_one,tap_three')
+        self._assert_import_command(args)
+
+    def test_command_import_wildcard_with_selected_tap(self):
+        """A wildcard combined with a tap still imports every tap."""
+        args = CliArgs(
+            dir=f'{os.path.dirname(__file__)}/resources/test_import_command',
+            taps='*,tap_one',
+        )
         self._assert_import_command(args)
 
     def test_import_accepts_salesforce_iceberg_and_generates_target_runtime(self, tmp_path):

--- a/tests/units/data_diff/test_cli.py
+++ b/tests/units/data_diff/test_cli.py
@@ -30,8 +30,8 @@ class RepositoryContext:
         self.filters = filters
         return self.checks
 
-    def sync_definitions(self, definitions, *, selected_taps):
-        self.synced = (definitions, selected_taps)
+    def sync_definitions(self, definitions, *, selected_taps, excluded_taps=None):
+        self.synced = (definitions, selected_taps, excluded_taps)
         return {"created": len(definitions)}
 
 
@@ -182,14 +182,15 @@ def test_import_persists_definitions_only_after_successful_discovery():
     ):
         pipelinewise.import_project()
 
-    assert repository.synced == ([definition], ["*"])
+    assert repository.synced == ([definition], ["*"], set())
 
 
-def test_import_does_not_activate_definitions_after_discovery_failure():
+def test_import_excludes_definitions_after_discovery_failure():
+    definition = Mock(tap_id="tap")
     imported = Mock()
     imported.global_config = {"backend_db": {"host": "backend"}}
     imported.targets = {"target": {"taps": [{"id": "tap"}]}}
-    imported.get_data_diff_definitions.return_value = [Mock()]
+    imported.get_data_diff_definitions.return_value = [definition]
     repository = RepositoryContext()
     pipelinewise = _pipelinewise(taps="*")
     pipelinewise.logger = Mock()
@@ -207,7 +208,116 @@ def test_import_does_not_activate_definitions_after_discovery_failure():
     ), pytest.raises(SystemExit):
         pipelinewise.import_project()
 
-    assert repository.synced is None
+    assert repository.synced == ([definition], ["*"], {"tap"})
+
+
+def test_import_persists_successful_tap_definitions_after_partial_failure():
+    successful_definition = Mock(tap_id="successful")
+    failed_definition = Mock(tap_id="failed")
+    imported = Mock()
+    imported.global_config = {"backend_db": {"host": "backend"}}
+    imported.targets = {
+        "target": {"taps": [{"id": "successful"}, {"id": "failed"}]}
+    }
+    imported.get_data_diff_definitions.return_value = [
+        successful_definition,
+        failed_definition,
+    ]
+    repository = RepositoryContext()
+    pipelinewise = _pipelinewise(taps="*")
+    pipelinewise.logger = Mock()
+    pipelinewise.config = {}
+    pipelinewise._discover_tap = Mock(
+        side_effect=lambda tap, **_kwargs: (
+            "discovery failed" if tap["id"] == "failed" else None
+        )
+    )
+    pipelinewise.load_config = Mock()
+    pipelinewise.cleanup_after_deleted_config = Mock(return_value=0)
+
+    with patch(
+        "pipelinewise.cli.pipelinewise.Config.from_yamls",
+        return_value=imported,
+    ), patch(
+        "pipelinewise.cli.pipelinewise.DataDiffRepository.from_backend_config",
+        return_value=repository,
+    ), pytest.raises(SystemExit) as exc:
+        pipelinewise.import_project()
+
+    assert exc.value.code == 1
+    assert repository.synced == (
+        [successful_definition, failed_definition],
+        ["*"],
+        {"failed"},
+    )
+    pipelinewise.logger.error.assert_called_once_with(
+        "Tap discovery failed: %s",
+        "discovery failed",
+    )
+
+
+def test_import_deactivates_removed_definition_for_successful_tap_after_partial_failure():
+    failed_definition = Mock(tap_id="failed")
+    imported = Mock()
+    imported.global_config = {"backend_db": {"host": "backend"}}
+    imported.targets = {
+        "target": {"taps": [{"id": "successful"}, {"id": "failed"}]}
+    }
+    imported.get_data_diff_definitions.return_value = [failed_definition]
+    repository = RepositoryContext()
+    pipelinewise = _pipelinewise(taps="*")
+    pipelinewise.logger = Mock()
+    pipelinewise.config = {}
+    pipelinewise._discover_tap = Mock(
+        side_effect=lambda tap, **_kwargs: (
+            "discovery failed" if tap["id"] == "failed" else None
+        )
+    )
+    pipelinewise.load_config = Mock()
+    pipelinewise.cleanup_after_deleted_config = Mock(return_value=0)
+
+    with patch(
+        "pipelinewise.cli.pipelinewise.Config.from_yamls",
+        return_value=imported,
+    ), patch(
+        "pipelinewise.cli.pipelinewise.DataDiffRepository.from_backend_config",
+        return_value=repository,
+    ), pytest.raises(SystemExit) as exc:
+        pipelinewise.import_project()
+
+    assert exc.value.code == 1
+    assert repository.synced == ([failed_definition], ["*"], {"failed"})
+
+
+def test_import_persists_found_tap_when_an_explicitly_selected_tap_is_missing():
+    definition = Mock(tap_id="found")
+    imported = Mock()
+    imported.global_config = {"backend_db": {"host": "backend"}}
+    imported.targets = {"target": {"taps": [{"id": "found"}]}}
+    imported.get_data_diff_definitions.return_value = [definition]
+    repository = RepositoryContext()
+    pipelinewise = _pipelinewise(taps="found,missing")
+    pipelinewise.logger = Mock()
+    pipelinewise.config = {}
+    pipelinewise._discover_tap = Mock(return_value=None)
+    pipelinewise.load_config = Mock()
+    pipelinewise.cleanup_after_deleted_config = Mock(return_value=0)
+
+    with patch(
+        "pipelinewise.cli.pipelinewise.Config.from_yamls",
+        return_value=imported,
+    ), patch(
+        "pipelinewise.cli.pipelinewise.DataDiffRepository.from_backend_config",
+        return_value=repository,
+    ), pytest.raises(SystemExit) as exc:
+        pipelinewise.import_project()
+
+    assert exc.value.code == 1
+    assert repository.synced == (
+        [definition],
+        ["found", "missing"],
+        {"missing"},
+    )
 
 
 def _alerting_pipelinewise(taps):

--- a/tests/units/data_diff/test_cli.py
+++ b/tests/units/data_diff/test_cli.py
@@ -15,8 +15,9 @@ from tests.units.cli.cli_args import CliArgs
 
 
 class RepositoryContext:
-    def __init__(self, checks=None):
+    def __init__(self, checks=None, sync_error=None):
         self.checks = checks or []
+        self.sync_error = sync_error
         self.filters = None
         self.synced = None
 
@@ -32,6 +33,8 @@ class RepositoryContext:
 
     def sync_definitions(self, definitions, *, selected_taps, excluded_taps=None):
         self.synced = (definitions, selected_taps, excluded_taps)
+        if self.sync_error:
+            raise self.sync_error
         return {"created": len(definitions)}
 
 
@@ -289,7 +292,7 @@ def test_import_deactivates_removed_definition_for_successful_tap_after_partial_
     assert repository.synced == ([failed_definition], ["*"], {"failed"})
 
 
-def test_import_persists_found_tap_when_an_explicitly_selected_tap_is_missing():
+def test_import_reconciles_an_explicitly_selected_tap_missing_from_yaml():
     definition = Mock(tap_id="found")
     imported = Mock()
     imported.global_config = {"backend_db": {"host": "backend"}}
@@ -316,8 +319,86 @@ def test_import_persists_found_tap_when_an_explicitly_selected_tap_is_missing():
     assert repository.synced == (
         [definition],
         ["found", "missing"],
-        {"missing"},
+        set(),
     )
+    pipelinewise.logger.error.assert_called_once_with(
+        "Tap not found in project YAML: %s",
+        "missing",
+    )
+
+
+def test_import_rejects_incomplete_parallel_discovery_results():
+    imported = Mock()
+    imported.global_config = {}
+    imported.targets = {
+        "target": {"taps": [{"id": "first"}, {"id": "second"}]}
+    }
+    imported.get_data_diff_definitions.return_value = []
+    pipelinewise = _pipelinewise(taps="*")
+
+    with patch(
+        "pipelinewise.cli.pipelinewise.Config.from_yamls",
+        return_value=imported,
+    ), patch("pipelinewise.cli.pipelinewise.Parallel") as parallel, pytest.raises(
+        ValueError, match="shorter"
+    ):
+        parallel.return_value.return_value = [None]
+        pipelinewise.import_project()
+
+
+def test_import_reports_backend_sync_failure_after_partial_discovery():
+    successful_definition = Mock(tap_id="successful")
+    failed_definition = Mock(tap_id="failed")
+    imported = Mock()
+    imported.global_config = {"backend_db": {"host": "backend"}}
+    imported.targets = {
+        "target": {"taps": [{"id": "successful"}, {"id": "failed"}]}
+    }
+    imported.get_data_diff_definitions.return_value = [
+        successful_definition,
+        failed_definition,
+    ]
+    backend_error = RuntimeError("backend unavailable")
+    repository = RepositoryContext(sync_error=backend_error)
+    pipelinewise = _pipelinewise(taps="*")
+    pipelinewise.config = {}
+    pipelinewise._discover_tap = Mock(
+        side_effect=lambda tap, **_kwargs: (
+            "discovery failed" if tap["id"] == "failed" else None
+        )
+    )
+    pipelinewise.load_config = Mock()
+    pipelinewise.cleanup_after_deleted_config = Mock(return_value=0)
+
+    with patch(
+        "pipelinewise.cli.pipelinewise.Config.from_yamls",
+        return_value=imported,
+    ), patch(
+        "pipelinewise.cli.pipelinewise.DataDiffRepository.from_backend_config",
+        return_value=repository,
+    ), pytest.raises(SystemExit) as exc:
+        pipelinewise.import_project()
+
+    assert exc.value.code == 1
+    assert repository.synced == (
+        [successful_definition, failed_definition],
+        ["*"],
+        {"failed"},
+    )
+    pipelinewise.logger.error.assert_called_once_with(
+        "Tap discovery failed: %s",
+        "discovery failed",
+    )
+    pipelinewise.logger.exception.assert_called_once_with(
+        "Failed to reconcile data-diff definitions: %s",
+        backend_error,
+    )
+    summary = next(
+        call
+        for call in pipelinewise.logger.info.call_args_list
+        if "IMPORTING YAML CONFIGS FINISHED" in call.args[0]
+    )
+    assert summary.args[1:6] == (1, 2, 1, 0, "['discovery failed']")
 
 
 def _alerting_pipelinewise(taps):

--- a/tests/units/data_diff/test_repository.py
+++ b/tests/units/data_diff/test_repository.py
@@ -149,7 +149,7 @@ def test_partial_scope_only_deactivates_selected_tap():
 
 def test_full_scope_preserves_failed_tap_and_deactivates_deleted_tap():
     failed_definition = _definition(tap_id="failed", source_table="new")
-    wildcard_definition = _definition(tap_id="*", source_table="new")
+    successful_definition = _definition(tap_id="successful", source_table="new")
     failed_check_id = uuid4()
     deleted_check_id = uuid4()
     current = [
@@ -170,7 +170,7 @@ def test_full_scope_preserves_failed_tap_and_deactivates_deleted_tap():
     repository = _repository_with_cursor(cursor)
 
     stats = repository.sync_definitions(
-        [failed_definition, wildcard_definition],
+        [failed_definition, successful_definition],
         selected_taps=["*"],
         excluded_taps=["failed"],
     )

--- a/tests/units/data_diff/test_repository.py
+++ b/tests/units/data_diff/test_repository.py
@@ -11,20 +11,20 @@ from pipelinewise.data_diff.repository import DataDiffRepository
 # pylint: disable=protected-access
 
 
-def _definition(config_hash_seed="one"):
+def _definition(config_hash_seed="one", *, tap_id="tap", source_table="payments"):
     # The seed varies frequency to produce different config hashes.
     return CheckDefinition(
-        full_check_name="target/tap/public/payments",
+        full_check_name=f"target/{tap_id}/public/{source_table}",
         target_id="target",
-        tap_id="tap",
+        tap_id=tap_id,
         source_type="tap-postgres",
         target_type="target-snowflake",
         source_database="source",
         target_database="target",
         source_schema="public",
-        source_table="payments",
+        source_table=source_table,
         target_schema="PUBLIC",
-        target_table="PAYMENTS",
+        target_table=source_table.upper(),
         source_key_column="id",
         target_key_column="ID",
         source_timestamp_column="updated_at",
@@ -145,6 +145,50 @@ def test_partial_scope_only_deactivates_selected_tap():
     # dd_checks is keyed by check_id; dd_check_id only exists on dd_runs.
     assert "WHERE check_id = %s" in updates[0][0]
     assert "dd_check_id" not in updates[0][0]
+
+
+def test_full_scope_preserves_failed_tap_and_deactivates_deleted_tap():
+    failed_definition = _definition(tap_id="failed", source_table="new")
+    wildcard_definition = _definition(tap_id="*", source_table="new")
+    failed_check_id = uuid4()
+    deleted_check_id = uuid4()
+    current = [
+        {
+            "check_id": failed_check_id,
+            "full_check_name": "target/failed/public/old",
+            "config_hash": "a" * 64,
+            "tap_id": "failed",
+        },
+        {
+            "check_id": deleted_check_id,
+            "full_check_name": "target/deleted/public/old",
+            "config_hash": "b" * 64,
+            "tap_id": "deleted",
+        },
+    ]
+    cursor = ScriptedCursor(current)
+    repository = _repository_with_cursor(cursor)
+
+    stats = repository.sync_definitions(
+        [failed_definition, wildcard_definition],
+        selected_taps=["*"],
+        excluded_taps=["failed"],
+    )
+
+    assert stats == {
+        "created": 1,
+        "unchanged": 0,
+        "superseded": 0,
+        "deactivated": 1,
+    }
+    assert not any(
+        params and failed_check_id in params
+        for _sql, params in cursor.executions
+    )
+    assert any(
+        params and deleted_check_id in params
+        for _sql, params in cursor.executions
+    )
 
 
 def test_list_checks_exposes_compare_columns_from_version_snapshot():


### PR DESCRIPTION
## Context

`import_config` previously skipped all data-diff definition reconciliation when
any selected tap failed discovery. One failed tap therefore prevented definitions
for every successful tap from reaching the backend database, leaving configured
checks absent from `dd_checks`.


## Changes

- Reconcile definitions for successfully discovered taps during a partially
  failed import while preserving existing definitions for taps whose discovery
  failed.
- Deactivate definitions for explicitly selected taps that no longer exist in
  the project YAML.
- Preserve the import summary and non-zero exit when backend reconciliation
  fails.
- Fail if parallel discovery returns an incomplete result set, and treat `*`
  combined with named tap filters as a consistent full-import scope.
- Require verifying the complete branch diff against the CHANGELOG before
  creating or updating a pull request.

Refer to [0.81.2 CHANGELOG](https://github.com/transferwise/pipelinewise/blob/af1b49e8d782f35d17ddbe8a3fa279081467abb4/CHANGELOG.md#0812-2026-09-02) for full details.


## Type of change

- [x] Bug fix
- [x] Documentation

## Compatibility and operations

No configuration or database schema migration is required. Existing definitions
for discovery-failed taps remain unchanged. Definitions for explicitly selected
taps absent from the YAML are deactivated as removed. Successful taps may create,
supersede, or deactivate definitions even when another tap fails discovery.
Operators still receive a non-zero import result and can retry the failed taps.
Rollback requires deploying the previous version and running a successful import
to reconcile configured definitions.


## Validation

| Command or check | Result |
|---|---|
| `docker exec pipelinewise ruff check pipelinewise tests` | Passed; 0 issues |
| `docker exec pipelinewise pylint pipelinewise tests` | Passed; 10.00/10 |
| `docker exec pipelinewise flake8 pipelinewise --count --select=E9,F63,F7,F82 --show-source --statistics` | Passed; 0 issues |
| `docker exec pipelinewise flake8 pipelinewise --count --max-complexity=15 --max-line-length=120 --statistics` | Passed; 0 issues |
| `docker exec pipelinewise pytest --cov=pipelinewise --cov-fail-under=77 -v tests/units` | Passed; 1,314 tests and 147 subtests, 0 failures or skips; 86% coverage |
| `docker exec -w /opt/pipelinewise/docs pipelinewise make check` | Passed; 6 documentation tests, reference checks, and strict 46-source Sphinx build; 0 failures or warnings |
| `docker exec pipelinewise python -m pytest tests/end_to_end/data_diff/test_postgres_to_postgres.py tests/end_to_end/data_diff/test_mysql_to_postgres.py -vx --timer-top-n 10` | Passed; 5 tests, 0 failures or skips |
| `git diff --check origin/master` | Passed |


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] This pull request is focused and can be reviewed and reverted
      independently.
- [x] Behavioural changes have regression tests, or I explained why tests are not
      applicable.
- [x] Relevant documentation and changelog entries are updated, or I explained
      why they are not applicable.
- [x] Applicable local checks pass; failures, skips, and unavailable checks are
      documented above.
- [x] The change contains no credentials, private keys, production identifiers,
      or source records.
- [x] Breaking and compatibility impacts are identified above.
