### PR TITLE
AP-2830 Rename data-diff watermark columns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,43 +2,47 @@
 
 ## Scope
 
-PipelineWise is a Python 3.12 Singer ELT framework. Write for senior engineers;
-prioritize operational precision, edge cases, and rationale. Read each relevant
-guide:
+PipelineWise is a Python 3.12 Singer ELT framework. Write for senior engineers
+with operational precision, edge cases, and rationale. Root rules apply
+repo-wide; scoped rules add to them, and explicit user instructions win. Read
+the guides relevant to the change:
 
 - `pipelinewise/AGENTS.md`: orchestration, FastSync, backend migrations, data-diff.
 - `singer-connectors/AGENTS.md`: vendored taps and targets.
-- `tests/AGENTS.md`: unit tests and suite boundaries.
-- `tests/end_to_end/AGENTS.md`: databases, connectors, E2E, `dev-project/`.
+- `tests/AGENTS.md`: units and suite boundaries.
+- `tests/end_to_end/AGENTS.md`: databases, connector routes, E2E, `dev-project/`.
 - `docs/AGENTS.md`: documentation.
 
-Scoped guidance adds to this file; explicit user instructions win. Each
-`CLAUDE.md` symlinks to its adjacent `AGENTS.md`; edit the latter and preserve
-the link.
+Every `CLAUDE.md` symlinks to its adjacent `AGENTS.md`; edit the latter and
+preserve the link.
 
 ## Architecture
 
-- Singer JSON flows as `tap | [transform-field] | [mbuffer] | target`; YAML becomes generated config, state, and catalog JSON.
-- `pipelinewise/cli/__init__.py` defines argparse and dispatches to `PipelineWise`. Canonical `fast_sync` and `import_config` retain deprecated aliases `sync_tables` and `import`.
-- FastSync is a native full/filtered bulk-transfer optimization, not a replication method. Singer handles INCREMENTAL/LOG_BASED and FULL_TABLE streams not selected for FastSync.
+- Singer JSON flows as `tap | [transform-field] | [mbuffer] | target`; YAML
+  generates config, state, and catalog JSON.
+- `pipelinewise/cli/__init__.py` defines argparse and dispatches to
+  `PipelineWise`. Canonical `fast_sync` and `import_config` retain deprecated
+  aliases `sync_tables` and `import`.
+- FastSync optimizes native full/filtered bulk transfer; it is not a replication
+  method. Singer handles INCREMENTAL/LOG_BASED and non-FastSync FULL_TABLE streams.
 
 ## Environment
 
-- Prefer the `dev-project` Docker stack; its Linux runtime best matches
-  production. Use the host only to manage Docker or when a check cannot run in
-  the container, and report the compatibility gap.
-- The repo is mounted at `/opt/pipelinewise` in the `pipelinewise` container.
-  `PIPELINEWISE_HOME` environments live under `dev-project/.virtualenvs/` and
-  are on `PATH`.
-- `make pipelinewise` installs the editable root plus test extras. Connector
+- Default to the `dev-project` Docker stack, whose Linux runtime best matches
+  production. Use the host only to manage Docker or when the container cannot
+  run a check; report that fallback and compatibility gap.
+- The repo mounts at `/opt/pipelinewise` in `pipelinewise`.
+  `PIPELINEWISE_HOME` environments are on `PATH` under
+  `dev-project/.virtualenvs/`.
+- `make pipelinewise` installs the editable root and test extras. Connector
   runtimes use `.virtualenvs/<name>/`; connector Makefiles may use `venv/`.
-  Never mix host, container, root, runtime-connector, or connector-test
-  interpreters, and never use repository `.venv/`.
+  Never mix host/container, root, runtime-connector, or connector-test
+  interpreters; never use repository `.venv/`.
 
 ## Validation
 
-For implementation changes, run these root gates verbatim and in order,
-preferably in the ready container:
+For implementation changes, run these root gates verbatim, in order, preferably
+in the ready container:
 
 ```bash
 ruff check pipelinewise tests
@@ -48,13 +52,14 @@ flake8 pipelinewise --count --max-complexity=15 --max-line-length=120 --statisti
 pytest --cov=pipelinewise --cov-fail-under=77 -v tests/units
 ```
 
-For an unavoidable host run, activate `.virtualenvs/pipelinewise/`. Do not alter
-paths or flags: Ruff/Pylint inspect `pipelinewise tests`; Flake8 inspects
-`pipelinewise`. Never run bare `pytest tests/`; it collects credentialed E2E.
-Collect nested data-diff/backend-db selections from `tests/units` and narrow
+An unavoidable host run must activate `.virtualenvs/pipelinewise/`. Keep paths
+and flags exact: Ruff/Pylint inspect `pipelinewise tests`; Flake8 inspects
+`pipelinewise`. Never run bare `pytest tests/` because it collects credentialed
+E2E. Collect nested data-diff/backend-db tests from `tests/units`, narrowing
 with `-k` to avoid import failures.
 
-For config-affecting changes, validate in Docker, where Compose loads `dev-project/.env`:
+After implementation, schema, example-config, or connector-config changes,
+validate in Docker (Compose loads `dev-project/.env`):
 
 ```bash
 pipelinewise validate --dir dev-project/pipelinewise-config
@@ -69,51 +74,50 @@ set +a
 .virtualenvs/pipelinewise/bin/pipelinewise validate --dir dev-project/pipelinewise-config
 ```
 
-Run this after implementation, schema, example-config, or connector-config
-changes.
+Also follow these scoped checks:
 
-Also follow scoped checks:
-
-- Database, migration, FastSync, data-diff, connector-route, or E2E: `tests/end_to_end/AGENTS.md`.
-- Connector source: `singer-connectors/AGENTS.md`; root gates do not inspect it.
+- Database, migration, FastSync, data-diff, connector-route, or E2E:
+  `tests/end_to_end/AGENTS.md`.
+- Connector source: `singer-connectors/AGENTS.md`; root gates exclude it.
 - Docs: `docs/AGENTS.md`; warnings fail.
 
 ## Style and safety
 
-- Python: 120 columns, complexity 15, four spaces, Google docstrings, consistent
-  single quotes, `snake_case` names/JSON keys, and `PascalCase` classes.
-- Uppercase Snowflake FastSync identifiers. Scope Pylint disables to a
-  line/function, never a module.
+- Python: 120 columns, complexity 15, four spaces, Google docstrings,
+  consistent single quotes, `snake_case` names/JSON keys, `PascalCase` classes.
+- Uppercase Snowflake FastSync identifiers. Scope Pylint disables to a line or
+  function, never a module.
 - Comments explain a non-obvious constraint or consequence in at most two
   lines; do not restate code, narrate edits, argue choices, or add walkthroughs.
-- Preserve dirty-worktree changes. Do not run `pre-commit run --all-files`,
+- Preserve dirty-worktree changes. Never run `pre-commit run --all-files`,
   reformat unrelated files, or broaden lint fixes.
-- Declare third-party imports in the owning `setup.py`; never rely on
+- Declare third-party imports in the owning `setup.py`; do not rely on
   transitive installs.
-- Never commit secrets, `.tfvars`, private keys, or populated environment
-  files.
-- Use `import_config` in docs, examples, tests, and comments; `import` is
-  deprecated.
+- Never commit secrets, `.tfvars`, private keys, or populated environment files.
+- Use `import_config` in docs, examples, tests, and comments; `import` is deprecated.
 
 ## Git and completion
 
 - Branch from `master`; keep diffs task-scoped. Sign every commit with
   `git commit -S`; never create or push an unsigned commit.
 - CHANGELOG bullets are atomic and outcome-focused: start with an action verb,
-  name the component and operational result, and include implementation detail
-  only to explain risk. Group related bullets under headings.
-- Before creating a PR or pushing changes to an existing PR, compare the
-  complete branch diff with the current release CHANGELOG entry. Do not create
-  or update the PR while the CHANGELOG omits, misstates, or claims changes that
-  are not present in the diff.
-- PipelineWise stays in `0.x` and must never publish `1.0.0` or above. Use a
-  patch for compatible fixes and the next `0.x` minor for features or intentional
-  compatibility changes. Document material operator impact and keep `setup.py`
-  aligned with the top CHANGELOG release.
+  name the component and operational result, group related bullets, and include
+  implementation detail only to explain risk.
+- Before creating a PR or pushing to an open PR, compare the complete branch
+  diff with the current CHANGELOG entry; do not proceed if the entry omits or
+  misstates the diff or claims absent changes. Set that release to today's date
+  (never `TBD` or an earlier date) and link its CHANGELOG entry directly in the
+  PR body.
+- PipelineWise remains `0.x`; never publish `1.0.0` or above. Use a patch for
+  compatible fixes and the next `0.x` minor for features or intentional
+  compatibility changes. Document material operator impact and align `setup.py`
+  with the top CHANGELOG release.
 
 Before completion:
 
-1. Run all applicable lint, unit, config, scoped E2E, connector, and docs checks.
-2. Update validated docs for user-facing behavior/config changes and the root changelog for release-visible connector changes.
-3. Report pass/skip/fail counts per group; skips, failures, and unavailable checks are not passing verification.
-4. Ensure `git diff --check` passes and `git status` contains only expected files.
+1. Run every applicable lint, unit, config, scoped E2E, connector, and docs check.
+2. Update validated docs for user-facing behavior/config changes and the root
+   changelog for release-visible connector changes.
+3. Report pass/skip/fail counts by group; skips, failures, and unavailable checks
+   are not passing verification.
+4. Require clean `git diff --check` and only expected `git status` entries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+0.84.0 (2026-09-07)
+-------------------
+
+**Data-diff backend schema**
+
+- Rename watermark state and event columns through migration 002 to use
+  ``verified_start``, ``verified_end``, ``furthest_observed_end``, and
+  ``verified_status`` while preserving existing state and event history
+- Use ``previous_verified_end`` for the earlier event boundary and
+  ``last_evaluated_run_id`` for mutable state while retaining ``evaluated_run_id``
+  as the causal run on each event
+- Align data-diff runtime state, CLI output, documentation, and the backend ERD with
+  the new names
+- Update reporting queries for renamed watermark columns and current unresolved
+  failures, add daily per-table check-result and run-level-error counts, and retain
+  remediation-history reporting
+- Require direct SQL consumers and replicated backend-table copies to adopt the new
+  columns; downgrade migration 002 before rolling back to an older PipelineWise version
+
 0.83.1 (2026-09-04)
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
 - Require direct SQL consumers and replicated backend-table copies to adopt the new
   columns; downgrade migration 002 before rolling back to an older PipelineWise version
 
+**Development workflow**
+
+- Compact repository agent guidance without changing commands, thresholds,
+  safeguards, or architecture contracts, and require current CHANGELOG dates
+  and direct entry links when opening or updating pull requests
+
 0.83.1 (2026-09-04)
 -------------------
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,13 +1,13 @@
 # Documentation Instructions
 
-Read root `AGENTS.md` and the guidance for the behavior being documented.
+Read root `AGENTS.md` and the guide for the documented behavior.
 
 ## Build and sources
 
-`docs/Makefile` sets `SPHINXOPTS = -W`; warnings fail. The root test extra omits
-Sphinx, so the ready container needs the editable package, `sphinx`, and
-`sphinx-rtd-theme`, and `sphinxcontrib-mermaid`. `scripts/publish_docs.sh`
-mutates Git; do not use it for validation.
+`docs/Makefile` sets `SPHINXOPTS = -W`, so warnings fail. The root test extra
+omits Sphinx; the ready container needs the editable package, `sphinx`,
+`sphinx-rtd-theme`, and `sphinxcontrib-mermaid`. Never validate with
+`scripts/publish_docs.sh`, which mutates Git.
 
 After changing RST, Sphinx config, or assets:
 
@@ -15,22 +15,21 @@ After changing RST, Sphinx config, or assets:
 cd docs && make check
 ```
 
-``make check`` validates embedded YAML and implementation-backed CLI, config,
+``make check`` validates embedded YAML plus implementation-backed CLI, config,
 and packaged-connector references before a strict clean HTML build. Use
 ``make clean html`` only to isolate Sphinx failures.
 
 Verify prose against implementation, CLI help, schemas, example YAML, and
-runtime—not assumptions or only the diff. Prefer `import_config` (`import` is
-deprecated); describe FastSync as a FullSync/PartialSync optimization, not
+runtime—not assumptions or only the diff. Use `import_config` (`import` is
+deprecated) and describe FastSync as a FullSync/PartialSync optimization, not
 Singer replication.
 
 ## Content
 
-- Write concise, authoritative, operations-first public docs for
-  operators/integration engineers; exclude Wise-only hosts, credentials, and
-  runbooks.
-- Order content as support, prerequisites/defaults, operational impact,
-  failures, diagnosis, and recovery.
+- Write concise, authoritative, operations-first public docs for operators and
+  integration engineers; exclude Wise-only hosts, credentials, and runbooks.
+- Order: support, prerequisites/defaults, operational impact, failures,
+  diagnosis, recovery.
 - Separate defaults from examples and current support from future intent;
   repeat only for standalone use or safety.
 
@@ -38,9 +37,10 @@ Singer replication.
 
 - Preserve heading levels. New pages use `=`, `-`, `'`, then `"` unless their
   section differs.
