### PR TITLE
AP-2520 Configure compatible Snowflake Iceberg storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.83.0 (2026-09-04)
+-------------------
+
+**Snowflake Iceberg**
+
+- Create managed Iceberg v3 tables with automatic target file sizing and
+  compatible storage serialization for third-party engine interoperability
+
 0.82.0 (2026-09-03)
 -------------------
 

--- a/docs/connectors/targets/snowflake_iceberg.rst
+++ b/docs/connectors/targets/snowflake_iceberg.rst
@@ -62,8 +62,10 @@ Snowflake prerequisites
 PipelineWise creates explicit v3 tables with ``CATALOG = 'SNOWFLAKE'`` and no
 ``EXTERNAL_VOLUME`` clause. Snowflake therefore uses the effective schema,
 database, or account default, or Snowflake-managed storage when no other default
-is set. New tables use one day of data retention, a 16 MB target file size, and
-automatic data compaction; these values are not configurable per tap.
+is set. New tables use one day of data retention, Snowflake's automatic target
+file sizing, compatible storage serialization, and automatic data compaction;
+these values are not configurable per tap. Compatible serialization prioritizes
+Parquet encoding and compression that interoperates with third-party engines.
 
 PipelineWise sets the required table parameter on every managed v3 table it
 creates or replaces. Snowflake ``UPDATE``, ``DELETE``, and ``MERGE`` therefore

--- a/pipelinewise/AGENTS.md
+++ b/pipelinewise/AGENTS.md
@@ -80,6 +80,9 @@ Read root `AGENTS.md` first; also use scoped connector, test, E2E, and docs guid
   `ICEBERG_MERGE_ON_READ_BEHAVIOR = 'DISABLED'` in creation, replacement, and
   converter DDL and before writes. Never use deprecated
   `ENABLE_ICEBERG_MERGE_ON_READ`.
+- Create every managed v3 table with `TARGET_FILE_SIZE = 'AUTO'` and
+  `STORAGE_SERIALIZATION_POLICY = 'COMPATIBLE'`; keep FastSync, conversion,
+  target-snowflake, and the dependency-free contract fixture aligned.
 - Map FastSync string-like/fallback MySQL, MariaDB, and PostgreSQL types to
   `VARCHAR(134217728)`. Auto-widen compatible narrow native PartialSync targets
   before DML. target-snowflake uses that width for new native/v3 Singer strings,

