### PR TITLE
AP-2830 Fix MariaDB data-diff statement timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.83.1 (2026-09-04)
+-------------------
+
+**Data-diff**
+
+- Detect MariaDB sources from the server handshake when ``db_conn.engine`` is
+  omitted, so statement timeouts use MariaDB's supported session variable
+
 0.83.0 (2026-09-04)
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 **Data-diff**
 
 - Detect MariaDB sources from the server handshake when ``db_conn.engine`` is
-  omitted, so statement timeouts use MariaDB's supported session variable
+  omitted, so statement timeouts use MariaDB's supported ``max_statement_time`` session variable.
 
 0.83.0 (2026-09-04)
 -------------------

--- a/docs/connectors/taps/mysql.rst
+++ b/docs/connectors/taps/mysql.rst
@@ -82,9 +82,9 @@ Configuration
      - Default
      - Effect
    * - ``engine``
-     - With GTID
-     - —
-     - Selects ``mariadb`` or ``mysql`` GTID semantics.
+     - For MariaDB GTID
+     - ``mysql``
+     - Selects MariaDB or MySQL source-specific semantics.
    * - ``use_gtid``
      - No
      - ``false``

--- a/docs/user_guide/data_diff.rst
+++ b/docs/user_guide/data_diff.rst
@@ -153,6 +153,13 @@ inherited from ``data_diff_defaults`` — the table value wins when both exist.
 Durations compose the units ``s``, ``min``, ``h``, ``d``, ``w``: ``"-15h"`` is 15
 hours before fire time, and ``"1d6h"`` is valid too.
 
+For ``tap-mysql`` sources, data-diff uses ``db_conn.engine`` when it is set. If
+it is omitted, data-diff infers MariaDB or MySQL from the connected server's
+handshake. This fallback applies only to data-diff; Singer ``tap-mysql`` and
+FastSync continue to default an omitted engine to ``mysql``. Set
+``engine: mariadb`` explicitly for MariaDB, especially with GTID, managed
+Iceberg v3 JSON aliases, or proxies that hide the server identity.
+
 Choosing a frequency and window
 '''''''''''''''''''''''''''''''
 

--- a/pipelinewise/data_diff/engine.py
+++ b/pipelinewise/data_diff/engine.py
@@ -241,7 +241,14 @@ def connect_source(check: dict, connection_config: dict) -> DatabaseAdapter:
                 ssl_temp_dir.cleanup()
         with connection.cursor() as cursor:
             cursor.execute("SET SESSION time_zone = '+00:00'")
-            if connection_config.get("engine", "mysql") == "mariadb":
+            engine = connection_config.get("engine")
+            if engine is None:
+                engine = (
+                    "mariadb"
+                    if "mariadb" in connection.get_server_info().lower()
+                    else "mysql"
+                )
+            if engine == "mariadb":
                 cursor.execute("SET SESSION max_statement_time = %s", (timeout,))
             else:
                 cursor.execute("SET SESSION max_execution_time = %s", (timeout * 1000,))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.12.*',
-      version='0.83.0',
+      version='0.83.1',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',

--- a/tests/end_to_end/data_diff/test-project/tap_mysql_data_diff_to_pg.yml.template
+++ b/tests/end_to_end/data_diff/test-project/tap_mysql_data_diff_to_pg.yml.template
@@ -11,8 +11,7 @@ db_conn:
   user: "${TAP_MYSQL_USER}"
   password: "${TAP_MYSQL_PASSWORD}"
   dbname: "${TAP_MYSQL_DB}"
-  # The dev container runs MariaDB, which has no max_execution_time variable.
-  engine: mariadb
+  # Deliberately omitted: data-diff must detect MariaDB from the server handshake.
   fastsync_parallelism: 1
 
 target: "data_diff_postgres_dwh"