-- Place `.. _label:` directly before its heading; link with ``:ref:`label` ``.
+- Put `.. _label:` directly before its heading; link with ``:ref:`label` ``.
 - Declare every code-block language and use Sphinx admonitions.
-- Add pages to the owning toctree, including nested connector indexes; strict builds reject orphans.
+- Add pages to the owning toctree, including nested connector indexes; strict
+  builds reject orphans.
 
 ## Update map
 
@@ -59,6 +59,6 @@ Singer replication.
 | Alert handlers | `user_guide/alerts.rst` |
 | Operational diagnostics | `user_guide/troubleshooting.rst` |
 
-Backend schema changes also need migration/ERD updates per
+Backend schema changes also require migration/ERD updates per
 `pipelinewise/AGENTS.md`. Update scoped guidance only for durable architecture,
 CI, or workflow changes; otherwise keep docs edits task-scoped.

--- a/docs/user_guide/data_diff.rst
+++ b/docs/user_guide/data_diff.rst
@@ -263,12 +263,12 @@ what keeps the volume sane.
 Coverage and remediation
 ------------------------
 
-``verified_through`` is the end of the contiguous union of successful windows
+``verified_end`` is the end of the contiguous union of successful windows
 for one definition revision:
 
 .. code-block:: text
 
-    [10:00, 11:00) PASS  → verified_through = 11:00
+    [10:00, 11:00) PASS  → verified_end = 11:00
     [11:00, 12:00) FAIL  → stays 11:00 (blocked)
     [12:00, 13:00) PASS  → stays 11:00
     rerun [11:00, 12:00) PASS → advances to 13:00

--- a/docs/user_guide/data_diff_backend.rst
+++ b/docs/user_guide/data_diff_backend.rst
@@ -44,9 +44,9 @@ credentials when separate roles are not required.
 Schema
 ------
 
-.. mermaid:: ../../pipelinewise/backend_db/migrations/versions/001_schema.erd.mmd
+.. mermaid:: ../../pipelinewise/backend_db/migrations/versions/002_schema.erd.mmd
    :align: center
-   :caption: Data-diff backend schema after migration 001
+   :caption: Data-diff backend schema after migration 002
    :zoom:
 
 The schema has two related paths. The first records definitions and execution
@@ -71,9 +71,10 @@ above shows the exact database relationships.
 PipelineWise keeps every attempt in ``dd_run_attempts`` and every watermark
 transition in ``dd_watermark_events``. ``dd_run_slot_state`` materializes only
 the highest terminal attempt for each scheduled slot, while
-``dd_watermark_state`` stores the current watermark. A new chronological slot
-updates that state directly. A replacement or out-of-order slot recalculates it
-from the slot-state rows without rescanning superseded attempts.
+``dd_watermark_state`` stores the current verified interval and the furthest
+observed window end. A new chronological slot updates that state directly. A
+replacement or out-of-order slot recalculates it from the slot-state rows
+without rescanning superseded attempts.
 
 
 Reporting queries
@@ -81,20 +82,121 @@ Reporting queries
 
 Run these queries against the PipelineWise backend database.
 
-Current coverage watermarks:
+Watermark per table:
 
 .. code-block:: sql
 
-    SELECT state.check_id, checks.full_check_name,
-           checks.revision, checks.source_schema, checks.source_table,
-           checks.source_timestamp_column, state.coverage_start,
-           state.verified_through, state.max_observed_end,
-           state.coverage_status, state.blocking_run_id,
-           state.evaluated_run_id, state.event_type,
-           state.updated_at AS verified_at, state.reason
-      FROM public.dd_watermark_state state
-      JOIN public.dd_check_definitions checks
-        ON checks.check_id = state.check_id;
+    SELECT d.full_check_name,
+           d.revision,
+           d.source_database,
+           d.source_schema,
+           d.source_table,
+           d.target_database,
+           d.target_schema,
+           d.target_table,
+           COALESCE(w.verified_status, 'NOT_RUN') AS verified_status,
+           w.verified_start,
+           w.verified_end,
+           w.furthest_observed_end,
+           CURRENT_TIMESTAMP - w.verified_end AS verification_lag,
+           w.blocking_run_id,
+           w.last_evaluated_run_id,
+           w.updated_at AS watermark_updated_at,
+           w.reason
+      FROM public.dd_check_definitions d
+      LEFT JOIN public.dd_watermark_state w
+        ON w.check_id = d.check_id
+     WHERE d.is_current
+     ORDER BY d.target_id, d.tap_id,
+              d.source_schema, d.source_table;
+
+Successful and failed check results per table per UTC day. Historical definition
+revisions and every attempt, including retries and remediation runs, are included.
+The result counts are per ``check_type``; terminal run-level errors without
+result rows are counted separately:
+
+.. code-block:: sql
+
+    WITH outcomes AS (
+        SELECT d.full_check_name,
+               d.source_database,
+               d.source_schema,
+               d.source_table,
+               d.target_database,
+               d.target_schema,
+               d.target_table,
+               (COALESCE(a.finished_at, a.started_at)
+                   AT TIME ZONE 'UTC')::date AS check_date,
+               a.status AS run_status,
+               r.run_id AS result_run_id,
+               r.status AS result_status
+          FROM public.dd_run_attempts a
+          JOIN public.dd_check_definitions d
+            ON d.check_id = a.check_id
+          LEFT JOIN public.dd_run_results r
+            ON r.run_id = a.run_id
+         WHERE a.status IN ('PASS', 'FAIL', 'ERROR')
+    )
+    SELECT full_check_name,
+           source_database,
+           source_schema,
+           source_table,
+           target_database,
+           target_schema,
+           target_table,
+           check_date,
+           COUNT(*) FILTER (
+               WHERE result_status = 'PASS'
+           ) AS successful_check_results,
+           COUNT(*) FILTER (
+               WHERE result_status IN ('FAIL', 'ERROR')
+           ) AS failed_check_results,
+           COUNT(*) FILTER (
+               WHERE result_run_id IS NULL
+                 AND run_status = 'ERROR'
+           ) AS run_level_errors
+      FROM outcomes
+     GROUP BY full_check_name,
+              source_database, source_schema, source_table,
+              target_database, target_schema, target_table,
+              check_date
+     ORDER BY check_date DESC, full_check_name;
+
+Current unresolved failures. Only current check-definition revisions are shown;
+failures belonging to superseded revisions are intentionally excluded:
+
+.. code-block:: sql
+
+    SELECT d.full_check_name,
+           d.revision,
+           d.source_schema,
+           d.source_table,
+           s.scheduled_for,
+           s.window_start,
+           s.window_end,
+           s.run_id,
+           a.attempt,
+           a.trigger_type,
+           COALESCE(r.check_type, '<run-level error>') AS failed_check,
+           COALESCE(r.status, s.status) AS failure_status,
+           COALESCE(r.error, a.error) AS error,
+           COALESCE(s.run_id = w.blocking_run_id, FALSE) AS blocks_watermark,
+           a.finished_at
+      FROM public.dd_run_slot_state s
+      JOIN public.dd_check_definitions d
+        ON d.check_id = s.check_id
+      JOIN public.dd_run_attempts a
+        ON a.run_id = s.run_id
+      LEFT JOIN public.dd_run_results r
+        ON r.run_id = s.run_id
+       AND r.status IN ('FAIL', 'ERROR')
+      LEFT JOIN public.dd_watermark_state w
+        ON w.check_id = s.check_id
+     WHERE d.is_current
+       AND s.status IN ('FAIL', 'ERROR')
+     ORDER BY a.finished_at DESC,
+              d.full_check_name,
+              r.check_type;
 
 Failed runs and their remediation attempts:
 

--- a/pipelinewise/AGENTS.md
+++ b/pipelinewise/AGENTS.md
@@ -1,46 +1,70 @@
 # PipelineWise Implementation Instructions
 
-Read root `AGENTS.md` first; also use scoped connector, test, E2E, and docs guidance where relevant.
+Read root `AGENTS.md` first, then relevant connector, test, E2E, and docs guides.
 
 ## Map and boundaries
 
-- `cli/__init__.py`: commands, aliases, dispatch. `cli/pipelinewise.py`: orchestration. `cli/commands.py`: Singer pipeline. `cli/config.py`: YAML validation and generated JSON under `$PIPELINEWISE_CONFIG_DIRECTORY/<target_id>/<tap_id>/` (default `~/.pipelinewise`). `cli/constants.py`: connector types/mappings. `cli/fastsync_capabilities.py`: the sole format-aware FullSync/PartialSync capability policy; resolve every native and Iceberg direct route through its operation-specific immutable registry, and derive any compatibility views from it rather than duplicating route matrices. `cli/schemas/`: JSON Schemas. `cli/alert_handlers/`: Slack/VictorOps; extend `BaseAlertHandler`.
-- `fastsync/`: native bulk sync. FullSync replaces tables for initial loads, FULL_TABLE, and explicit `fast_sync`; PartialSync merges filtered ranges for `partial_sync_table` and `sync_start_from`. FullSync supports `tap-mysql` (MariaDB/MySQL), `tap-postgres`, and `tap-mongodb` to PostgreSQL/Snowflake; PartialSync supports `tap-mysql` and `tap-postgres` to Snowflake. S3 CSV stays on Singer and outside FastSync. Keep the MySQL/PostgreSQL-to-Snowflake lifecycle in `commons/rdbms_to_snowflake.py` and `partialsync/rdbms_to_snowflake.py`; source modules are thin adapters for source construction, mapping, and ordering differences. Put other shared primitives in `commons/`, imported by `partialsync/`; keep `docs/concept/fastsync.rst` aligned.
-- `backend_db/`: PostgreSQL connections, transactions, Alembic. `ddl_user`/`ddl_password` are required, though they may equal app credentials. It must not depend on data-diff or replication orchestration; an AST test enforces this boundary.
-- `data_diff/`: may use backend-db, never Singer/FastSync execution. Supported routes are MySQL/MariaDB or PostgreSQL to PostgreSQL/Snowflake. `adapters.py` owns dialect behavior; `engine.py` execution; `repository.py` persistence; `runner.py` scheduling/remediation; `config.py`, `comparison.py`, and `coverage.py` own their named concerns; `runtime.py` generated connector JSON; `credentials.py` private keys. `import_config` persists definitions only after connector generation/discovery. Add database types at the adapter boundary and AST coverage for new dependency seams.
+- `cli/__init__.py`: commands/aliases/dispatch; `cli/pipelinewise.py`:
+  orchestration; `cli/commands.py`: Singer pipeline; `cli/config.py`: YAML
+  validation and generated JSON under
+  `$PIPELINEWISE_CONFIG_DIRECTORY/<target_id>/<tap_id>/` (default
+  `~/.pipelinewise`); `cli/constants.py`: connector types/mappings;
+  `cli/schemas/`: JSON Schemas; `cli/alert_handlers/`: Slack/VictorOps—extend
+  `BaseAlertHandler`. `cli/fastsync_capabilities.py` is the sole format-aware
+  FullSync/PartialSync policy: resolve every native/Iceberg direct route through
+  its operation-specific immutable registry and derive, never duplicate,
+  compatibility views.
+- `fastsync/`: native bulk sync. FullSync replaces tables for initial loads,
+  FULL_TABLE, and explicit `fast_sync`; PartialSync merges filtered ranges for
+  `partial_sync_table`/`sync_start_from`. FullSync supports `tap-mysql`
+  (MariaDB/MySQL), `tap-postgres`, and `tap-mongodb` to PostgreSQL/Snowflake;
+  PartialSync supports `tap-mysql`/`tap-postgres` to Snowflake. S3 CSV remains
+  Singer-only. Keep MySQL/PostgreSQL→Snowflake lifecycle in
+  `commons/rdbms_to_snowflake.py` and `partialsync/rdbms_to_snowflake.py`;
+  source modules only adapt source construction, mapping, and ordering. Put
+  other shared primitives in `commons/`, imported by `partialsync/`, and align
+  `docs/concept/fastsync.rst`.
+- `backend_db/`: PostgreSQL connections, transactions, Alembic. Required
+  `ddl_user`/`ddl_password` may equal app credentials. It cannot depend on
+  data-diff or replication orchestration; an AST test enforces this.
+- `data_diff/`: may use backend-db, never Singer/FastSync execution. Supports
+  MySQL/MariaDB or PostgreSQL → PostgreSQL/Snowflake. Ownership: `adapters.py`
+  dialects; `engine.py` execution; `repository.py` persistence; `runner.py`
+  scheduling/remediation; `config.py`, `comparison.py`, `coverage.py` their
+  named concerns; `runtime.py` generated connector JSON; `credentials.py`
+  private keys. `import_config` persists definitions only after connector
+  generation/discovery. Add database types at the adapter boundary and AST
+  coverage for new dependency seams.
 
 ## Backend schema
 
-- Primary keys use concise domain names such as `check_id`, `run_id`, and
-  `preflight_id`. Foreign keys reuse the referenced primary-key name. Add a role
-  prefix only when the relationship has a distinct meaning, such as
+- Primary keys use concise domain names (`check_id`, `run_id`, `preflight_id`);
+  foreign keys reuse them. Prefix a role only for distinct meaning, e.g.
   `rerun_of_run_id`, `evaluated_run_id`, or `blocking_run_id`.