--- a/pipelinewise/fastsync/commons/snowflake_iceberg_versions.py
+++ b/pipelinewise/fastsync/commons/snowflake_iceberg_versions.py
@@ -425,7 +425,8 @@ MANAGED_ICEBERG_V3_SPEC = ManagedIcebergVersionSpec(
     logical_to_physical_types=_V3_LOGICAL_TO_PHYSICAL_TYPES,
     table_options={
         'DATA_RETENTION_TIME_IN_DAYS': 1,
-        'TARGET_FILE_SIZE': '16MB',
+        'TARGET_FILE_SIZE': 'AUTO',
+        'STORAGE_SERIALIZATION_POLICY': 'COMPATIBLE',
         'ENABLE_DATA_COMPACTION': True,
         ICEBERG_MERGE_ON_READ_BEHAVIOR: 'DISABLED',
     },

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.12.*',
-      version='0.82.0',
+      version='0.83.0',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',

--- a/singer-connectors/AGENTS.md
+++ b/singer-connectors/AGENTS.md
@@ -99,6 +99,9 @@ Parquet and a real client-side encryption master key.
 - Managed v3 requires table-level
   `ICEBERG_MERGE_ON_READ_BEHAVIOR = 'DISABLED'` in CREATE and before writes;
   keep core parity and never use deprecated `ENABLE_ICEBERG_MERGE_ON_READ`.
+- Create managed v3 with `TARGET_FILE_SIZE = 'AUTO'` and
+  `STORAGE_SERIALIZATION_POLICY = 'COMPATIBLE'`; keep the dependency-free
+  fixture and core FastSync/conversion contract aligned.
 - Emit new native/v3 strings as `VARCHAR(134217728)`. Keep compatible existing
   native widths; require exact v3 width and never widen existing Iceberg
   implicitly. Emit v3 binary explicitly as `BINARY(67108864)` in CREATE/ADD.

--- a/singer-connectors/target-snowflake/target_snowflake/managed_iceberg.py
+++ b/singer-connectors/target-snowflake/target_snowflake/managed_iceberg.py
@@ -565,7 +565,8 @@ _MANAGED_ICEBERG_V3_CONTRACT = ManagedIcebergContract(
     },
     table_option_semantics={
         'DATA_RETENTION_TIME_IN_DAYS': 1,
-        'TARGET_FILE_SIZE': '16MB',
+        'TARGET_FILE_SIZE': 'AUTO',
+        'STORAGE_SERIALIZATION_POLICY': 'COMPATIBLE',
         'ENABLE_DATA_COMPACTION': True,
         ICEBERG_MERGE_ON_READ_PARAMETER: ICEBERG_COPY_ON_WRITE_VALUE,
     },

--- a/singer-connectors/target-snowflake/tests/integration/test_iceberg_v3.py
+++ b/singer-connectors/target-snowflake/tests/integration/test_iceberg_v3.py
@@ -289,6 +289,20 @@ class TestManagedIcebergV3Integration(unittest.TestCase):
         self.assertEqual(len(merge_on_read_rows), 1)
         self.assertEqual(str(merge_on_read_rows[0]['value']).upper(), 'DISABLED')
         self.assertEqual(str(merge_on_read_rows[0]['level']).upper(), 'TABLE')
+        target_file_size_rows = self.snowflake.query(
+            "SHOW PARAMETERS LIKE 'TARGET_FILE_SIZE' "
+            f'IN TABLE {table_fqtn}'
+        )
+        self.assertEqual(len(target_file_size_rows), 1)
+        self.assertEqual(str(target_file_size_rows[0]['value']).upper(), 'AUTO')
+        self.assertEqual(str(target_file_size_rows[0]['level']).upper(), 'TABLE')
+        serialization_rows = self.snowflake.query(
+            "SHOW PARAMETERS LIKE 'STORAGE_SERIALIZATION_POLICY' "
+            f'IN TABLE {table_fqtn}'
+        )
+        self.assertEqual(len(serialization_rows), 1)
+        self.assertEqual(str(serialization_rows[0]['value']).upper(), 'COMPATIBLE')
+        self.assertEqual(str(serialization_rows[0]['level']).upper(), 'TABLE')
         column_types = self.snowflake.query(
             'SELECT "COLUMN_NAME", "DATA_TYPE" '
             f'FROM {self._quote_identifier(self.database)}."INFORMATION_SCHEMA"."COLUMNS" '

--- a/singer-connectors/target-snowflake/tests/unit/test_db_sync.py
+++ b/singer-connectors/target-snowflake/tests/unit/test_db_sync.py
@@ -1724,12 +1724,14 @@ class TestDBSync(unittest.TestCase):
             'CREATE ICEBERG TABLE IF NOT EXISTS dummy-schema."TABLE1" '
             '("ID" number(38,0), "NAME" varchar(134217728), "PAYLOAD" variant, PRIMARY KEY("ID")) '
             "CATALOG='SNOWFLAKE' ICEBERG_VERSION=3 DATA_RETENTION_TIME_IN_DAYS=1 "
-            "TARGET_FILE_SIZE='16MB' ENABLE_DATA_COMPACTION=TRUE "
+            "TARGET_FILE_SIZE='AUTO' STORAGE_SERIALIZATION_POLICY='COMPATIBLE' "
+            'ENABLE_DATA_COMPACTION=TRUE '
             "ICEBERG_MERGE_ON_READ_BEHAVIOR='DISABLED'",
         )
         self.assertIn('CREATE ICEBERG TABLE IF NOT EXISTS', ddl)
         self.assertIn('DATA_RETENTION_TIME_IN_DAYS', ddl)
         self.assertIn('TARGET_FILE_SIZE', ddl)
+        self.assertIn("STORAGE_SERIALIZATION_POLICY='COMPATIBLE'", ddl)
         self.assertIn('ENABLE_DATA_COMPACTION', ddl)
         self.assertIn("ICEBERG_MERGE_ON_READ_BEHAVIOR='DISABLED'", ddl)
         self.assertEqual(

--- a/singer-connectors/target-snowflake/tests/unit/test_managed_iceberg.py
+++ b/singer-connectors/target-snowflake/tests/unit/test_managed_iceberg.py
@@ -48,6 +48,11 @@ def test_v3_registry_entry_is_a_complete_contract():
         'timestamp_ntz',
         'variant',
     }
+    assert contract.table_option_semantics['TARGET_FILE_SIZE'] == 'AUTO'
+    assert (
+        contract.table_option_semantics['STORAGE_SERIALIZATION_POLICY']
+        == 'COMPATIBLE'
+    )
     assert contract.table_option_semantics['ICEBERG_MERGE_ON_READ_BEHAVIOR'] == 'DISABLED'
     assert contract.copy_on_write_level == 'TABLE'
     assert callable(contract.canonical_type)
@@ -355,7 +360,8 @@ def test_v3_contract_drives_type_mapping_and_table_options():
         '("ID" number(38,0), PRIMARY KEY("ID")) '
         "CATALOG='SNOWFLAKE' ICEBERG_VERSION=3 "
         'DATA_RETENTION_TIME_IN_DAYS=1 '
-        "TARGET_FILE_SIZE='16MB' ENABLE_DATA_COMPACTION=TRUE "
+        "TARGET_FILE_SIZE='AUTO' STORAGE_SERIALIZATION_POLICY='COMPATIBLE' "
+        'ENABLE_DATA_COMPACTION=TRUE '
         "ICEBERG_MERGE_ON_READ_BEHAVIOR='DISABLED'"
     )
 