--- a/tests/end_to_end/data_diff/test-project/tap_mysql_data_diff_to_sf.yml.template
+++ b/tests/end_to_end/data_diff/test-project/tap_mysql_data_diff_to_sf.yml.template
@@ -11,7 +11,7 @@ db_conn:
   user: "${TAP_MYSQL_USER}"
   password: "${TAP_MYSQL_PASSWORD}"
   dbname: "${TAP_MYSQL_DB}"
-  # The dev container runs MariaDB, which has no max_execution_time variable.
+  # Keep this explicit; the PostgreSQL-target E2E covers handshake detection.
   engine: mariadb
   fastsync_parallelism: 1
 

--- a/tests/units/data_diff/test_engine.py
+++ b/tests/units/data_diff/test_engine.py
@@ -333,12 +333,13 @@ def test_canonical_value_normalizes_numbers_and_timestamps_to_utc():
     assert canonical_value(datetime(2026, 7, 22, 12, 0)) == "2026-07-22T12:00:00Z"
 
 
-def _connection_with_cursor():
+def _connection_with_cursor(server_version="8.0.39"):
     cursor = Mock()
     cursor_context = MagicMock()
     cursor_context.__enter__.return_value = cursor
     connection = Mock(closed=False)
     connection.cursor.return_value = cursor_context
+    connection.get_server_info.return_value = server_version
     return connection, cursor
 
 
@@ -368,8 +369,12 @@ def test_postgres_source_is_read_only_utc_and_time_limited():
     ]
 
 