-- Do not use PostgreSQL or Snowflake reserved or limited keywords as backend
-  table, column, constraint, or index identifiers. Prefer descriptive names
-  such as `is_current` and `trigger_type` even when quoting could make a keyword
-  legal in one database.
-- Data-diff table suffixes describe lifecycle: `_definitions` stores versioned
-  configuration, `_attempts` stores executions, `_results` stores execution
-  detail, `_state` stores mutable materialized projections, and `_events` or
-  `_log` stores append-only history.
+- Backend table/column/constraint/index identifiers must avoid PostgreSQL and
+  Snowflake reserved or limited keywords. Prefer descriptive `is_current` and
+  `trigger_type` even if quoting makes a keyword legal in one database.
+- Data-diff suffixes encode lifecycle: `_definitions` versioned config,
+  `_attempts` executions, `_results` execution detail, `_state` mutable
+  materialized projections, `_events`/`_log` append-only history.
 - `public` is fixed across Alembic, runtime, tests, ERDs, and docs. Changing it requires a forward migration plan and synchronized updates.
-- Each `NNN_*.py` revision needs a matching `NNN_schema.erd.mmd` Mermaid ERD of the resulting `public` schema; preserve old ERDs and show foreign-key relationships on the tables diagram.
-- Migration 001 originally shipped in PipelineWise `0.78.0`. Its `0.82.0`
-  schema finalization is an explicitly approved exception requiring coordinated
-  manual updates to existing databases. Treat migration 001 as immutable after
-  `0.82.0`; make every later schema change in a new forward migration with a
-  matching ERD.
-- History is append-oriented: preflight logs, results, and watermark events are
-  inserts; definitions, run attempts, run-slot state, and watermark state have
-  controlled updates. The database does not enforce immutability.
+- Every `NNN_*.py` revision needs a matching `NNN_schema.erd.mmd` Mermaid ERD
+  of the resulting `public` schema. Preserve old ERDs; show FKs on the tables diagram.
+- Migration 001 shipped in `0.78.0`; its `0.82.0` schema finalization is an
+  approved exception requiring coordinated manual updates to existing
+  databases. It is immutable after `0.82.0`; all later changes need a new
+  forward migration and matching ERD.
+- History is append-oriented: insert preflight logs, results, and watermark
+  events; control updates to definitions, run attempts, run-slot state, and
+  watermark state. The database does not enforce immutability.
 
 ## Runtime and data-diff constraints
 
 - Soft delete (`hard_delete: false`, `_SDC_DELETED_AT`) is deprecated. Preserve
-  compatibility, but add no features/docs and do not restore data-diff
-  `exclude_soft_deleted`; new taps use `hard_delete: true`.
-- Dev MySQL requires TLS; use `ssl={'': True}`. PyMySQL interpolates bound SQL,
-  so double literal tokens, e.g. `DATE_FORMAT(t, '%%Y')`.
+  compatibility but add no features/docs, do not restore data-diff
+  `exclude_soft_deleted`, and use `hard_delete: true` for new taps.
+- Dev MySQL requires TLS (`ssl={'': True}`). PyMySQL interpolates bound SQL, so
+  double literal tokens, e.g. `DATE_FORMAT(t, '%%Y')`.
 - PostgreSQL `reltuples == 0` after ANALYZE-then-load does not prove emptiness;
   partitioned parents can duplicate child estimates. Sum leaf partitions.
 - SIGTERM normally does not raise `SystemExit`; durable handling needs an
@@ -48,78 +72,71 @@ Read root `AGENTS.md` first; also use scoped connector, test, E2E, and docs guid
 - Separate backend app roles receive schema/sequence access plus `SELECT`,
   `INSERT`, and `UPDATE`, but no `DELETE`/DDL. A shared app/DDL identity removes
   that separation intentionally.
-- Source preflight checks estimates and timestamp-index shape, not exact counts
-  or actual index use; bound execution with a statement timeout. Treat
-  `min_key`/`max_key` values in `dd_run_results` as sensitive and avoid casual
-  logging.
+- Source preflight checks estimates and timestamp-index shape—not exact counts
+  or actual index use—and requires a statement timeout. Treat `min_key`/`max_key`
+  values in `dd_run_results` as sensitive; avoid casual logging.
 
 ## Snowflake and Iceberg contract
 
-- PipelineWise is the sole automated writer. External reads are allowed; DBA
-  writes/DDL require a maintenance window with affected replication stopped and
-  no active recovery. Every replicated table and column must originate from
-  FullSync, PartialSync, target-snowflake, or the supported converter; never
-  adopt arbitrary external schemas or add replicated objects during repair.
-- Tap-level `target_table_format: iceberg` plus integer `iceberg_version: 3` is
-  the sole managed-Iceberg creation contract; omitted/native creates native.
-  Retain both settings for Singer handover and evolution. Route compatible
-  Singer taps through target-snowflake and MySQL/PostgreSQL FastSync through the
-  shared publisher; keep native `SWAP WITH`. Every v3 tap requires
-  `hard_delete: true`; only FastSync-capable MySQL/PostgreSQL also require
-  `data_flattening_max_level: 0` (preserve Singer-only defaults such as
-  Salesforce level 10).
+- PipelineWise is the sole automated writer; external reads are allowed. DBA
+  writes/DDL require a maintenance window, stopped affected replication, and no
+  active recovery. Replicated tables/columns must originate via FullSync,
+  PartialSync, target-snowflake, or the supported converter—never arbitrary
+  external schemas or repair-added objects. Before resuming, exceptional repair
+  must preserve v3, copy-on-write, width, metadata, and recovery invariants.
+- Only tap-level `target_table_format: iceberg` plus integer
+  `iceberg_version: 3` creates managed Iceberg; omitted/native creates native.
+  Retain both through Singer
+  handover/evolution. Route compatible Singer taps through target-snowflake and
+  MySQL/PostgreSQL FastSync through the shared publisher; retain native
+  `SWAP WITH`. All v3 taps need `hard_delete: true`; only FastSync-capable
+  MySQL/PostgreSQL also need `data_flattening_max_level: 0` (keep Singer-only
+  defaults such as Salesforce level 10).
 - Carry `iceberg_version` through tap/generated config, publication/recovery,
-  and conversion. Only v3 is supported; reject all others before mutation.
-  Future versions require explicit branches and tests.
-- `snowflake_iceberg_versions.py` owns each version's format, canonical types,
-  existing-table checks, semantic options, and copy-on-write level through
-  executable hooks. Keep the dependency-free fixture aligned with
-  target-snowflake CREATE, ADD, metadata, and transport behavior; never let a
-  new registry entry inherit v3 implicitly.
-- Managed v3 requires table-level
-  `ICEBERG_MERGE_ON_READ_BEHAVIOR = 'DISABLED'` in creation, replacement, and
-  converter DDL and before writes. Never use deprecated
-  `ENABLE_ICEBERG_MERGE_ON_READ`.
-- Create every managed v3 table with `TARGET_FILE_SIZE = 'AUTO'` and
-  `STORAGE_SERIALIZATION_POLICY = 'COMPATIBLE'`; keep FastSync, conversion,
+  and conversion; reject non-v3 before mutation. Future versions need explicit
+  branches/tests. Through executable hooks, `snowflake_iceberg_versions.py`
+  owns format, canonical types, existing-table checks, semantic options, and
+  copy-on-write level. Align its dependency-free fixture with target-snowflake
+  CREATE/ADD/metadata/transport; new registry entries cannot inherit v3 implicitly.
+- All managed-v3 creation, replacement, converter DDL, and pre-write paths need
+  table-level `ICEBERG_MERGE_ON_READ_BEHAVIOR = 'DISABLED'`; never use deprecated
+  `ENABLE_ICEBERG_MERGE_ON_READ`. Creation also needs
+  `TARGET_FILE_SIZE = 'AUTO'` and
+  `STORAGE_SERIALIZATION_POLICY = 'COMPATIBLE'`. Keep FastSync, conversion,
   target-snowflake, and the dependency-free contract fixture aligned.
 - Map FastSync string-like/fallback MySQL, MariaDB, and PostgreSQL types to
-  `VARCHAR(134217728)`. Auto-widen compatible narrow native PartialSync targets
-  before DML. target-snowflake uses that width for new native/v3 Singer strings,
-  leaves compatible existing native strings unchanged, and requires exact width
-  on existing v3 strings without implicit widening.
-- Exceptional DBA repair must preserve v3, copy-on-write, width, metadata, and
-  recovery invariants before replication resumes.
-- Key recovery by stable source stream, index the active attempt by physical
-  target, and hold both locks throughout. Reject source, target, staging, role,
-  transformation, or boundary drift.
-- `RecoveryCoordinator` owns the target runtime root, store, ordered locks,
-  pointers, persistence, transitions, completion, and abort. Use typed payloads;
-  legacy `context` is only a serialized compatibility projection. Reject invalid
-  transitions. After validating retained staging keys, ambiguous PartialSync
-  MERGE replay rotates submission identity, clears query evidence, durably
-  returns to `staged`, then replans.
+  `VARCHAR(134217728)`; before DML, auto-widen compatible narrow native
+  PartialSync targets. target-snowflake uses that width for new native/v3 Singer
+  strings, preserves compatible existing native widths, and requires exact
+  existing-v3 width without implicit widening.
+- Key recovery by stable source stream, index active attempts by physical
+  target, and hold both locks throughout; reject source, target, staging, role,
+  transformation, or boundary drift. `RecoveryCoordinator` owns target runtime
+  root, store, ordered locks, pointers, persistence, transitions, completion,
+  and abort. Use typed payloads; legacy `context` is only a serialized
+  compatibility projection. Reject invalid transitions. After retained-stage
+  key validation, ambiguous PartialSync MERGE replay rotates submission
+  identity, clears query evidence, durably returns to `staged`, then replans.
 - Reuse `SnowflakeSqlClient` for authentication/query/transactions and
-  `SnowflakeTableInspector` for discovery. Compose publication, finalization,
-  conversion-evidence, and `SnowflakeConversionFinalizationValidator`
-  explicitly; keep the validator in
-  `snowflake_iceberg_conversion_recovery.py`. Do not restore mixin inheritance,
+  `SnowflakeTableInspector` for discovery. Explicitly compose publication,
+  finalization, conversion evidence, and
+  `SnowflakeConversionFinalizationValidator`, kept in
+  `snowflake_iceberg_conversion_recovery.py`; never restore mixin inheritance,
   dynamic binding, or duplicate catalog inspection.
 - Advance state only after publication, metadata, grants, and cleanup. Persist
-  registered finalization actions only with exact Boolean `true`; require
-  grants, S3 cleanup, staging cleanup, and replacement metadata restoration.
-  Require a serialized dictionary `source_bookmark`, even empty, and reject
-  malformed recovery. PartialSync requires a PK and rejects transformed-stage
-  NULL or duplicate key groups before publication.
-- Content mismatches may report counts and aggregate fingerprints, never source
-  values/samples. Treat bounded query-history visibility/lookup failures as
-  retryable ambiguity: preserve state, manifest, and staging; instruct an
-  unchanged retry; reserve tracebacks for unexpected errors.
+  registered finalization actions only as exact Boolean `true`; require grants,
+  S3/staging cleanup, and replacement metadata restoration. Require a serialized
+  dictionary `source_bookmark`, even empty, and reject malformed recovery.
+  PartialSync needs a PK and rejects transformed-stage NULL or duplicate-key
+  groups before publication.
+- Content mismatches may expose counts/aggregate fingerprints, never source
+  values/samples. Bounded query-history visibility/lookup failures are retryable
+  ambiguity: preserve state/manifest/staging, instruct an unchanged retry, and
+  reserve tracebacks for unexpected errors.
 - Guarded replacement/conversion requires the owning account role; reject
-  database-role ownership and unsafe dependencies or metadata.
-- Conversion remains target-only and fidelity-first. Exclude external writers
-  for every copy; `eventual=iceberg` also needs a reader/writer outage. Retain
-  the native backup and recover through the manifest. Copy and validate the
-  complete row multiset—including duplicate keys and representable flaws—without
-  filtering, repair, or deduplication; fail before cutover if v3 cannot represent
-  it exactly.
+  database-role ownership and unsafe dependencies/metadata. Conversion is
+  target-only and fidelity-first: exclude external writers for every copy;
+  `eventual=iceberg` also needs a reader/writer outage. Retain the native backup
+  and recover through the manifest. Copy/validate the whole row multiset,
+  including duplicate keys and representable flaws, without filtering, repair,
+  or deduplication; fail before cutover if v3 cannot represent it exactly.

