### PR TITLE
Switch to Debian Trixie based image & bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.85.0 (2026-09-08)
+-------------------
+
+- Switch base image to Debian Trixie, as Bullseye is now deprecated
+
 0.84.0 (2026-09-07)
 -------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye
+FROM python:3.12-slim-trixie
 
 ARG connectors=all
 

--- a/Dockerfile.barebone
+++ b/Dockerfile.barebone
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye
+FROM python:3.12-slim-trixie
 
 RUN apt-get -qq update \
     && apt-get -qqy --no-install-recommends install \

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.12.*',
-      version='0.84.0',
+      version='0.85.0',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
## Context

Debian Bullseye is now [out of support, as of the end of August](https://www.debian.org/releases/). 

## Changes

Bumps the Pipelinewise Dockerfile base to a Trixie based image, with support until 2030-06-30

## Type of change


- [ ] Bug fix
- [ ] New functionality
- [x] Maintenance, dependency, or CI
- [ ] Documentation
- [ ] Breaking change


## Compatibility and operations

N/A

## Validation

N/A

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] This pull request is focused and can be reviewed and reverted
      independently.
- [x] Behavioural changes have regression tests, or I explained why tests are not
      applicable.
- [x] Relevant documentation and changelog entries are updated, or I explained
      why they are not applicable.
- [x] Applicable local checks pass; failures, skips, and unavailable checks are
      documented above.
- [x] The change contains no credentials, private keys, production identifiers,
      or source records.
- [x] Breaking and compatibility impacts are identified above.