-def test_mariadb_source_is_read_only_utc_and_time_limited():
-    connection, cursor = _connection_with_cursor()
+@pytest.mark.parametrize(
+    "server_version",
+    ["11.4.10-MariaDB-log", "5.5.5-10.6.18-MariaDB-ubu2004-log"],
+)
+def test_mariadb_source_is_detected_and_time_limited_without_engine(server_version):
+    connection, cursor = _connection_with_cursor(server_version)
     check = {"source_type": "tap-mysql", "statement_timeout_seconds": 120}
     config = {
         "host": "source",
@@ -377,7 +382,6 @@ def test_mariadb_source_is_read_only_utc_and_time_limited():
         "user": "reader",
         "password": "secret",
         "dbname": "payments",
-        "engine": "mariadb",
     }
 
     with patch(
@@ -389,6 +393,72 @@ def test_mariadb_source_is_read_only_utc_and_time_limited():
     assert cursor.execute.call_args_list == [
         call("SET SESSION time_zone = '+00:00'"),
         call("SET SESSION max_statement_time = %s", (120,)),
+        call("START TRANSACTION READ ONLY"),
+    ]
+
+
+def test_mysql_source_is_detected_and_time_limited_without_engine():
+    connection, cursor = _connection_with_cursor("8.0.39")
+    check = {"source_type": "tap-mysql", "statement_timeout_seconds": 120}
+    config = {
+        "host": "source",
+        "port": 3306,
+        "user": "reader",
+        "password": "secret",
+        "dbname": "payments",
+    }
+
+    with patch(
+        "pipelinewise.data_diff.engine.pymysql.connect",
+        return_value=connection,
+    ):
+        connect_source(check, config)
+
+    assert cursor.execute.call_args_list == [
+        call("SET SESSION time_zone = '+00:00'"),
+        call("SET SESSION max_execution_time = %s", (120_000,)),
+        call("START TRANSACTION READ ONLY"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "engine,server_version,timeout_call",
+    [
+        (
+            "mariadb",
+            "8.0.39",
+            call("SET SESSION max_statement_time = %s", (120,)),
+        ),
+        (
+            "mysql",
+            "11.4.10-MariaDB-log",
+            call("SET SESSION max_execution_time = %s", (120_000,)),
+        ),
+    ],
+)
+def test_explicit_engine_overrides_server_version(
+    engine, server_version, timeout_call
+):
+    connection, cursor = _connection_with_cursor(server_version)
+    check = {"source_type": "tap-mysql", "statement_timeout_seconds": 120}
+    config = {
+        "host": "source",
+        "port": 3306,
+        "user": "reader",
+        "password": "secret",
+        "dbname": "payments",
+        "engine": engine,
+    }
+
+    with patch(
+        "pipelinewise.data_diff.engine.pymysql.connect",
+        return_value=connection,
+    ):
+        connect_source(check, config)
+
+    assert cursor.execute.call_args_list == [
+        call("SET SESSION time_zone = '+00:00'"),
+        timeout_call,
         call("START TRANSACTION READ ONLY"),
     ]
 


### PR DESCRIPTION
## Context

Data-diff treated `tap-mysql` sources without an explicit `db_conn.engine` as
MySQL and executed `SET SESSION max_execution_time`. MariaDB does not support
that variable, so affected checks failed before comparing any data.

This is a database-family difference rather than an old MariaDB-version issue:
MariaDB uses `max_statement_time`, while MySQL uses `max_execution_time`.


## Changes

- Detect MariaDB from PyMySQL's server handshake when `db_conn.engine` is
  omitted, without adding a database round-trip.
- Keep an explicitly configured `engine` authoritative, including when a proxy
  presents a misleading server identity.
- Apply MariaDB timeouts in seconds and MySQL timeouts in milliseconds.
- Cover automatic detection and explicit overrides for both database families.
- Exercise omitted-engine detection in the MariaDB-to-PostgreSQL E2E route
  while retaining explicit MariaDB configuration in the Snowflake route.
- Document data-diff's detection fallback and correct the documented
  `tap-mysql` engine default.
- Release the compatible fix as PipelineWise 0.83.1.


## Type of change

- [x] Bug fix
- [x] Documentation


## Compatibility and operations

This is a backward-compatible patch. Existing explicit `engine: mariadb` and
`engine: mysql` configurations retain their current behaviour. Omitted-engine
MySQL sources remain on the MySQL path; omitted-engine MariaDB sources now use
the supported MariaDB timeout variable.

Singer `tap-mysql` and FastSync still default an omitted engine to MySQL.
Operators should continue setting `engine: mariadb` explicitly for MariaDB,
especially with GTID, managed Iceberg v3 JSON aliases, or proxies that hide the
server identity.

No backend schema, replication state, or target-data migration is required.
Rollback is safe; after rollback, MariaDB sources must explicitly configure
`engine: mariadb` to avoid the original error.


## Validation

| Command or check | Result |
|---|---|
| `ruff check pipelinewise tests` | Passed |
| `pylint pipelinewise tests` | Passed, 10.00/10 |
| `flake8 pipelinewise --count --select=E9,F63,F7,F82 --show-source --statistics` | Passed, 0 findings |
| `flake8 pipelinewise --count --max-complexity=15 --max-line-length=120 --statistics` | Passed, 0 findings |
| `pytest --cov=pipelinewise --cov-fail-under=77 -v tests/units` | 1,319 passed, 147 subtests passed, 0 failed, 0 skipped; 86.09% coverage |
| `pytest tests/end_to_end/data_diff/test_mysql_to_postgres.py -vx --timer-top-n 10` | 2 passed, 0 failed, 0 skipped |
| `pytest tests/end_to_end/data_diff/test_mysql_to_snowflake.py -vx --timer-top-n 10` | 2 passed, 0 failed, 0 skipped |
| Live MariaDB 10.6 and MySQL 8.0 session-timeout smoke checks | Both passed |
| `pipelinewise validate --dir dev-project/pipelinewise-config` | Passed |
| `cd docs && make check` | 6 reference tests passed; 46 pages built with zero warnings |
| `git diff --check` | Passed |


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] This pull request is focused and can be reviewed and reverted
      independently.
- [x] Behavioural changes have regression tests, or I explained why tests are not
      applicable.
- [x] Relevant documentation and changelog entries are updated, or I explained
      why they are not applicable.
- [x] Applicable local checks pass; failures, skips, and unavailable checks are
      documented above.
- [x] The change contains no credentials, private keys, production identifiers,
      or source records.
- [x] Breaking and compatibility impacts are identified above.