--- a/pipelinewise/backend_db/migrations/versions/002_rename_watermark_columns.py
+++ b/pipelinewise/backend_db/migrations/versions/002_rename_watermark_columns.py
@@ -1,0 +1,123 @@
+"""rename watermark state and event columns
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-09-07
+"""
+
+from alembic import op
+
+revision = "002"
+down_revision = "001"
+branch_labels = None
+depends_on = None
+
+SCHEMA = "public"
+STATE_TABLE = "dd_watermark_state"
+EVENTS_TABLE = "dd_watermark_events"
+
+STATE_COLUMN_RENAMES = (
+    ("coverage_start", "verified_start"),
+    ("verified_through", "verified_end"),
+    ("max_observed_end", "furthest_observed_end"),
+    ("coverage_status", "verified_status"),
+    ("evaluated_run_id", "last_evaluated_run_id"),
+)
+
+EVENT_COLUMN_RENAMES = (
+    ("coverage_start", "verified_start"),
+    ("previous_verified_through", "previous_verified_end"),
+    ("verified_through", "verified_end"),
+    ("max_observed_end", "furthest_observed_end"),
+    ("coverage_status", "verified_status"),
+)
+
+STATE_CONSTRAINT_RENAMES = (
+    (
+        "dd_watermark_state_coverage_status_check",
+        "dd_watermark_state_verified_status_check",
+    ),
+    (
+        "dd_watermark_state_evaluated_run_id_fkey",
+        "dd_watermark_state_last_evaluated_run_id_fkey",
+    ),
+)
+
+EVENT_CONSTRAINT_RENAMES = (
+    (
+        "dd_watermark_events_coverage_status_check",
+        "dd_watermark_events_verified_status_check",
+    ),
+)
+
+
+def _rename_columns(table, renames):
+    for old_name, new_name in renames:
+        op.execute(
+            f"ALTER TABLE {SCHEMA}.{table} "
+            f"RENAME COLUMN {old_name} TO {new_name}"
+        )
+
+
+def _rename_constraints(table, renames):
+    for old_name, new_name in renames:
+        op.execute(
+            f"ALTER TABLE {SCHEMA}.{table} "
+            f"RENAME CONSTRAINT {old_name} TO {new_name}"
+        )
+
+
+def upgrade():
+    _rename_columns(STATE_TABLE, STATE_COLUMN_RENAMES)
+    _rename_columns(EVENTS_TABLE, EVENT_COLUMN_RENAMES)
+    _rename_constraints(STATE_TABLE, STATE_CONSTRAINT_RENAMES)
+    _rename_constraints(EVENTS_TABLE, EVENT_CONSTRAINT_RENAMES)
+    op.execute(
+        f"COMMENT ON TABLE {SCHEMA}.{STATE_TABLE} IS "
+        "'Mutable current verified interval and furthest observed window "
+        "for each check definition'"
+    )
+    op.execute(
+        f"COMMENT ON TABLE {SCHEMA}.{EVENTS_TABLE} IS "
+        "'Append-only history of verified intervals and furthest observed "
+        "window transitions'"
+    )
+
+
+def downgrade():
+    _rename_constraints(
+        EVENTS_TABLE,
+        (
+            (new_name, old_name)
+            for old_name, new_name in reversed(EVENT_CONSTRAINT_RENAMES)
+        ),
+    )
+    _rename_constraints(
+        STATE_TABLE,
+        (
+            (new_name, old_name)
+            for old_name, new_name in reversed(STATE_CONSTRAINT_RENAMES)
+        ),
+    )
+    _rename_columns(
+        EVENTS_TABLE,
+        (
+            (new_name, old_name)
+            for old_name, new_name in reversed(EVENT_COLUMN_RENAMES)
+        ),
+    )
+    _rename_columns(
+        STATE_TABLE,
+        (
+            (new_name, old_name)
+            for old_name, new_name in reversed(STATE_COLUMN_RENAMES)
+        ),
+    )
+    op.execute(
+        f"COMMENT ON TABLE {SCHEMA}.{STATE_TABLE} IS "
+        "'Mutable current verified-through watermark for each check definition'"
+    )
+    op.execute(
+        f"COMMENT ON TABLE {SCHEMA}.{EVENTS_TABLE} IS "
+        "'Append-only history of verified-through watermark transitions'"
+    )