--- a/tests/resources/snowflake_managed_iceberg_contract.json
+++ b/tests/resources/snowflake_managed_iceberg_contract.json
@@ -20,7 +20,8 @@
         },
         "table_options": {
           "DATA_RETENTION_TIME_IN_DAYS": 1,
-          "TARGET_FILE_SIZE": "16MB",
+          "TARGET_FILE_SIZE": "AUTO",
+          "STORAGE_SERIALIZATION_POLICY": "COMPATIBLE",
           "ENABLE_DATA_COMPACTION": true,
           "ICEBERG_MERGE_ON_READ_BEHAVIOR": "DISABLED"
         },

--- a/tests/units/fastsync/commons/test_snowflake_iceberg_converter.py
+++ b/tests/units/fastsync/commons/test_snowflake_iceberg_converter.py
@@ -438,7 +438,8 @@ def test_native_mode_keeps_companion(tmp_path):
     assert not _manifest_files(tmp_path)
     create_sql = next(sql for sql, _, _ in snowflake.queries if sql.startswith('CREATE'))
     assert "CATALOG = 'SNOWFLAKE' ICEBERG_VERSION = 3" in create_sql
-    assert "TARGET_FILE_SIZE = '16MB'" in create_sql
+    assert "TARGET_FILE_SIZE = 'AUTO'" in create_sql
+    assert "STORAGE_SERIALIZATION_POLICY = 'COMPATIBLE'" in create_sql
     assert 'OR REPLACE' not in create_sql
     assert create_sql.startswith(
         'CREATE ICEBERG TABLE "DATABASE"."SCHEMA"."TABLE_ICEBERG"'

--- a/tests/units/fastsync/commons/test_snowflake_iceberg_manifest.py
+++ b/tests/units/fastsync/commons/test_snowflake_iceberg_manifest.py
@@ -447,10 +447,15 @@ def test_conversion_payload_and_rollback_transition_are_explicit(spec):
 
 def test_version_strategy_is_immutable_and_complete():
     """A future strategy cannot omit CoW or silently mutate v3 semantics."""
+    assert MANAGED_ICEBERG_V3_SPEC.table_options['TARGET_FILE_SIZE'] == 'AUTO'
+    assert (
+        MANAGED_ICEBERG_V3_SPEC.table_options['STORAGE_SERIALIZATION_POLICY']
+        == 'COMPATIBLE'
+    )
     with pytest.raises(TypeError):
         MANAGED_ICEBERG_V3_SPEC.table_options['TARGET_FILE_SIZE'] = '64MB'
     with pytest.raises(ValueError, match='incomplete'):
         replace(
             MANAGED_ICEBERG_V3_SPEC,
-            table_options={'TARGET_FILE_SIZE': '16MB'},
+            table_options={'TARGET_FILE_SIZE': 'AUTO'},
         )


### PR DESCRIPTION
## Context

PipelineWise created Snowflake-managed Iceberg v3 tables with a fixed 16 MB
Parquet target and Snowflake's default optimized serialization. The optimized
policy can use Snowflake-specific encoding or compression that is not intended
for third-party Iceberg engines.

## Changes

- Create every new or replacement managed Iceberg v3 table with
  `TARGET_FILE_SIZE = 'AUTO'` and
  `STORAGE_SERIALIZATION_POLICY = 'COMPATIBLE'`.
- Keep target-snowflake, FastSync publication, native-to-Iceberg conversion,
  and the shared dependency-free contract fixture aligned.
- Verify the resulting table-level settings against Snowflake.
- Document the new creation defaults and release the change as PipelineWise
  0.83.0.

## Type of change

- [x] Bug fix
- [x] Documentation

## Compatibility and operations

The change applies only when PipelineWise creates or replaces a managed
Iceberg v3 table. Existing tables are not altered. Snowflake does not allow
`STORAGE_SERIALIZATION_POLICY` to be changed after table creation, so an
existing table must be recreated if it needs the compatible policy.

Rollback is a code revert, but tables already created with compatible
serialization retain that immutable setting. Recovery and replication state
formats are unchanged.

## Validation

| Command or check | Result |
|---|---|
| Root Ruff, Pylint, both Flake8 gates, and `pytest --cov=pipelinewise --cov-fail-under=77 -v tests/units` | Passed: 1,315 tests and 147 subtests; zero failures or skips; coverage threshold met |
| `make unit_test` in target-snowflake | Passed: 123 tests and 61 subtests; zero failures or skips; 81.05% coverage |
| Target-snowflake managed-Iceberg Snowflake integration test | Passed: 1 test; Snowflake reported `AUTO` and `COMPATIBLE` at `TABLE` level |
| `cd docs && make check` | Passed: 6 reference tests and strict HTML build of 46 sources with no warnings |
| `pylint --rcfile=pylintrc target_snowflake/managed_iceberg.py` | Passed: 10.00/10 |
| Connector-wide `make pylint` | Non-green because the legacy Pylint configuration is incompatible with the installed Pylint and reports unrelated existing warnings; no new finding in the changed module |
| Full E2E matrix | Not run; publication behavior is unchanged and the generated DDL was exercised directly against Snowflake |
| `git diff --check` | Passed |

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] This pull request is focused and can be reviewed and reverted
      independently.
- [x] Behavioural changes have regression tests, or I explained why tests are not
      applicable.
- [x] Relevant documentation and changelog entries are updated, or I explained
      why they are not applicable.
- [x] Applicable local checks pass; failures, skips, and unavailable checks are
      documented above.
- [x] The change contains no credentials, private keys, production identifiers,
      or source records.
- [x] Breaking and compatibility impacts are identified above.