--- a/pipelinewise/backend_db/migrations/versions/002_schema.erd.mmd
+++ b/pipelinewise/backend_db/migrations/versions/002_schema.erd.mmd
@@ -1,0 +1,128 @@
+%%{init: {"er": {"diagramPadding": 8, "entityPadding": 8}}}%%
+erDiagram
+    direction LR
+    dd_check_definitions ||--o{ dd_preflight_log : check_id
+    dd_check_definitions ||--o{ dd_run_attempts : check_id
+    dd_preflight_log o|--o{ dd_run_attempts : preflight_id
+    dd_run_attempts o|--o{ dd_run_attempts : rerun_of_run_id
+    dd_run_attempts ||--o{ dd_run_results : run_id
+    dd_check_definitions ||--o{ dd_run_slot_state : check_id
+    dd_run_attempts ||--o| dd_run_slot_state : run_id
+    dd_check_definitions ||--o{ dd_watermark_events : check_id
+    dd_run_attempts ||--o| dd_watermark_events : evaluated_run_id
+    dd_run_attempts o|--o{ dd_watermark_events : blocking_run_id
+    dd_check_definitions ||--o| dd_watermark_state : check_id
+    dd_run_attempts ||--o{ dd_watermark_state : last_evaluated_run_id
+    dd_run_attempts o|--o{ dd_watermark_state : blocking_run_id
+
+    dd_check_definitions["dd_check_definitions<br/>Versioned data-diff check definitions<br/>imported from YAML configuration"] {
+        UUID check_id PK
+        TEXT full_check_name "UQ with revision; UQ when is_current"
+        INTEGER revision "UQ with full_check_name"
+        CHAR(64) config_hash
+        JSONB canonical_config
+        TEXT target_id
+        TEXT tap_id
+        TEXT source_type
+        TEXT target_type
+        TEXT source_database
+        TEXT target_database
+        TEXT source_schema
+        TEXT source_table
+        TEXT target_schema
+        TEXT target_table
+        TEXT source_key_column
+        TEXT target_key_column
+        TEXT source_timestamp_column
+        TEXT target_timestamp_column
+        JSONB checks
+        TEXT frequency
+        BIGINT window_start_seconds "greater than 0"
+        BIGINT window_end_seconds "at least 0"
+        BIGINT statement_timeout_seconds "greater than 0"
+        BOOLEAN is_current
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ superseded_at "nullable"
+    }
+
+    dd_preflight_log["dd_preflight_log<br/>Append-only preflight evidence and<br/>early validation errors for run attempts"] {
+        UUID preflight_id PK
+        UUID check_id FK
+        TEXT status "PASS, BLOCKED, or ERROR"
+        TIMESTAMPTZ checked_at
+        CHAR(64) query_fingerprint
+        JSONB index_metadata
+        JSONB findings
+        TEXT error "nullable"
+        BIGINT table_rows "nullable"
+        BIGINT row_limit "nullable"
+        BOOLEAN has_leading_index "nullable"
+    }
+
+    dd_run_attempts["dd_run_attempts<br/>Execution attempts updated from RUNNING<br/>to a terminal outcome"] {
+        UUID run_id PK
+        UUID check_id FK
+        TIMESTAMPTZ scheduled_for "UQ with check_id and attempt"
+        TIMESTAMPTZ window_start "before window_end"
+        TIMESTAMPTZ window_end
+        INTEGER attempt "UQ with check_id and scheduled_for"
+        TEXT trigger_type "SCHEDULED, MANUAL, RETRY, or REMEDIATION"
+        TEXT status "RUNNING, PASS, FAIL, or ERROR"
+        UUID rerun_of_run_id FK "nullable self-reference"
+        TEXT remediation_reference "nullable"
+        UUID preflight_id FK "nullable"
+        TIMESTAMPTZ started_at
+        TIMESTAMPTZ finished_at "nullable"
+        TEXT error "nullable"
+    }
+
+    dd_run_results["dd_run_results<br/>Append-only per-check-type outcomes<br/>for completed run attempts"] {
+        UUID run_id PK, FK
+        TEXT check_type PK
+        TEXT status "PASS, FAIL, or ERROR"
+        JSONB source_value "nullable"
+        JSONB target_value "nullable"
+        DOUBLE_PRECISION source_query_seconds "nullable"
+        DOUBLE_PRECISION target_query_seconds "nullable"
+        TEXT error "nullable"
+    }
+
+    dd_run_slot_state["dd_run_slot_state<br/>Mutable selected terminal attempt for<br/>each check and scheduled slot"] {
+        UUID check_id PK, FK
+        TIMESTAMPTZ scheduled_for PK
+        UUID run_id FK, UK
+        INTEGER attempt "greater than 0"
+        TIMESTAMPTZ window_start "before window_end"
+        TIMESTAMPTZ window_end
+        TEXT status "PASS, FAIL, or ERROR"
+    }
+
+    dd_watermark_state["dd_watermark_state<br/>Mutable current verified interval and furthest<br/>observed window for each check definition"] {
+        UUID check_id PK, FK
+        TIMESTAMPTZ verified_start "at most verified_end"
+        TIMESTAMPTZ verified_end "at most furthest_observed_end"
+        TIMESTAMPTZ furthest_observed_end
+        TEXT verified_status "CONTIGUOUS or BLOCKED"
+        UUID blocking_run_id FK "nullable"
+        UUID last_evaluated_run_id FK
+        TEXT event_type "INITIALIZE, ADVANCE, INVALIDATE, BLOCK, or CONFIRM"
+        BIGINT state_version "greater than 0"
+        TIMESTAMPTZ updated_at
+        TEXT reason
+    }
+
+    dd_watermark_events["dd_watermark_events<br/>Append-only history of verified intervals<br/>and furthest observed window transitions"] {
+        UUID watermark_event_id PK
+        BIGSERIAL event_sequence UK
+        UUID check_id FK
+        UUID evaluated_run_id FK, UK
+        TEXT event_type "INITIALIZE, ADVANCE, INVALIDATE, BLOCK, or CONFIRM"
+        TIMESTAMPTZ verified_start "at most verified_end"
+        TIMESTAMPTZ previous_verified_end "nullable"
+        TIMESTAMPTZ verified_end "at most furthest_observed_end"
+        TIMESTAMPTZ furthest_observed_end
+        TEXT verified_status "CONTIGUOUS or BLOCKED"
+        UUID blocking_run_id FK "nullable"
+        TIMESTAMPTZ recorded_at
+        TEXT reason
+    }

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -1925,9 +1925,9 @@ class PipelineWise:
                 check['frequency'],
                 check['window_start_seconds'],
                 check['window_end_seconds'],
-                check.get('coverage_status') or '',
-                check['verified_through'].isoformat()
-                if check.get('verified_through') else '',
+                check.get('verified_status') or '',
+                check['verified_end'].isoformat()
+                if check.get('verified_end') else '',
             ]
             for check in checks
         ]
@@ -1938,7 +1938,7 @@ class PipelineWise:
                     'Check ID', 'Rev', 'Current', 'Target',
                     'Tap', 'Source table', 'Checks', 'Key', 'Timestamp',
                     'Compare columns', 'Frequency', 'Window start (s)',
-                    'Window end (s)', 'Coverage', 'Verified through',
+                    'Window end (s)', 'Verified status', 'Verified end',
                 ],
             )
         )

--- a/pipelinewise/data_diff/coverage.py
+++ b/pipelinewise/data_diff/coverage.py
@@ -23,9 +23,9 @@ def calculate_coverage(runs: list, *, data_checks_enabled: bool = True) -> dict:
     if not effective:
         return {}
 
-    coverage_start = min(run["window_start"] for run in effective)
-    max_observed_end = max(run["window_end"] for run in effective)
-    cursor = coverage_start
+    verified_start = min(run["window_start"] for run in effective)
+    furthest_observed_end = max(run["window_end"] for run in effective)
+    cursor = verified_start
     blocking_runs = sorted(
         (run for run in effective if run["status"] != "PASS"),
         key=lambda item: (item["window_start"], item["window_end"]),
@@ -49,9 +49,11 @@ def calculate_coverage(runs: list, *, data_checks_enabled: bool = True) -> dict:
     blocking_run = None
     if barrier is not None and barrier <= cursor:
         blocking_run = blocking_runs[0]
-    status = "CONTIGUOUS" if cursor >= max_observed_end else "BLOCKED"
+    verified_status = (
+        "CONTIGUOUS" if cursor >= furthest_observed_end else "BLOCKED"
+    )
     if not data_checks_enabled:
-        status = "BLOCKED"
+        verified_status = "BLOCKED"
 
     if not data_checks_enabled:
         reason = "Metadata-only checks cannot advance table coverage"
@@ -60,16 +62,16 @@ def calculate_coverage(runs: list, *, data_checks_enabled: bool = True) -> dict:
             f"Run {blocking_run['run_id']} has status {blocking_run['status']} at the "
             "coverage boundary"
         )
-    elif status == "BLOCKED":
+    elif verified_status == "BLOCKED":
         reason = "No successful run covers the next timestamp interval"
     else:
         reason = "All observed timestamp intervals are covered by successful runs"
 
     return {
-        "coverage_start": coverage_start,
-        "verified_through": cursor,
-        "max_observed_end": max_observed_end,
-        "coverage_status": status,
+        "verified_start": verified_start,
+        "verified_end": cursor,
+        "furthest_observed_end": furthest_observed_end,
+        "verified_status": verified_status,
         "blocking_run_id": blocking_run["run_id"] if blocking_run else None,
         "reason": reason,
     }
@@ -84,55 +86,57 @@ def advance_coverage(previous: dict, run: dict, *, data_checks_enabled: bool = T
     if not previous:
         return calculate_coverage([run], data_checks_enabled=data_checks_enabled)
 
-    coverage_start = previous["coverage_start"]
-    verified_through = previous["verified_through"]
-    max_observed_end = max(previous["max_observed_end"], run["window_end"])
+    verified_start = previous["verified_start"]
+    verified_end = previous["verified_end"]
+    furthest_observed_end = max(
+        previous["furthest_observed_end"], run["window_end"]
+    )
     blocking_run_id = previous.get("blocking_run_id")
 
     if not data_checks_enabled:
         return {
-            "coverage_start": coverage_start,
-            "verified_through": verified_through,
-            "max_observed_end": max_observed_end,
-            "coverage_status": "BLOCKED",
+            "verified_start": verified_start,
+            "verified_end": verified_end,
+            "furthest_observed_end": furthest_observed_end,
+            "verified_status": "BLOCKED",
             "blocking_run_id": None,
             "reason": "Metadata-only checks cannot advance table coverage",
         }
 
-    if previous["coverage_status"] == "BLOCKED":
+    if previous["verified_status"] == "BLOCKED":
         return {
-            "coverage_start": coverage_start,
-            "verified_through": verified_through,
-            "max_observed_end": max_observed_end,
-            "coverage_status": "BLOCKED",
+            "verified_start": verified_start,
+            "verified_end": verified_end,
+            "furthest_observed_end": furthest_observed_end,
+            "verified_status": "BLOCKED",
             "blocking_run_id": blocking_run_id,
             "reason": previous["reason"],
         }
 
     if run["status"] == "PASS":
-        if run["window_start"] <= verified_through:
-            verified_through = max(verified_through, run["window_end"])
-    elif run["window_start"] <= verified_through:
-        verified_through = run["window_start"]
+        if run["window_start"] <= verified_end:
+            verified_end = max(verified_end, run["window_end"])
+    elif run["window_start"] <= verified_end:
+        verified_end = run["window_start"]
         blocking_run_id = run["run_id"]
 
-    coverage_status = (
-        "CONTIGUOUS" if verified_through >= max_observed_end else "BLOCKED"
+    verified_status = (
+        "CONTIGUOUS" if verified_end >= furthest_observed_end else "BLOCKED"
     )
     if blocking_run_id:
         reason = (
             f"Run {blocking_run_id} has status {run['status']} at the coverage boundary"
         )
-    elif coverage_status == "BLOCKED":
+    elif verified_status == "BLOCKED":
         reason = "No successful run covers the next timestamp interval"
     else:
         reason = "All observed timestamp intervals are covered by successful runs"
 
     return {
-        "coverage_start": coverage_start,
-        "verified_through": verified_through,
-        "max_observed_end": max_observed_end,
-        "coverage_status": coverage_status,
+        "verified_start": verified_start,
+        "verified_end": verified_end,
+        "furthest_observed_end": furthest_observed_end,
+        "verified_status": verified_status,
         "blocking_run_id": blocking_run_id,
         "reason": reason,
     }
@@ -142,12 +146,12 @@ def coverage_event_type(previous: dict, current: dict) -> str:
     """Describe how a newly evaluated run changed the coverage watermark."""
     if not previous:
         return "INITIALIZE"
-    old_value = previous["verified_through"]
-    new_value = current["verified_through"]
+    old_value = previous["verified_end"]
+    new_value = current["verified_end"]
     if new_value > old_value:
         return "ADVANCE"
     if new_value < old_value:
         return "INVALIDATE"
-    if current["coverage_status"] == "BLOCKED":
+    if current["verified_status"] == "BLOCKED":
         return "BLOCK"
     return "CONFIRM"

--- a/pipelinewise/data_diff/repository.py
+++ b/pipelinewise/data_diff/repository.py
@@ -242,11 +242,12 @@ class DataDiffRepository:
             cursor.execute(
                 f"""
                 SELECT checks.*,
-                       coverage.coverage_start, coverage.verified_through,
-                       coverage.max_observed_end, coverage.coverage_status,
+                       coverage.verified_start, coverage.verified_end,
+                       coverage.furthest_observed_end,
+                       coverage.verified_status,
                        coverage.blocking_run_id,
                        coverage.updated_at AS verified_at,
-                       coverage.evaluated_run_id AS coverage_run_id,
+                       coverage.last_evaluated_run_id,
                        coverage.reason AS coverage_reason
                   FROM {SCHEMA}.dd_check_definitions checks
                   LEFT JOIN {SCHEMA}.dd_watermark_state coverage
@@ -277,11 +278,12 @@ class DataDiffRepository:
             cursor.execute(
                 f"""
                 SELECT checks.*,
-                       coverage.coverage_start, coverage.verified_through,
-                       coverage.max_observed_end, coverage.coverage_status,
+                       coverage.verified_start, coverage.verified_end,
+                       coverage.furthest_observed_end,
+                       coverage.verified_status,
                        coverage.blocking_run_id,
                        coverage.updated_at AS verified_at,
-                       coverage.evaluated_run_id AS coverage_run_id,
+                       coverage.last_evaluated_run_id,
                        coverage.reason AS coverage_reason
                   FROM {SCHEMA}.dd_check_definitions checks
                   LEFT JOIN {SCHEMA}.dd_watermark_state coverage
@@ -553,8 +555,8 @@ class DataDiffRepository:
             coverage = {
                 key: previous[key]
                 for key in (
-                    "coverage_start", "verified_through", "max_observed_end",
-                    "coverage_status", "blocking_run_id", "reason",
+                    "verified_start", "verified_end", "furthest_observed_end",
+                    "verified_status", "blocking_run_id", "reason",
                 )
             }
         else:
@@ -587,7 +589,10 @@ class DataDiffRepository:
     def _watermark_state_for_update(cursor, check_id):
         cursor.execute(
             f"""
-            SELECT *
+            SELECT check_id, verified_start, verified_end,
+                   furthest_observed_end, verified_status, blocking_run_id,
+                   last_evaluated_run_id, event_type, state_version,
+                   updated_at, reason
               FROM {SCHEMA}.dd_watermark_state
              WHERE check_id = %s
              FOR UPDATE
@@ -677,26 +682,26 @@ class DataDiffRepository:
         cursor.execute(
             f"""
             INSERT INTO {SCHEMA}.dd_watermark_state(
-                check_id, coverage_start, verified_through, max_observed_end,
-                coverage_status, blocking_run_id, evaluated_run_id, event_type,
-                state_version, updated_at, reason
+                check_id, verified_start, verified_end, furthest_observed_end,
+                verified_status, blocking_run_id, last_evaluated_run_id,
+                event_type, state_version, updated_at, reason
             ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (check_id) DO UPDATE
-               SET coverage_start = EXCLUDED.coverage_start,
-                   verified_through = EXCLUDED.verified_through,
-                   max_observed_end = EXCLUDED.max_observed_end,
-                   coverage_status = EXCLUDED.coverage_status,
+               SET verified_start = EXCLUDED.verified_start,
+                   verified_end = EXCLUDED.verified_end,
+                   furthest_observed_end = EXCLUDED.furthest_observed_end,
+                   verified_status = EXCLUDED.verified_status,
                    blocking_run_id = EXCLUDED.blocking_run_id,
-                   evaluated_run_id = EXCLUDED.evaluated_run_id,
+                   last_evaluated_run_id = EXCLUDED.last_evaluated_run_id,
                    event_type = EXCLUDED.event_type,
                    state_version = EXCLUDED.state_version,
                    updated_at = EXCLUDED.updated_at,
                    reason = EXCLUDED.reason
             """,
             (
-                definition["check_id"], coverage["coverage_start"],
-                coverage["verified_through"], coverage["max_observed_end"],
-                coverage["coverage_status"], coverage["blocking_run_id"],
+                definition["check_id"], coverage["verified_start"],
+                coverage["verified_end"], coverage["furthest_observed_end"],
+                coverage["verified_status"], coverage["blocking_run_id"],
                 definition["run_id"], event_type, state_version, recorded_at,
                 coverage["reason"],
             ),
@@ -715,17 +720,17 @@ class DataDiffRepository:
             f"""
             INSERT INTO {SCHEMA}.dd_watermark_events(
                 watermark_event_id, check_id, evaluated_run_id, event_type,
-                coverage_start, previous_verified_through, verified_through,
-                max_observed_end, coverage_status, blocking_run_id,
+                verified_start, previous_verified_end, verified_end,
+                furthest_observed_end, verified_status, blocking_run_id,
                 recorded_at, reason
             ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 uuid.uuid4(), definition["check_id"], definition["run_id"],
-                event_type, coverage["coverage_start"],
-                previous["verified_through"] if previous else None,
-                coverage["verified_through"], coverage["max_observed_end"],
-                coverage["coverage_status"], coverage["blocking_run_id"],
+                event_type, coverage["verified_start"],
+                previous["verified_end"] if previous else None,
+                coverage["verified_end"], coverage["furthest_observed_end"],
+                coverage["verified_status"], coverage["blocking_run_id"],
                 recorded_at, coverage["reason"],
             ),
         )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.12.*',
-      version='0.83.1',
+      version='0.84.0',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',

--- a/singer-connectors/AGENTS.md
+++ b/singer-connectors/AGENTS.md
@@ -1,42 +1,44 @@
 # Singer Connector Instructions
 
-Read root `AGENTS.md` and any relevant implementation, test, E2E, or docs guide.
+Read root `AGENTS.md` and relevant implementation, test, E2E, and docs guides.
 
 ## Environments and CI
 
-This is vendored source, not submodules; root lint/unit gates do not inspect it.
-Prefer the ready `pipelinewise` container and report host fallbacks.
+These are vendored sources, not submodules, and root lint/unit gates exclude
+them. Prefer the ready `pipelinewise` container; report host fallbacks.
 
-Connector CI installs all connectors and runs Python 3.12 unit gates for
-tap-mysql (`make unit_test_cov`, 47%), tap-postgres (`make unit_test_cov`, 58%),
-and target-snowflake (`make unit_test`, 67%). It does not run integration;
-behavior changes need local connector tests and an available E2E route.
+Connector CI installs all connectors and runs Python 3.12 units for tap-mysql
+(`make unit_test_cov`, 47%), tap-postgres (`make unit_test_cov`, 58%), and
+target-snowflake (`make unit_test`, 67%). It excludes integration; behavior
+changes need local connector tests and an available E2E route.
 
 Root `make connectors -e pw_connector=<name>` creates runtime
-`.virtualenvs/<name>/`; connector Makefiles often use `./venv/` for tests. Never
-mix PipelineWise, runtime-connector, connector-test, host, or container
-interpreters.
+`.virtualenvs/<name>/`; connector Makefiles often test in `./venv/`. Never mix
+PipelineWise, runtime-connector, connector-test, host, or container interpreters.
 
 ## Validation
 
-The owning Makefile is authoritative. Run its environment, Pylint, unit,
-integration, and coverage targets where present; never lower thresholds.
-Integration may need containers or credentials.
+The owning Makefile is authoritative. Run available environment, Pylint, unit,
+integration, and coverage targets without lowering thresholds; integration may
+need containers or credentials.
 
 - Most use `venv`, `pylint`, `unit_test`, and `integration_test`; inspect the
   Makefile for variants.
-- PostgreSQL also requires `integration_test_cov` >=63 and `total_cov` >=85; MySQL uses Pytest for unit and integration tests.
-- No Makefile: GitHub (`tests/`), Zendesk (Nose), and transform-field (direct suites and Singer E2E). Jira is an external pin without local source/tests; Salesforce has a Makefile but no tests. GitHub, Jira, and Zendesk lack repository E2E.
+- PostgreSQL also requires `integration_test_cov` >=63 and `total_cov` >=85;
+  MySQL uses Pytest for unit and integration tests.
+- Without Makefiles: GitHub uses `tests/`, Zendesk uses Nose, and
+  transform-field uses direct suites and Singer E2E. Jira is an external pin
+  without local source/tests; Salesforce has a Makefile but no tests. GitHub,
+  Jira, and Zendesk lack repository E2E.
 
 Report unavailable or skipped integration/E2E coverage as unverified.
 
 ### Target-snowflake integration tests in dev-project
 
 Run credentialed target-snowflake integration only in the ready `pipelinewise`
-container, never beside another Snowflake group. The suite drops
-`TARGET_SNOWFLAKE_SCHEMA`; dedicate that schema. After changing
-`dev-project/.env`, recreate the CLI container and wait for its current-start
-readiness marker:
+container and never beside another Snowflake group. The suite drops
+`TARGET_SNOWFLAKE_SCHEMA`; dedicate it. After changing `dev-project/.env`,
+recreate the CLI container and await its current-start readiness marker:
 
 ```bash
 docker compose -f dev-project/docker-compose.yml up -d --force-recreate --no-deps pipelinewise
@@ -44,9 +46,9 @@ docker logs --follow pipelinewise
 ```
 
 Require `PipelineWise Dev environment is ready in Docker container(s).`. The
-CSV suite needs standard Snowflake/S3 variables plus
-`TARGET_SNOWFLAKE_SCHEMA` and `TARGET_SNOWFLAKE_FILE_FORMAT_CSV` (which may
-reuse `TARGET_SNOWFLAKE_FILE_FORMAT`); verify the private key is readable.
+CSV suite needs standard Snowflake/S3 variables,
+`TARGET_SNOWFLAKE_SCHEMA`, and `TARGET_SNOWFLAKE_FILE_FORMAT_CSV` (which may
+reuse `TARGET_SNOWFLAKE_FILE_FORMAT`); ensure the private key is readable.
 
 Run the supported 46-test subset with plaintext upload explicitly selected:
 
@@ -61,7 +63,7 @@ docker exec -t -e CLIENT_SIDE_ENCRYPTION_MASTER_KEY= pipelinewise bash -lc '
 ```
 
 This excludes Parquet, mixed CSV/Parquet table-stage, and successful client-side
-encryption, but retains wrong-key rejection. Expect 46 passes and zero skips;
+encryption while retaining wrong-key rejection. Expect 46 passes, zero skips;
 anything else is non-green. Full `make integration_test` separately requires
 Parquet and a real client-side encryption master key.
 
@@ -69,51 +71,37 @@ Parquet and a real client-side encryption master key.
 
 - Connector source ships with PipelineWise. Unless a standalone release is
   explicit, do not bump connector versions or add versioned connector
-  changelogs. Put release-visible changes under the current root release;
-  include test/CI/fixture changes only when release-relevant. Jira remains an
-  external pin.
-- These are upstream-derived copies. Coordinate non-trivial divergence upstream; keep local fixes narrow and comments limited to why divergence is needed. Avoid broad formatting.
+  changelogs. Put release-visible changes in the current root release; include
+  test/CI/fixture changes only when release-relevant. Jira remains an external pin.
+- These are upstream-derived copies. Coordinate non-trivial divergence
+  upstream; keep local fixes narrow, comments limited to why divergence is
+  needed, and avoid broad formatting.
 
 ## Snowflake traps
 
-- Uppercase and double-quote identifiers; with
+The Snowflake/Iceberg contract in `pipelinewise/AGENTS.md` is authoritative for
+creation settings, versions, types, writer/DBA boundaries, and conversion
+invariants. Connector-specific rules follow:
+
+- Uppercase and double-quote identifiers. With
   `QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE`, DDL/DML case must match. Compare
-  generated types with Snowflake's canonical reports because aliases can cause
-  false replacement.
+  generated types with Snowflake canonical reports; aliases can cause false
+  replacement.
 - Connector version prints to stderr; E2E must check exit status because
   `assert_command_success` treats stderr as failure.
-- Only tap-level `target_table_format: iceberg` plus integer
-  `iceberg_version: 3` creates managed Iceberg; omitted/native creates native.
-  Retain both settings through Singer handover/evolution and reject every other
-  version before mutation.
 - The connector serves all compatible v3 Singer sources; core serves only
-  MariaDB/MySQL/PostgreSQL FastSync. Every v3 route needs `hard_delete: true`;
-  preserve Singer-only defaults such as Salesforce flattening level 10. Keep
-  discovery/type/version contracts aligned without importing core or reducing
-  the version to a Boolean; future versions need explicit branches and tests.
+  MariaDB/MySQL/PostgreSQL FastSync. Align discovery/type/version contracts
+  without importing core or reducing version to Boolean.
 - `target_snowflake/managed_iceberg.py` owns per-version configuration,
   discovery, validation, DDL, compatibility, and pure column planning. `DbSync`
-  in `target_snowflake/db_sync.py` executes its native/managed plan; do not add
-  another Iceberg policy layer. Keep the dependency-free fixture aligned with
-  the isolated core.
-- Managed v3 requires table-level
-  `ICEBERG_MERGE_ON_READ_BEHAVIOR = 'DISABLED'` in CREATE and before writes;
-  keep core parity and never use deprecated `ENABLE_ICEBERG_MERGE_ON_READ`.
-- Create managed v3 with `TARGET_FILE_SIZE = 'AUTO'` and
-  `STORAGE_SERIALIZATION_POLICY = 'COMPATIBLE'`; keep the dependency-free
-  fixture and core FastSync/conversion contract aligned.
-- Emit new native/v3 strings as `VARCHAR(134217728)`. Keep compatible existing
-  native widths; require exact v3 width and never widen existing Iceberg
-  implicitly. Emit v3 binary explicitly as `BINARY(67108864)` in CREATE/ADD.
-- PipelineWise is the sole automated writer; external reads are allowed. DBA
-  writes/DDL require a maintenance window with replication stopped and no
-  recovery, followed by v3 revalidation. Replicated tables/columns must come
-  from FullSync, PartialSync, target-snowflake, or the supported converter;
-  never adopt arbitrary external schemas.
+  in `target_snowflake/db_sync.py` executes native/managed plans; add no other
+  Iceberg policy layer. Keep the dependency-free fixture aligned with core.
+- Keep all managed-v3 DDL/type/version settings and the dependency-free fixture
+  in exact core parity. CREATE/ADD emits v3 binary as `BINARY(67108864)`.
 - Conversion stays in the PipelineWise command; do not restore a connector
   executable or duplicate its type, metadata, or recovery policy.
 - Detect MariaDB JSON aliases only from the exact generated `JSON_VALID`
   constraint and explicit v3. Advertise object, array, string, number, Boolean,
   and null roots. Carry non-SQL-null values as validated serialized JSON so
-  `PARSE_JSON` restores the root and JSON null remains distinct from SQL NULL;
+  `PARSE_JSON` restores roots and keeps JSON null distinct from SQL NULL;
   preserve ordinary `LONGTEXT` and native mappings.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,23 +1,26 @@
 # Test Suite Instructions
 
-Read root `AGENTS.md`; database/dev-project work also uses E2E guidance, and
-connector-local tests use connector guidance.
+Read root `AGENTS.md`; database/dev-project work also follows E2E guidance and
+connector-local tests follow connector guidance.
 
 ## Boundaries
 
-- Prefer root units in the ready `pipelinewise` container; report host fallback.
-  `tests/units` is the credential/container-free root CI gate; use the exact
-  root command and its fixed 77% threshold, regardless of `.coveragerc`.
+- Prefer root units in the ready `pipelinewise` container and report host
+  fallback. `tests/units` is the credential/container-free root CI gate; use
+  the exact root command and fixed 77% threshold regardless of `.coveragerc`.
 - Collect nested data-diff/backend-db selections from `tests/units` and narrow
-  with `-k`; direct nested paths can break imports.
-- Never run bare `pytest tests/`; it collects credentialed E2E.
-- Connector tests are separate; database-backed and route tests follow their scoped files.
+  with `-k`; direct nested paths can break imports. Never run bare
+  `pytest tests/`, which collects credentialed E2E.
+- Connector tests are separate; database-backed and route tests follow their
+  scoped guides.
 
 ## Proof
 
-- Generated SQL assertions prove text, not database acceptance; identify missing
+- Generated-SQL assertions prove text, not database acceptance; identify absent
   real-engine proof.
-- Mirror implementation paths and cover unsupported-route guards, not only happy
+- Mirror implementation paths and unsupported-route guards, not only happy
   paths. Prefer behavior assertions unless exact SQL is the behavior.
-- Add import/AST coverage when changing dependency seams; currently only backend-db -> data-diff is directly enforced.
-- Report pass/skip/fail counts per command group. Skips and partial matrices are not complete.
+- Add import/AST coverage for dependency-seam changes; only backend-db →
+  data-diff is currently enforced directly.
+- Report pass/skip/fail counts per command group; skips and partial matrices are
+  incomplete verification.

--- a/tests/end_to_end/AGENTS.md
+++ b/tests/end_to_end/AGENTS.md
@@ -1,24 +1,24 @@
 # End-to-End and Dev-Project Instructions
 
-Read root `AGENTS.md`. This file covers E2E, database checks, connector routes,
-and `dev-project/`; connector source also follows connector guidance.
+Read root `AGENTS.md`. This guide covers E2E, database checks, connector routes,
+and `dev-project/`; connector-source work also follows connector guidance.
 
 ## Stack readiness and evidence
 
-Use dev-project Docker for supported database/E2E checks; report host fallbacks
-and gaps.
+Use dev-project Docker for supported database/E2E checks; report host fallbacks/gaps.
 
-Reuse a ready stack only while environment/install inputs are unchanged. Changes
-to `.env`, dependencies, connector selection, `entrypoint.sh`, Dockerfiles, or
-images require recreating affected services without deleting volumes. Source is
-bind-mounted; container environment and virtualenv volumes are not. Never
-replace ignored `.env` or recreate volumes without approval:
+Reuse a ready stack only while environment/install inputs are unchanged.
+Changes to `.env`, dependencies, connector selection, `entrypoint.sh`,
+Dockerfiles, or images require recreating affected services without deleting
+volumes. Source is bind-mounted; container environment and virtualenv volumes
+are not. Never replace ignored `.env` or recreate volumes without approval:
 
 ```bash
 docker compose -f dev-project/docker-compose.yml up -d
 ```
 
-Before database/E2E commands, inspect container state and require a readiness marker from the current start:
+Before database/E2E commands, inspect container state and require the current
+start's marker:
 
 ```bash
 docker ps --format '{{.Names}}\t{{.Status}}'
@@ -28,14 +28,14 @@ docker logs --since "$started_at" pipelinewise 2>&1 | grep -F "PipelineWise Dev 
 
 `Up` is insufficient during provisioning. Persisted volumes/config may differ
 from CI; only fresh provisioning with required credentials and no unplanned
-skips is CI-equivalent. Green workflows may skip E2E jobs: confirm each named
+skips is CI-equivalent. Green workflows may skip E2E jobs: confirm every named
 step ran and report pass/skip/fail counts.
 
 ## E2E matrix
 
 These groups mirror `.github/workflows/e2e_tests.yml`; update both together. CI
-runs the eight Snowflake groups concurrently on isolated runners. Local groups
-share/reset fixtures and config, so run them serially:
+runs eight Snowflake groups concurrently on isolated runners; local groups
+share/reset fixtures/config and must run serially:
 
 ```bash
 run_e2e() { docker exec -t pipelinewise pytest "$@" -vx --timer-top-n 10; }
@@ -89,40 +89,43 @@ run_e2e \
 
 Run all nine only for a full suite; otherwise run every affected group. MariaDB
 and PostgreSQL cover native and explicit v3; genuine MySQL covers explicit v3.
-Do not infer one format from the other. `SHOW PRIMARY KEYS` does not prove
-Iceberg identifier fields; inspect raw metadata and compare
-`identifier-field-ids` with current schema field IDs.
+Do not infer one format from another. `SHOW PRIMARY KEYS` does not prove Iceberg
+identifier fields; compare raw-metadata `identifier-field-ids` with current
+schema field IDs.
 
 ## Credentials and destructive scope
 
-- Snowflake E2E requires a dedicated database/role,
-  `dev-project/snowflake.pem`,
+- Snowflake E2E requires a dedicated database/role, `dev-project/snowflake.pem`,
   `TARGET_SNOWFLAKE_PRIVATE_KEY=/opt/pipelinewise/.ssh/snowflake.pem`,
   `helpers/env.py` fields, and staging credentials. Teardown drops only unique
   run schemas; never use production credentials.
-- CI sets `PIPELINEWISE_E2E_NAMESPACE` from the run, attempt, and shard. It must
-  contain only letters, digits, underscores, and hyphens. The namespace scopes
-  Snowflake staging, archive keys, and tap-S3 fixtures; local runs leave it unset.
+- CI derives `PIPELINEWISE_E2E_NAMESPACE` from run, attempt, and shard. It allows
+  only letters, digits, underscores, and hyphens and scopes Snowflake staging,
+  archive keys, and tap-S3 fixtures; local runs leave it unset.
 - Tap-S3 needs dedicated `TAP_S3_CSV_AWS_KEY`,
   `TAP_S3_CSV_AWS_SECRET_ACCESS_KEY`, and `TAP_S3_CSV_BUCKET`. Setup uploads both
   namespaced fixture objects before discovery, and teardown removes them.
-- The archive route removes its namespaced files after every test. Use only the
+- The archive route removes namespaced files after every test. Use only the
   dedicated `TARGET_SNOWFLAKE_S3_BUCKET`.
 - Target-PostgreSQL includes S3 and may skip despite healthy databases;
   credential skips are not passes.
 
 ## Topology and traps
 
-- Missing generated config is tolerated during cleanup; other cleanup failures surface.
+- Cleanup tolerates missing generated config; other failures surface.
 - Normal databases are health-gated; the MariaDB replica has no
   healthcheck/`depends_on`, so verify it before diagnosing early failures. The
   Oracle MySQL 8 service proves MySQL-specific behavior.
-- Keep MongoDB healthcheck as bare `ping`: the PipelineWise container initializes `rs0`, so `rs.status()` deadlocks startup. Keep container `PATH` literal to prevent host Compose interpolation.
+- Keep MongoDB healthcheck as bare `ping`: PipelineWise initializes `rs0`, so
+  `rs.status()` deadlocks startup. Keep container `PATH` literal to prevent host
+  Compose interpolation.
 - `entrypoint.sh` explicitly runs `tap_mysql_db.sh`, `tap_oracle_mysql_db.sh`,
   `tap_postgres_db.sh`, `tap_mongodb.sh`, and `target_postgres.sh`; wire new seed
   scripts there. Alembic runs only after successful `import_config` persists
   data-diff definitions.
-- Docker `initdb.d` runs only on empty volumes. Deleting `pipelinewise-backend-data` destroys local state; identify it exactly and obtain permission first.
+- Docker `initdb.d` runs only on empty volumes. Deleting
+  `pipelinewise-backend-data` destroys local state; identify it exactly and get
+  permission first.
 - Use the shared TLS helper for dev MySQL. Check target-snowflake exit status rather than stderr.
 - Fixture resets are stateful; after cross-group failures, reset and rerun
   serially before diagnosing a regression.

--- a/tests/end_to_end/data_diff/test_postgres_to_postgres.py
+++ b/tests/end_to_end/data_diff/test_postgres_to_postgres.py
@@ -230,8 +230,9 @@ class TestPostgresToPostgresDataDiff:
 
         initial_coverage = self.run_backend_query(
             f"""
-            SELECT coverage_status, blocking_run_id::text,
-                   evaluated_run_id::text, verified_through
+            SELECT verified_status, blocking_run_id::text,
+                   last_evaluated_run_id::text, verified_start, verified_end,
+                   furthest_observed_end
               FROM public.dd_watermark_state
              WHERE check_id = '{check_id}'
             """
@@ -240,6 +241,8 @@ class TestPostgresToPostgresDataDiff:
             'CONTIGUOUS',
             None,
             pass_run_id,
+            pass_window_start,
+            pass_window_end,
             pass_window_end,
         )
         assert self.run_backend_query(
@@ -251,7 +254,7 @@ class TestPostgresToPostgresDataDiff:
         ) == [(pass_run_id, 1, 'PASS')]
         assert self.run_backend_query(
             f"""
-            SELECT state_version, evaluated_run_id::text
+            SELECT state_version, last_evaluated_run_id::text
               FROM public.dd_watermark_state
              WHERE check_id = '{check_id}'
             """
@@ -320,7 +323,8 @@ class TestPostgresToPostgresDataDiff:
 
         blocked_coverage = self.run_backend_query(
             f"""
-            SELECT coverage_status, blocking_run_id::text, verified_through
+            SELECT verified_status, blocking_run_id::text, verified_end,
+                   furthest_observed_end
               FROM public.dd_watermark_state
              WHERE check_id = '{check_id}'
             """
@@ -329,6 +333,7 @@ class TestPostgresToPostgresDataDiff:
             'BLOCKED',
             failed_run_id,
             failed_window_start,
+            failed_window_end,
         )
         assert self.run_backend_query(
             f"""
@@ -339,7 +344,7 @@ class TestPostgresToPostgresDataDiff:
         ) == [(failed_run_id, failed_attempt, 'FAIL')]
         assert self.run_backend_query(
             f"""
-            SELECT state_version, evaluated_run_id::text
+            SELECT state_version, last_evaluated_run_id::text
               FROM public.dd_watermark_state
              WHERE check_id = '{check_id}'
             """
@@ -424,8 +429,8 @@ class TestPostgresToPostgresDataDiff:
 
         final_coverage = self.run_backend_query(
             f"""
-            SELECT coverage_status, blocking_run_id::text,
-                   evaluated_run_id::text, verified_through
+            SELECT verified_status, blocking_run_id::text,
+                   last_evaluated_run_id::text, verified_end
               FROM public.dd_watermark_state
              WHERE check_id = '{check_id}'
             """
@@ -445,7 +450,7 @@ class TestPostgresToPostgresDataDiff:
         ) == [(remediation_run_id, remediation_attempt, 'PASS')]
         assert self.run_backend_query(
             f"""
-            SELECT state_version, evaluated_run_id::text
+            SELECT state_version, last_evaluated_run_id::text
               FROM public.dd_watermark_state
              WHERE check_id = '{check_id}'
             """
@@ -485,8 +490,8 @@ class TestPostgresToPostgresDataDiff:
         ]
         assert self.run_backend_query(
             f"""
-            SELECT state_version, evaluated_run_id::text,
-                   verified_through, event_type
+            SELECT state_version, last_evaluated_run_id::text,
+                   verified_end, event_type
               FROM public.dd_watermark_state
              WHERE check_id = '{check_id}'
             """
@@ -585,9 +590,44 @@ class TestPostgresToPostgresDataDiff:
                 'dd_current_coverage', 'dd_remediation_history',
             }.isdisjoint(tables)
 
+            watermark_columns = {
+                row[0] for row in self.run_backend_query(
+                    "SELECT column_name FROM information_schema.columns"
+                    " WHERE table_schema = 'public'"
+                    " AND table_name = 'dd_watermark_state'"
+                )
+            }
+            assert {
+                'verified_start', 'verified_end', 'furthest_observed_end',
+                'verified_status', 'last_evaluated_run_id',
+            } <= watermark_columns
+            assert {
+                'coverage_start', 'verified_through', 'max_observed_end',
+                'coverage_status', 'evaluated_run_id',
+            }.isdisjoint(watermark_columns)
+
+            watermark_event_columns = {
+                row[0] for row in self.run_backend_query(
+                    "SELECT column_name FROM information_schema.columns"
+                    " WHERE table_schema = 'public'"
+                    " AND table_name = 'dd_watermark_events'"
+                )
+            }
+            assert {
+                'verified_start', 'previous_verified_end', 'verified_end',
+                'furthest_observed_end', 'verified_status', 'evaluated_run_id',
+            } <= watermark_event_columns
+            assert {
+                'coverage_start', 'previous_verified_through',
+                'verified_through', 'max_observed_end', 'coverage_status',
+            }.isdisjoint(watermark_event_columns)
+
             assert self.e2e.run_ddl_pipelinewise_backend(
                 "SELECT to_regclass(quote_ident(current_user) || '.alembic_version')"
             )[0][0] is None
+            assert self.run_backend_query(
+                'SELECT version_num FROM public.alembic_version'
+            ) == [('002',)]
             # Alembic stamped its version, so a second import is a no-op migration.
             assert self.run_backend_query(
                 'SELECT COUNT(*) FROM public.alembic_version'

--- a/tests/units/backend_db/test_migrations.py
+++ b/tests/units/backend_db/test_migrations.py
@@ -1,0 +1,111 @@
+import importlib
+from unittest.mock import patch
+
+
+# pylint: disable=missing-function-docstring
+
+
+MIGRATION = importlib.import_module(
+    "pipelinewise.backend_db.migrations.versions.002_rename_watermark_columns"
+)
+
+UPGRADE_STATE_COLUMN_RENAMES = [
+    "ALTER TABLE public.dd_watermark_state "
+    "RENAME COLUMN coverage_start TO verified_start",
+    "ALTER TABLE public.dd_watermark_state "
+    "RENAME COLUMN verified_through TO verified_end",
+    "ALTER TABLE public.dd_watermark_state "
+    "RENAME COLUMN max_observed_end TO furthest_observed_end",
+    "ALTER TABLE public.dd_watermark_state "
+    "RENAME COLUMN coverage_status TO verified_status",
+    "ALTER TABLE public.dd_watermark_state "
+    "RENAME COLUMN evaluated_run_id TO last_evaluated_run_id",
+]
+
+UPGRADE_EVENT_COLUMN_RENAMES = [
+    "ALTER TABLE public.dd_watermark_events "
+    "RENAME COLUMN coverage_start TO verified_start",
+    "ALTER TABLE public.dd_watermark_events "
+    "RENAME COLUMN previous_verified_through TO previous_verified_end",
+    "ALTER TABLE public.dd_watermark_events "
+    "RENAME COLUMN verified_through TO verified_end",
+    "ALTER TABLE public.dd_watermark_events "
+    "RENAME COLUMN max_observed_end TO furthest_observed_end",
+    "ALTER TABLE public.dd_watermark_events "
+    "RENAME COLUMN coverage_status TO verified_status",
+]
+
+
+def _executed_sql(operation):
+    return [call.args[0] for call in operation.call_args_list]
+
+
+def test_watermark_upgrade_renames_columns_and_constraints():
+    with patch.object(MIGRATION.op, "execute") as execute:
+        MIGRATION.upgrade()
+
+    statements = _executed_sql(execute)
+    assert statements[:5] == UPGRADE_STATE_COLUMN_RENAMES
+    assert statements[5:10] == UPGRADE_EVENT_COLUMN_RENAMES
+    assert statements[10:12] == [
+        "ALTER TABLE public.dd_watermark_state "
+        "RENAME CONSTRAINT dd_watermark_state_coverage_status_check "
+        "TO dd_watermark_state_verified_status_check",
+        "ALTER TABLE public.dd_watermark_state "
+        "RENAME CONSTRAINT dd_watermark_state_evaluated_run_id_fkey "
+        "TO dd_watermark_state_last_evaluated_run_id_fkey",
+    ]
+    assert statements[12] == (
+        "ALTER TABLE public.dd_watermark_events "
+        "RENAME CONSTRAINT dd_watermark_events_coverage_status_check "
+        "TO dd_watermark_events_verified_status_check"
+    )
+    assert "verified interval" in statements[13]
+    assert "verified interval" in statements[14]
+    assert "furthest observed" in statements[14]
+
+
+def test_watermark_downgrade_reverses_every_rename():
+    with patch.object(MIGRATION.op, "execute") as execute:
+        MIGRATION.downgrade()
+
+    statements = _executed_sql(execute)
+    assert statements[0] == (
+        "ALTER TABLE public.dd_watermark_events "
+        "RENAME CONSTRAINT dd_watermark_events_verified_status_check "
+        "TO dd_watermark_events_coverage_status_check"
+    )
+    assert statements[1:3] == [
+        "ALTER TABLE public.dd_watermark_state "
+        "RENAME CONSTRAINT dd_watermark_state_last_evaluated_run_id_fkey "
+        "TO dd_watermark_state_evaluated_run_id_fkey",
+        "ALTER TABLE public.dd_watermark_state "
+        "RENAME CONSTRAINT dd_watermark_state_verified_status_check "
+        "TO dd_watermark_state_coverage_status_check",
+    ]
+    assert statements[3:8] == [
+        "ALTER TABLE public.dd_watermark_events "
+        "RENAME COLUMN verified_status TO coverage_status",
+        "ALTER TABLE public.dd_watermark_events "
+        "RENAME COLUMN furthest_observed_end TO max_observed_end",
+        "ALTER TABLE public.dd_watermark_events "
+        "RENAME COLUMN verified_end TO verified_through",
+        "ALTER TABLE public.dd_watermark_events "
+        "RENAME COLUMN previous_verified_end TO previous_verified_through",
+        "ALTER TABLE public.dd_watermark_events "
+        "RENAME COLUMN verified_start TO coverage_start",
+    ]
+    assert statements[8:13] == [
+        "ALTER TABLE public.dd_watermark_state "
+        "RENAME COLUMN last_evaluated_run_id TO evaluated_run_id",
+        "ALTER TABLE public.dd_watermark_state "
+        "RENAME COLUMN verified_status TO coverage_status",
+        "ALTER TABLE public.dd_watermark_state "
+        "RENAME COLUMN furthest_observed_end TO max_observed_end",
+        "ALTER TABLE public.dd_watermark_state "
+        "RENAME COLUMN verified_end TO verified_through",
+        "ALTER TABLE public.dd_watermark_state "
+        "RENAME COLUMN verified_start TO coverage_start",
+    ]
+    assert "verified-through" in statements[13]
+    assert "verified-through" in statements[14]

--- a/tests/units/data_diff/test_cli.py
+++ b/tests/units/data_diff/test_cli.py
@@ -50,10 +50,9 @@ def _pipelinewise(**args):
 
 def _stored_check():
     return {
-        "id": uuid4(),
+        "check_id": uuid4(),
         "revision": 2,
         "is_current": True,
-        "enabled": True,
         "target_id": "target",
         "tap_id": "tap",
         "source_schema": "public",
@@ -62,13 +61,12 @@ def _stored_check():
         "source_key_column": "id",
         "source_timestamp_column": "updated_at",
         "source_compare_columns": [],
-        "frequency_seconds": 3600,
-        "duration_seconds": 3600,
-        "settling_delay_seconds": 21600,
-        "name": "payments-check",
-        "full_check_name": "target/tap/public/payments/payments-check",
-        "coverage_status": None,
-        "verified_through": None,
+        "frequency": "0 * * * *",
+        "window_start_seconds": 3600,
+        "window_end_seconds": 0,
+        "full_check_name": "target/tap/public/payments",
+        "verified_status": None,
+        "verified_end": None,
     }
 
 
@@ -100,12 +98,41 @@ def test_list_checks_reads_backend_and_supports_json(capsys):
         pipelinewise.list_data_diff_checks()
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload[0]["name"] == "payments-check"
+    assert payload[0]["full_check_name"] == "target/tap/public/payments"
+    assert "verified_status" in payload[0]
+    assert "verified_end" in payload[0]
+    assert "coverage_status" not in payload[0]
+    assert "verified_through" not in payload[0]
     assert repository.filters == {
         "target_id": "target",
         "tap_id": "tap",
         "include_versioned": True,
     }
+
+
+def test_list_checks_uses_verified_state_names_in_table_output(capsys):
+    check = _stored_check()
+    check["verified_status"] = "CONTIGUOUS"
+    check["verified_end"] = datetime(2026, 7, 22, 13, tzinfo=timezone.utc)
+    repository = RepositoryContext([check])
+    pipelinewise = _pipelinewise(
+        target="target",
+        tap="tap",
+        output_format="table",
+        include_versioned=False,
+    )
+
+    with patch(
+        "pipelinewise.cli.pipelinewise.DataDiffRepository.from_backend_config",
+        return_value=repository,
+    ):
+        pipelinewise.list_data_diff_checks()
+
+    output = capsys.readouterr().out
+    assert "Verified status" in output
+    assert "Verified end" in output
+    assert "CONTIGUOUS" in output
+    assert "2026-07-22T13:00:00+00:00" in output
 
 
 def test_run_checks_prints_utc_window_and_returns_on_pass(capsys):
@@ -119,7 +146,7 @@ def test_run_checks_prints_utc_window_and_returns_on_pass(capsys):
     ):
         pipelinewise.run_data_diff_checks()
 
-    assert "payments-check" in capsys.readouterr().out
+    assert "target/tap/public/payments" in capsys.readouterr().out
     pipelinewise.alert_sender.send_to_all_handlers.assert_not_called()
 
 

--- a/tests/units/data_diff/test_coverage.py
+++ b/tests/units/data_diff/test_coverage.py
@@ -34,9 +34,10 @@ def test_failed_interval_blocks_later_successful_coverage():
         _run(12, 13, "PASS"),
     ])
 
-    assert coverage["coverage_start"] == _instant(10)
-    assert coverage["verified_through"] == _instant(11)
-    assert coverage["coverage_status"] == "BLOCKED"
+    assert coverage["verified_start"] == _instant(10)
+    assert coverage["verified_end"] == _instant(11)
+    assert coverage["furthest_observed_end"] == _instant(13)
+    assert coverage["verified_status"] == "BLOCKED"
     assert coverage["blocking_run_id"] == failed["run_id"]
 
 
@@ -49,15 +50,15 @@ def test_successful_remediation_fills_gap_and_advances_over_later_passes():
         _run(12, 13, "PASS"),
     ])
 
-    assert coverage["verified_through"] == _instant(13)
-    assert coverage["coverage_status"] == "CONTIGUOUS"
+    assert coverage["verified_end"] == _instant(13)
+    assert coverage["verified_status"] == "CONTIGUOUS"
     assert coverage["blocking_run_id"] is None
 
 
 def test_later_failed_revalidation_invalidates_previous_coverage():
     previous = {
-        "verified_through": _instant(12),
-        "coverage_status": "CONTIGUOUS",
+        "verified_end": _instant(12),
+        "verified_status": "CONTIGUOUS",
     }
     current = calculate_coverage([
         _run(10, 11, "PASS"),
@@ -65,7 +66,7 @@ def test_later_failed_revalidation_invalidates_previous_coverage():
         _run(11, 12, "FAIL", attempt=2),
     ])
 
-    assert current["verified_through"] == _instant(11)
+    assert current["verified_end"] == _instant(11)
     assert coverage_event_type(previous, current) == "INVALIDATE"
 
 
@@ -74,8 +75,8 @@ def test_metadata_only_definition_never_advances_coverage():
         [_run(10, 11, "PASS")], data_checks_enabled=False
     )
 
-    assert coverage["verified_through"] == _instant(10)
-    assert coverage["coverage_status"] == "BLOCKED"
+    assert coverage["verified_end"] == _instant(10)
+    assert coverage["verified_status"] == "BLOCKED"
     assert "Metadata-only" in coverage["reason"]
 
 
@@ -85,7 +86,7 @@ def test_missing_interval_is_reported_as_blocked_without_failure_run():
         _run(12, 13, "PASS"),
     ])
 
-    assert coverage["verified_through"] == _instant(11)
+    assert coverage["verified_end"] == _instant(11)
     assert coverage["blocking_run_id"] is None
     assert "next timestamp interval" in coverage["reason"]
 
@@ -115,7 +116,7 @@ def test_window_narrower_than_cadence_blocks_coverage():
     # what the shipped defaults did before they were widened.
     coverage = calculate_coverage(_schedule(6, 15, 12))
 
-    assert coverage["coverage_status"] == "BLOCKED"
+    assert coverage["verified_status"] == "BLOCKED"
 
 
 def test_window_wider_than_cadence_keeps_coverage_contiguous():
@@ -123,14 +124,14 @@ def test_window_wider_than_cadence_keeps_coverage_contiguous():
     # skipped slot cannot open a gap.
     coverage = calculate_coverage(_schedule(6, 15, 3))
 
-    assert coverage["coverage_status"] == "CONTIGUOUS"
+    assert coverage["verified_status"] == "CONTIGUOUS"
 
 
 def test_overlapping_windows_survive_a_skipped_slot():
     runs = _schedule(6, 15, 3)
     del runs[1]
 
-    assert calculate_coverage(runs)["coverage_status"] == "CONTIGUOUS"
+    assert calculate_coverage(runs)["verified_status"] == "CONTIGUOUS"
 
 
 def test_incremental_coverage_matches_full_calculation_for_appended_slots():

--- a/tests/units/data_diff/test_repository.py
+++ b/tests/units/data_diff/test_repository.py
@@ -204,6 +204,11 @@ def test_list_checks_exposes_compare_columns_from_version_snapshot():
     assert checks[0]["source_compare_columns"] == ["status", "amount"]
     assert checks[0]["target_compare_columns"] == ["STATUS", "AMOUNT"]
     assert "LEFT JOIN public.dd_watermark_state coverage" in cursor.last_sql
+    assert "coverage.verified_start" in cursor.last_sql
+    assert "coverage.verified_end" in cursor.last_sql
+    assert "coverage.furthest_observed_end" in cursor.last_sql
+    assert "coverage.verified_status" in cursor.last_sql
+    assert "coverage.last_evaluated_run_id" in cursor.last_sql
     assert "coverage.updated_at AS verified_at" in cursor.last_sql
     assert "dd_current_coverage" not in cursor.last_sql
 
@@ -297,10 +302,10 @@ def test_finish_run_updates_coverage_in_same_transaction():
 
 def _coverage_state(start, end, *, status="CONTIGUOUS", blocking_run_id=None):
     return {
-        "coverage_start": start,
-        "verified_through": end,
-        "max_observed_end": end,
-        "coverage_status": status,
+        "verified_start": start,
+        "verified_end": end,
+        "furthest_observed_end": end,
+        "verified_status": status,
         "blocking_run_id": blocking_run_id,
         "reason": "previous coverage state",
         "state_version": 4,
@@ -349,8 +354,8 @@ def test_new_latest_slot_advances_coverage_without_history_scan():
 
     recalculate.assert_not_called()
     coverage = upsert_state.call_args.args[2]
-    assert coverage["verified_through"] == attempt["window_end"]
-    assert coverage["coverage_status"] == "CONTIGUOUS"
+    assert coverage["verified_end"] == attempt["window_end"]
+    assert coverage["verified_status"] == "CONTIGUOUS"
 
 
 def test_replacement_attempt_recalculates_from_effective_slots():
@@ -362,8 +367,8 @@ def test_replacement_attempt_recalculates_from_effective_slots():
     previous = _coverage_state(start, end)
     recalculated = {
         **previous,
-        "verified_through": start,
-        "coverage_status": "BLOCKED",
+        "verified_end": start,
+        "verified_status": "BLOCKED",
         "blocking_run_id": attempt["run_id"],
         "reason": "replacement failed",
     }
@@ -457,7 +462,67 @@ def test_exceptional_recalculation_reads_effective_slots_not_run_history():
     sql = " ".join(cursor.execute.call_args.args[0].split())
     assert "FROM public.dd_run_slot_state" in sql
     assert "FROM public.dd_run_attempts" not in sql
-    assert coverage["coverage_status"] == "CONTIGUOUS"
+    assert coverage["verified_status"] == "CONTIGUOUS"
+
+
+def test_current_watermark_uses_renamed_state_columns():
+    cursor = Mock()
+    start = datetime(2026, 7, 22, 10, tzinfo=timezone.utc)
+    end = start + timedelta(hours=1)
+    definition = {"check_id": uuid4(), "run_id": uuid4()}
+    coverage = _coverage_state(start, end)
+
+    DataDiffRepository._upsert_watermark_state(
+        cursor,
+        definition,
+        coverage,
+        "ADVANCE",
+        5,
+        end,
+    )
+
+    sql = " ".join(cursor.execute.call_args.args[0].split())
+    assert "verified_start, verified_end, furthest_observed_end" in sql
+    assert "verified_status, blocking_run_id, last_evaluated_run_id" in sql
+    assert "coverage_start" not in sql
+    assert "verified_through" not in sql
+    assert "max_observed_end" not in sql
+    assert "coverage_status" not in sql
+    assert "evaluated_run_id" not in sql.replace("last_evaluated_run_id", "")
+
+
+def test_watermark_event_uses_consistent_verified_column_names():
+    cursor = Mock()
+    start = datetime(2026, 7, 22, 10, tzinfo=timezone.utc)
+    end = start + timedelta(hours=1)
+    definition = {"check_id": uuid4(), "run_id": uuid4()}
+    previous = _coverage_state(start, start)
+    coverage = _coverage_state(start, end)
+
+    DataDiffRepository._insert_watermark_event(
+        cursor,
+        definition,
+        previous,
+        coverage,
+        "ADVANCE",
+        end,
+    )
+
+    sql, params = cursor.execute.call_args.args
+    sql = " ".join(sql.split())
+    assert "verified_start, previous_verified_end, verified_end" in sql
+    assert "furthest_observed_end, verified_status" in sql
+    assert "coverage_start" not in sql
+    assert "verified_through" not in sql
+    assert "max_observed_end" not in sql
+    assert "coverage_status" not in sql
+    assert params[4:9] == (
+        coverage["verified_start"],
+        previous["verified_end"],
+        coverage["verified_end"],
+        coverage["furthest_observed_end"],
+        coverage["verified_status"],
+    )
 
 
 def test_repository_builds_the_shared_database_from_backend_config():


### PR DESCRIPTION
## Context

The data-diff backend exposed the current watermark with names that did not clearly distinguish its verified interval from the furthest observed window. Renaming only the mutable state would also leave equivalent event-history fields using a second vocabulary.

## Changes

- Add reversible backend migration 002 to rename watermark state and event fields while preserving existing rows, constraints, privileges, and history.
- Use `verified_start`, `verified_end`, `furthest_observed_end`, and `verified_status` consistently; use `last_evaluated_run_id` for mutable state while retaining `evaluated_run_id` as each event's causal run.
- Align repository persistence, CLI output, unit/E2E coverage, and the migration 002 ERD.
- Update backend reporting queries to distinguish per-check-result outcomes from run-level errors, describe current unresolved failures, and retain remediation history.
- Compact repository agent guidance without changing commands, thresholds, safeguards, or architecture contracts.
- Bump PipelineWise to [0.84.0 (2026-09-07)](https://github.com/transferwise/pipelinewise/blob/AP-2830-data-diff-reporting/CHANGELOG.md#0840-2026-09-07) and document direct-SQL, replicated-copy, deployment, and rollback compatibility.

## Type of change

- [x] Maintenance, dependency, or CI
- [x] Documentation
- [x] Breaking change

## Compatibility and operations

Migration 002 renames columns in `public.dd_watermark_state` and `public.dd_watermark_events` in place. Existing rows and event history are preserved. PostgreSQL takes brief `ACCESS EXCLUSIVE` locks for the metadata-only renames, so deploy while data-diff activity is quiesced.

Direct SQL consumers and replicated backend-table copies must adopt the renamed columns. An older PipelineWise binary is incompatible after migration 002; downgrade the database to revision 001 with the 0.84.0 code before rolling back the application.

The migration remains strict for the canonical revision-001 constraint names. Manually drifted schemas must be normalized before deployment.

The agent-guidance maintenance changes do not affect runtime behaviour.

## Validation

| Command or check | Result |
|---|---|
| `ruff check pipelinewise tests` | Passed |
| `pylint pipelinewise tests` | Passed — 10.00/10 |
| `flake8 pipelinewise --count --select=E9,F63,F7,F82 --show-source --statistics` | Passed — 0 |
| `flake8 pipelinewise --count --max-complexity=15 --max-line-length=120 --statistics` | Passed — 0 |
| `pytest --cov=pipelinewise --cov-fail-under=77 -v tests/units` | Passed — 1,324 tests and 147 subtests; 90 warnings |
| `pipelinewise validate --dir dev-project/pipelinewise-config` | Passed |
| `cd docs && make check` | Passed — 6 checks and strict Sphinx build |
| Populated PostgreSQL `001 → 002 → 001` migration round-trip | Passed — state/event values, constraints, and comments preserved; restored to 002 |
| Data-diff E2E: PostgreSQL/MariaDB → PostgreSQL/Snowflake | Passed — 9 tests, 0 skipped, 0 failed |
| Agent-guidance preservation audit | Passed — 6 guides reduced from 3,823 to 3,502 words; commands, thresholds, identifiers, versions, safeguards, and symlinks preserved |
| `git diff --check origin/master...HEAD` | Passed |
| Credential-like addition scan | Passed — no matches |

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] This pull request is focused and can be reviewed and reverted independently.
- [x] Behavioural changes have regression tests, or I explained why tests are not applicable.
- [x] Relevant documentation and changelog entries are updated, or I explained why they are not applicable.
- [x] Applicable local checks pass; failures, skips, and unavailable checks are documented above.
- [x] The change contains no credentials, private keys, production identifiers, or source records.
- [x] Breaking and compatibility impacts are identified above.