### PR TITLE
AP-3173: Simplify PostgreSQL logical replication progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,9 @@ Also follow these scoped checks:
 
 - Python: 120 columns, complexity 15, four spaces, Google docstrings,
   consistent single quotes, `snake_case` names/JSON keys, `PascalCase` classes.
-- Uppercase Snowflake FastSync identifiers. Scope Pylint disables to a line or
-  function, never a module.
+- Uppercase Snowflake FastSync identifiers. Scope new Pylint disables to a line
+  or function. Preserve existing connector module suppressions when removing
+  them would expose unrelated legacy findings; do not broaden their scope.
 - Comments explain a non-obvious constraint or consequence in at most two
   lines; do not restate code, narrate edits, argue choices, or add walkthroughs.
 - Preserve dirty-worktree changes. Never run `pre-commit run --all-files`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@
   emission so unavailable markers do not create expected source-database errors
 - Use the LSN returned by PostgreSQL logical-message emission and the first
   decoded commit at or beyond it as the idle-WAL bookmark boundary
-- Reject zero as a newly emitted marker boundary while preserving general
-  conversion of valid low LSN values
+- Reject zero as a newly emitted marker boundary while preserving conversion and
+  final bookmark updates for valid low LSN values
 - Emit the marker-boundary state only once in continuous mode and close logical
   replication resources on every exit path
 
@@ -26,8 +26,8 @@
 
 - Verify the PostgreSQL 11.2 source-connection boundary, cleanup-only slot
   removal, current WAL functions, LOG_BASED progress, marker capability fallback,
-  one-time continuous checkpoints, marker validation, and replication resource
-  cleanup
+  one-time continuous checkpoints, marker validation, zero-LSN finalization, and
+  replication resource cleanup
 
 0.84.0 (2026-09-08)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+0.84.1 (TBD)
+------------
+
+**PostgreSQL logical replication**
+
+- Emit LOG_BASED progress markers only after replication starts, using a
+  three-argument call compatible with PostgreSQL 11 through 18
+- Use the LSN returned by PostgreSQL logical-message emission and the first
+  decoded commit at or beyond it as the idle-WAL bookmark boundary
+
+**Tests**
+
+- Verify LOG_BASED progress from the returned marker LSN without marker UUID or
+  payload matching
+
 0.84.0 (2026-09-08)
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,33 @@
-0.84.1 (TBD)
-------------
+0.85.0 (2026-09-08)
+-------------------
+
+**PostgreSQL source compatibility**
+
+- Require PostgreSQL 11.2 or later for every Singer source replication method,
+  FullSync, and PartialSync, while retaining cleanup-only removal of replication
+  slots from older sources
+- Remove pre-11 WAL-function compatibility and use the supported WAL functions
+  directly
 
 **PostgreSQL logical replication**
 
 - Emit LOG_BASED progress markers only after replication starts, using a
   three-argument call compatible with PostgreSQL 11 through 18
+- Check both PostgreSQL marker-function signatures and execution privilege before
+  emission so unavailable markers do not create expected source-database errors
 - Use the LSN returned by PostgreSQL logical-message emission and the first
   decoded commit at or beyond it as the idle-WAL bookmark boundary
+- Reject zero as a newly emitted marker boundary while preserving general
+  conversion of valid low LSN values
+- Emit the marker-boundary state only once in continuous mode and close logical
+  replication resources on every exit path
 
 **Tests**
 
-- Verify LOG_BASED progress from the returned marker LSN without marker UUID or
-  payload matching
+- Verify the PostgreSQL 11.2 source-connection boundary, cleanup-only slot
+  removal, current WAL functions, LOG_BASED progress, marker capability fallback,
+  one-time continuous checkpoints, marker validation, and replication resource
+  cleanup
 
 0.84.0 (2026-09-08)
 -------------------

--- a/docs/connectors/taps/postgres.rst
+++ b/docs/connectors/taps/postgres.rst
@@ -125,12 +125,12 @@ PipelineWise sends feedback only up to the minimum target-acknowledged LSN store
 in ``state.json``. Missing, unreadable, invalid, or regressing state retains the
 previous safe LSN.
 
-Before consuming ongoing LOG_BASED WAL on PostgreSQL 9.6 or later, PipelineWise
-attempts to emit a transactional ``pg_logical_emit_message`` in each tap
-database when the tap user can execute the function. The transaction's commit
-provides a decodable bookmark boundary even when the selected tables are idle.
-Slot feedback advances through that boundary only after the target acknowledges
-the state.
+After logical replication starts on PostgreSQL 9.6 or later, PipelineWise
+attempts to emit one transactional ``pg_logical_emit_message`` in each tap
+database. The returned marker LSN identifies the fence, and the first decoded
+transaction commit at or beyond that position provides a safe bookmark boundary
+even when the selected tables are idle. Slot feedback advances through that
+boundary only after the target acknowledges the state.
 
 If the function is unavailable or inaccessible, replication continues using
 the captured current-WAL boundary. Fully filtered idle WAL may then require a

--- a/docs/connectors/taps/postgres.rst
+++ b/docs/connectors/taps/postgres.rst
@@ -4,7 +4,9 @@ PostgreSQL source
 =================
 
 ``tap-postgres`` extracts tables with full-table, key-based incremental, or
-wal2json logical replication.
+wal2json logical replication from PostgreSQL 11.2 or later. This source minimum
+applies to every Singer replication method and PipelineWise FullSync/PartialSync;
+it does not constrain PostgreSQL targets or the PipelineWise backend database.
 
 .. list-table:: Support
    :header-rows: 1
@@ -125,12 +127,14 @@ PipelineWise sends feedback only up to the minimum target-acknowledged LSN store
 in ``state.json``. Missing, unreadable, invalid, or regressing state retains the
 previous safe LSN.
 
-After logical replication starts on PostgreSQL 9.6 or later, PipelineWise
-attempts to emit one transactional ``pg_logical_emit_message`` in each tap
-database. The returned marker LSN identifies the fence, and the first decoded
-transaction commit at or beyond that position provides a safe bookmark boundary
-even when the selected tables are idle. Slot feedback advances through that
-boundary only after the target acknowledges the state.
+After logical replication starts, PipelineWise attempts to emit one transactional
+``pg_logical_emit_message`` in each tap database. It checks the available function
+signature and execution privilege before emission, avoiding an expected source
+error when the marker is unavailable or inaccessible. The returned marker LSN
+identifies the fence, and the first decoded transaction commit at or beyond that
+position provides a safe bookmark boundary even when the selected tables are
+idle. Slot feedback advances through that boundary only after the target
+acknowledges the state.
 
 If the function is unavailable or inaccessible, replication continues using
 the captured current-WAL boundary. Fully filtered idle WAL may then require a

--- a/docs/user_guide/troubleshooting.rst
+++ b/docs/user_guide/troubleshooting.rst
@@ -325,7 +325,7 @@ interval before changing timeouts or state.
 * **If the source or network terminated the connection,** correct that cause and
   restart the same tap without advancing state.
 
-* **For PostgreSQL versions before 12, consider upgrading.** PostgreSQL 12 and
+* **For PostgreSQL 11, consider upgrading.** PostgreSQL 12 and
   later support the session-level ``wal_sender_timeout`` that PipelineWise sets.
 
 * **If the PostgreSQL log reports a sender timeout,** check the effective value:
@@ -356,8 +356,8 @@ or concurrent transactions, or several PipelineWise replications consuming slots
 on the same PostgreSQL cluster can increase both spill I/O and total memory demand.
 
 *How to diagnose:*
-Check the configured value. PostgreSQL versions before 13 return no row because
-they do not provide this setting:
+Check the configured value. PostgreSQL 11 and 12 return no row because they do
+not provide this setting:
 
 .. code-block:: sql
 

--- a/pipelinewise/AGENTS.md
+++ b/pipelinewise/AGENTS.md
@@ -60,6 +60,10 @@ Read root `AGENTS.md` first, then relevant connector, test, E2E, and docs guides
 
 ## Runtime and data-diff constraints
 
+- PostgreSQL replication sources require 11.2 or later across Singer,
+  FullSync, and PartialSync. Keep the Singer and FastSync connection gates
+  aligned; only deleted-tap slot cleanup may bypass the floor. PostgreSQL
+  targets, the backend, and data-diff connections are separate.
 - Soft delete (`hard_delete: false`, `_SDC_DELETED_AT`) is deprecated. Preserve
   compatibility but add no features/docs, do not restore data-diff
   `exclude_soft_deleted`, and use `hard_delete: true` for new taps.

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -2635,7 +2635,10 @@ TAP RUN SUMMARY
                 self.get_tap_dir(target_id, tap_id)
             ))
             if tap_config:
-                FastSyncTapPostgres.drop_slot(tap_config)
+                FastSyncTapPostgres.drop_slot(
+                    tap_config,
+                    allow_unsupported_version_for_config_removal=True,
+                )
 
         utils.silentremove(self.get_tap_dir(target_id, tap_id))
 

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -17,6 +17,7 @@ from .partial_sync_boundary import PartialSyncBoundary
 from ...utils import safe_column_name
 
 LOGGER = logging.getLogger(__name__)
+MIN_SUPPORTED_POSTGRES_VERSION = 110002
 
 
 class FastSyncTapPostgres:
@@ -99,17 +100,30 @@ class FastSyncTapPostgres:
         return slot_name
 
     @classmethod
-    def drop_slot(cls, connection_config: Dict) -> None:
+    def drop_slot(
+        cls,
+        connection_config: Dict,
+        *,
+        allow_unsupported_version_for_config_removal: bool = False,
+    ) -> None:
         """
         Dropping the logical replication slot from primary server
 
         Args:
             connection_config: Dictionary with db credentials
+            allow_unsupported_version_for_config_removal: Permit cleanup of a
+                removed tap whose source predates the supported version floor.
         """
         LOGGER.info('Attempting to drop slot ...')
 
         LOGGER.debug('Creating a connection to Primary server ..')
-        connection = cls.get_connection(connection_config, prioritize_primary=True)
+        connection = cls.get_connection(
+            connection_config,
+            prioritize_primary=True,
+            allow_unsupported_version_for_config_removal=(
+                allow_unsupported_version_for_config_removal
+            ),
+        )
         LOGGER.debug('Connection to Primary server created.')
 
         try:
@@ -130,7 +144,13 @@ class FastSyncTapPostgres:
             connection.close()
 
     @classmethod
-    def get_connection(cls, connection_config: Dict, prioritize_primary: bool = False):
+    def get_connection(
+        cls,
+        connection_config: Dict,
+        prioritize_primary: bool = False,
+        *,
+        allow_unsupported_version_for_config_removal: bool = False,
+    ):
         """
         Class method to create a pg connection instance with autocommit enabled
         Connection is either to the primary or a replica if its credentials are given
@@ -138,6 +158,8 @@ class FastSyncTapPostgres:
         Args:
             prioritize_primary: boolean to control whether to connect to primary or replica
             connection_config: Dictionary containing the db connection details
+            allow_unsupported_version_for_config_removal: Permit only removed-tap
+                cleanup to connect below the supported version floor.
         Returns:
             pg Connection instance
         """
@@ -173,6 +195,19 @@ class FastSyncTapPostgres:
             conn_string += " sslmode='require'"
 
         conn = psycopg2.connect(conn_string)
+
+        if (
+            not allow_unsupported_version_for_config_removal
+            and conn.server_version < MIN_SUPPORTED_POSTGRES_VERSION
+        ):
+            server_version = conn.server_version
+            try:
+                conn.close()
+            finally:
+                raise RuntimeError(
+                    'PostgreSQL 11.2 or later is required; '
+                    f'connected server reports server_version_num {server_version}'
+                )
 
         # Set connection to autocommit
         conn.autocommit = True
@@ -288,7 +323,7 @@ class FastSyncTapPostgres:
             else:
                 raise exc
 
-    # pylint: disable=too-many-branches,no-member,chained-comparison
+    # pylint: disable=no-member
     def fetch_current_log_pos(self):
         """
         Get the actual wal position in Postgres
@@ -299,28 +334,6 @@ class FastSyncTapPostgres:
             self.connection_config, prioritize_primary=True
         )
         try:
-            # Make sure PostgreSQL version is 9.4 or higher
-            # pylint: disable=assignment-from-no-return
-            result = self.primary_host_query(
-                "SELECT setting::int AS version FROM pg_settings WHERE name='server_version_num'"
-            )
-            # pylint: disable=unsubscriptable-object
-            version = result[0].get('version')
-
-            # Do not allow minor versions with PostgreSQL BUG #15114
-            if (version >= 110000) and (version < 110002):
-                raise Exception('PostgreSQL upgrade required to minor version 11.2')
-            if (version >= 100000) and (version < 100007):
-                raise Exception('PostgreSQL upgrade required to minor version 10.7')
-            if (version >= 90600) and (version < 90612):
-                raise Exception('PostgreSQL upgrade required to minor version 9.6.12')
-            if (version >= 90500) and (version < 90516):
-                raise Exception('PostgreSQL upgrade required to minor version 9.5.16')
-            if (version >= 90400) and (version < 90421):
-                raise Exception('PostgreSQL upgrade required to minor version 9.4.21')
-            if version < 90400:
-                raise Exception('Logical replication not supported before PostgreSQL 9.4')
-
             # Create replication slot
             self.create_replication_slot()
         finally:
@@ -329,26 +342,10 @@ class FastSyncTapPostgres:
         # is replica_host set ?
         if self.connection_config.get('replica_host'):
             # Get latest applied lsn from replica_host
-            if version >= 100000:
-                result = self.query('SELECT pg_last_wal_replay_lsn() AS current_lsn')
-            elif version >= 90400:
-                result = self.query(
-                    'SELECT pg_last_xlog_replay_location() AS current_lsn'
-                )
-            else:
-                raise Exception(
-                    'Logical replication not supported before PostgreSQL 9.4'
-                )
+            result = self.query('SELECT pg_last_wal_replay_lsn() AS current_lsn')
         else:
             # Get current lsn from primary host
-            if version >= 100000:
-                result = self.query('SELECT pg_current_wal_lsn() AS current_lsn')
-            elif version >= 90400:
-                result = self.query('SELECT pg_current_xlog_location() AS current_lsn')
-            else:
-                raise Exception(
-                    'Logical replication not supported before PostgreSQL 9.4'
-                )
+            result = self.query('SELECT pg_current_wal_lsn() AS current_lsn')
 
         current_lsn = result[0].get('current_lsn')
         file, index = current_lsn.split('/')

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.12.*',
-      version='0.84.0',
+      version='0.84.1',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.12.*',
-      version='0.84.1',
+      version='0.85.0',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',

--- a/singer-connectors/AGENTS.md
+++ b/singer-connectors/AGENTS.md
@@ -22,6 +22,10 @@ The owning Makefile is authoritative. Run available environment, Pylint, unit,
 integration, and coverage targets without lowering thresholds; integration may
 need containers or credentials.
 
+Legacy connector Pylint configurations may not be green with the installed
+Pylint. Preserve or improve the master score and finding set, and report the
+baseline configuration errors and findings rather than claiming the gate passed.
+
 - Most use `venv`, `pylint`, `unit_test`, and `integration_test`; inspect the
   Makefile for variants.
 - PostgreSQL also requires `integration_test_cov` >=63 and `total_cov` >=85;
@@ -76,6 +80,10 @@ Parquet and a real client-side encryption master key.
 - These are upstream-derived copies. Coordinate non-trivial divergence
   upstream; keep local fixes narrow, comments limited to why divergence is
   needed, and avoid broad formatting.
+- PostgreSQL sources require version 11.2 or later for every Singer replication
+  method and PipelineWise FullSync/PartialSync. Keep their version checks aligned;
+  this source minimum does not constrain target-postgres or the PipelineWise
+  backend database.
 
 ## Snowflake traps
 

--- a/singer-connectors/tap-postgres/README.md
+++ b/singer-connectors/tap-postgres/README.md
@@ -8,6 +8,10 @@
 
 This is a [PipelineWise](https://transferwise.github.io/pipelinewise) compatible tap connector.
 
+PostgreSQL 11.2 or later is required for every Singer replication method and for
+PipelineWise FullSync/PartialSync. This source minimum does not constrain
+PostgreSQL targets or the PipelineWise backend database.
+
 ## How to use it
 
 The recommended method of running this tap is to use it from [PipelineWise](https://transferwise.github.io/pipelinewise). When running it from PipelineWise you don't need to configure this tap with JSON files and most of things are automated. Please check the related documentation at [Tap Postgres](https://transferwise.github.io/pipelinewise/connectors/taps/postgres.html)
@@ -115,15 +119,6 @@ The tap will write bookmarks to stdout which can be captured and passed as an op
 to the tap for the next sync.
 
 ### Log Based replication requirements
-
-* PostgreSQL databases running **PostgreSQL versions 9.4.x or greater**. To avoid a critical PostgreSQL bug,
-  use at least one of the following minor versions:
-   - PostgreSQL 12.0
-   - PostgreSQL 11.2
-   - PostgreSQL 10.7
-   - PostgreSQL 9.6.12
-   - PostgreSQL 9.5.16
-   - PostgreSQL 9.4.21
 
 * **A connection to the master instance**. Log-based replication will only work by connecting to the master instance.
 

--- a/singer-connectors/tap-postgres/tap_postgres/__init__.py
+++ b/singer-connectors/tap-postgres/tap_postgres/__init__.py
@@ -194,8 +194,7 @@ def sync_traditional_stream(conn_config, stream, state, sync_method, end_lsn):
     return state
 
 
-# pylint: disable-next=too-many-arguments
-def sync_logical_streams(conn_config, logical_streams, state, end_lsn, state_file, *, wal_progress_content=None):
+def sync_logical_streams(conn_config, logical_streams, state, end_lsn, state_file):
     """
     Sync streams that use LOG_BASED method
     """
@@ -225,7 +224,6 @@ def sync_logical_streams(conn_config, logical_streams, state, end_lsn, state_fil
             state,
             end_lsn,
             state_file,
-            wal_progress_content=wal_progress_content,
         )
 
     return state
@@ -328,17 +326,12 @@ def do_sync(conn_config, catalog, default_replication_method, state, state_file=
     for dbname, streams in itertools.groupby(
             logical_streams, lambda s: metadata.to_map(s['metadata']).get(()).get('database-name')):
         conn_config['dbname'] = dbname
-        # Logical messages are decoded only by slots in the same database.
-        wal_progress_content = logical_replication.emit_wal_progress_message(conn_config)
-        logical_end_lsn = (logical_replication.fetch_current_lsn(conn_config)
-                           if wal_progress_content is not None else end_lsn)
         state = sync_logical_streams(
             conn_config,
             list(streams),
             state,
-            logical_end_lsn,
+            end_lsn,
             state_file,
-            wal_progress_content=wal_progress_content,
         )
     return state
 

--- a/singer-connectors/tap-postgres/tap_postgres/db.py
+++ b/singer-connectors/tap-postgres/tap_postgres/db.py
@@ -14,6 +14,21 @@ from dateutil.parser import parse
 LOGGER = singer.get_logger('tap_postgres')
 
 CURSOR_ITER_SIZE = 20000
+MIN_SUPPORTED_POSTGRES_VERSION = 110002
+
+
+class UnsupportedPostgresVersionError(RuntimeError):
+    """Raised when a source is older than the connector support floor."""
+
+
+def validate_server_version(connection):
+    """Reject PostgreSQL source versions older than 11.2."""
+    server_version = connection.server_version
+    if server_version < MIN_SUPPORTED_POSTGRES_VERSION:
+        raise UnsupportedPostgresVersionError(
+            'PostgreSQL 11.2 or later is required; '
+            f'connected server reports server_version_num {server_version}'
+        )
 
 
 # pylint: disable=invalid-name,missing-function-docstring
@@ -62,6 +77,11 @@ def open_connection(conn_config, logical_replication=False, prioritize_primary=F
         cfg['connection_factory'] = psycopg2.extras.LogicalReplicationConnection
 
     conn = psycopg2.connect(**cfg)
+    try:
+        validate_server_version(conn)
+    except UnsupportedPostgresVersionError:
+        conn.close()
+        raise
 
     return conn
 
@@ -215,7 +235,7 @@ def compute_tap_stream_id(schema_name, table_name):
 # NB> numeric/decimal columns in postgres without a specified scale && precision
 # default to 'up to 131072 digits before the decimal point; up to 16383
 # digits after the decimal point'. For practical reasons, we are capping this at 74/38
-#  https://www.postgresql.org/docs/10/static/datatype-numeric.html#DATATYPE-NUMERIC-TABLE
+#  https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-TABLE
 MAX_SCALE = 38
 MAX_PRECISION = 100
 

--- a/singer-connectors/tap-postgres/tap_postgres/sync_strategies/logical_replication.py
+++ b/singer-connectors/tap-postgres/tap_postgres/sync_strategies/logical_replication.py
@@ -6,7 +6,6 @@ import copy
 import json
 import re
 import singer
-import uuid
 import warnings
 
 from select import select
@@ -26,7 +25,7 @@ FEEDBACK_POLL_INTERVAL = 10
 FALLBACK_DATETIME = '9999-12-31T23:59:59.999+00:00'
 FALLBACK_DATE = '9999-12-31T00:00:00+00:00'
 WAL_PROGRESS_MESSAGE_PREFIX = 'pipelinewise'
-WAL_PROGRESS_MESSAGE_CONTENT_PREFIX = 'wal_progress:'
+WAL_PROGRESS_MESSAGE_CONTENT = 'wal_progress'
 
 
 class ReplicationSlotNotFoundError(Exception):
@@ -114,43 +113,22 @@ def fetch_current_lsn(conn_config):
             return lsn_to_int(current_lsn)
 
 
-def wal_progress_message_content(conn_info, marker_id):
-    """Return content unique to one tap invocation."""
-    return f"{WAL_PROGRESS_MESSAGE_CONTENT_PREFIX}{conn_info['tap_id']}:{marker_id}"
-
-
 def emit_wal_progress_message(conn_info):
-    """Emit a source-database marker when logical messages are available."""
-    availability_query = """
-        WITH function_check AS (
-            SELECT to_regprocedure(
-                'pg_catalog.pg_logical_emit_message(boolean,text,text)'
-            ) AS function_oid
-        )
-        SELECT CASE
-                   WHEN function_oid IS NULL THEN FALSE
-                   ELSE has_function_privilege(current_user, function_oid, 'EXECUTE')
-               END
-          FROM function_check
-    """
-
-    message_content = wal_progress_message_content(conn_info, uuid.uuid4().hex)
+    """Emit a transactional marker through the portable three-argument API."""
     conn = None
     try:
         conn = post_db.open_connection(conn_info, False, True)
         with conn:
             with conn.cursor() as cur:
-                cur.execute(availability_query)
-                available = cur.fetchone()
-                if not available or available[0] is not True:
-                    LOGGER.debug('Logical WAL progress messages are unavailable')
-                    return None
-
                 cur.execute(
                     'SELECT pg_catalog.pg_logical_emit_message(TRUE, %s, %s)',
-                    (WAL_PROGRESS_MESSAGE_PREFIX, message_content)
+                    (WAL_PROGRESS_MESSAGE_PREFIX, WAL_PROGRESS_MESSAGE_CONTENT)
                 )
-        return message_content
+                emitted_lsn = cur.fetchone()
+        return lsn_to_int(emitted_lsn[0]) if emitted_lsn else None
+    except (psycopg2.errors.InsufficientPrivilege, psycopg2.errors.UndefinedFunction):
+        LOGGER.debug('Logical WAL progress messages are unavailable')
+        return None
     except psycopg2.Error as ex:
         LOGGER.warning('Unable to emit a logical WAL progress message; continuing without it: %s', ex)
         return None
@@ -662,7 +640,7 @@ def _write_lsn_state(state, logical_streams, lsn):
     return state
 
 
-def sync_tables(conn_info, logical_streams, state, end_lsn, state_file, *, wal_progress_content=None):
+def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
     target_acknowledged_lsn = _minimum_acknowledged_lsn(state, logical_streams)
     start_lsn = target_acknowledged_lsn
     lsn_to_flush = None
@@ -696,10 +674,6 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file, *, wal_p
         cur.execute(f"SET SESSION wal_sender_timeout = {wal_sender_timeout}")
 
     try:
-        LOGGER.info('Request wal streaming from %s to %s (slot %s)',
-                    int_to_lsn(start_lsn),
-                    int_to_lsn(end_lsn),
-                    slot)
         # psycopg2 2.8.4 will send a keep-alive message to postgres every status_interval
         cur.start_replication(slot_name=slot,
                               decode=True,
@@ -717,10 +691,18 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file, *, wal_p
     except psycopg2.ProgrammingError as ex:
         raise Exception(f"Unable to start replication with logical replication (slot {ex})") from ex
 
+    marker_lsn = emit_wal_progress_message(conn_info)
+    if marker_lsn is not None:
+        end_lsn = marker_lsn
+
+    LOGGER.info('Request wal streaming from %s to %s (slot %s)',
+                int_to_lsn(start_lsn),
+                int_to_lsn(end_lsn),
+                slot)
+
     lsn_received_timestamp = datetime.datetime.utcnow()
     poll_timestamp = datetime.datetime.utcnow()
 
-    wal_progress_message_seen = False
     completed_wal_progress_lsn = None
     try:
         while True:
@@ -742,7 +724,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file, *, wal_p
                 raise
 
             if msg:
-                if (break_at_end_lsn) and (msg.data_start > end_lsn):
+                if marker_lsn is None and break_at_end_lsn and msg.data_start > end_lsn:
                     LOGGER.info('Breaking - latest wal message %s is past end_lsn %s',
                                 int_to_lsn(msg.data_start),
                                 int_to_lsn(end_lsn))
@@ -752,13 +734,6 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file, *, wal_p
                     message_payload = json.loads(msg.payload)
                 except (TypeError, ValueError):
                     message_payload = {}
-
-                if (wal_progress_content is not None
-                        and message_payload.get('action') == 'M'
-                        and message_payload.get('transactional') is True
-                        and message_payload.get('prefix') == WAL_PROGRESS_MESSAGE_PREFIX
-                        and message_payload.get('content') == wal_progress_content):
-                    wal_progress_message_seen = True
 
                 state = consume_message(
                     logical_streams,
@@ -796,10 +771,13 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file, *, wal_p
                         state = _write_lsn_state(state, logical_streams, lsn_last_processed)
                         lsn_processed_count = 0
 
-                if wal_progress_message_seen and message_payload.get('action') == 'C':
+                # The returned marker LSN is inside its transaction. Only a decoded
+                # commit at or beyond it proves a complete, restart-safe boundary.
+                if (marker_lsn is not None
+                        and message_payload.get('action') == 'C'
+                        and msg.data_start >= marker_lsn):
                     lsn_last_processed = msg.data_start
                     completed_wal_progress_lsn = lsn_last_processed
-                    wal_progress_message_seen = False
                     if break_at_end_lsn:
                         LOGGER.info('Breaking - reached PipelineWise WAL progress message at %s',
                                     int_to_lsn(lsn_last_processed))

--- a/singer-connectors/tap-postgres/tap_postgres/sync_strategies/logical_replication.py
+++ b/singer-connectors/tap-postgres/tap_postgres/sync_strategies/logical_replication.py
@@ -815,7 +815,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
     finally:
         try:
             if finalize_state:
-                if lsn_last_processed:
+                if lsn_last_processed is not None:
                     if target_acknowledged_lsn > lsn_last_processed:
                         LOGGER.info('Current lsn_last_processed %s is older than target-acknowledged lsn %s',
                                     int_to_lsn(lsn_last_processed),

--- a/singer-connectors/tap-postgres/tap_postgres/sync_strategies/logical_replication.py
+++ b/singer-connectors/tap-postgres/tap_postgres/sync_strategies/logical_replication.py
@@ -36,20 +36,8 @@ class UnsupportedPayloadKindError(Exception):
     """Custom exception when waljson payload is not insert, update nor delete"""
 
 
+# Preserve the legacy connector lint baseline; scope new suppressions narrowly.
 # pylint: disable=invalid-name,missing-function-docstring,too-many-branches,too-many-statements,too-many-arguments
-def _read_pg_version(conn):
-    with conn.cursor() as cur:
-        cur.execute("SELECT setting::int AS version FROM pg_settings WHERE name='server_version_num'")
-        version = cur.fetchone()[0]
-    LOGGER.debug('Detected PostgreSQL version: %s', version)
-    return version
-
-
-def get_pg_version(conn_info):
-    with post_db.open_connection(conn_info, False, True) as conn:
-        return _read_pg_version(conn)
-
-
 def lsn_to_int(lsn):
     """Convert pg_lsn to int"""
 
@@ -64,7 +52,7 @@ def lsn_to_int(lsn):
 def int_to_lsn(lsni):
     """Convert int to pg_lsn"""
 
-    if not lsni:
+    if lsni is None:
         return None
 
     # Convert the integer to binary
@@ -83,31 +71,10 @@ def int_to_lsn(lsni):
     return lsn
 
 
-# pylint: disable=chained-comparison
 def fetch_current_lsn(conn_config):
     with post_db.open_connection(conn_config, False, True) as conn:
-        version = _read_pg_version(conn)
-        # Make sure PostgreSQL version is 9.4 or higher
-        # Do not allow minor versions with PostgreSQL BUG #15114
-        if (version >= 110000) and (version < 110002):
-            raise Exception('PostgreSQL upgrade required to minor version 11.2')
-        if (version >= 100000) and (version < 100007):
-            raise Exception('PostgreSQL upgrade required to minor version 10.7')
-        if (version >= 90600) and (version < 90612):
-            raise Exception('PostgreSQL upgrade required to minor version 9.6.12')
-        if (version >= 90500) and (version < 90516):
-            raise Exception('PostgreSQL upgrade required to minor version 9.5.16')
-        if (version >= 90400) and (version < 90421):
-            raise Exception('PostgreSQL upgrade required to minor version 9.4.21')
-        if version < 90400:
-            raise Exception('Logical replication not supported before PostgreSQL 9.4')
-
         with conn.cursor() as cur:
-            # Use version specific lsn command
-            if version >= 100000:
-                cur.execute("SELECT pg_current_wal_lsn() AS current_lsn")
-            else:
-                cur.execute("SELECT pg_current_xlog_location() AS current_lsn")
+            cur.execute("SELECT pg_current_wal_lsn() AS current_lsn")
 
             current_lsn = cur.fetchone()[0]
             return lsn_to_int(current_lsn)
@@ -115,18 +82,45 @@ def fetch_current_lsn(conn_config):
 
 def emit_wal_progress_message(conn_info):
     """Emit a transactional marker through the portable three-argument API."""
+    availability_query = """
+        WITH function_check AS (
+            SELECT COALESCE(
+                pg_catalog.to_regprocedure(
+                    'pg_catalog.pg_logical_emit_message(boolean,text,text,boolean)'
+                ),
+                pg_catalog.to_regprocedure(
+                    'pg_catalog.pg_logical_emit_message(boolean,text,text)'
+                )
+            ) AS function_oid
+        )
+        SELECT CASE
+                   WHEN function_oid IS NULL THEN FALSE
+                   ELSE pg_catalog.has_function_privilege(current_user, function_oid, 'EXECUTE')
+               END
+          FROM function_check
+    """
+
     conn = None
     try:
         conn = post_db.open_connection(conn_info, False, True)
         with conn:
             with conn.cursor() as cur:
+                cur.execute(availability_query)
+                available = cur.fetchone()
+                if not available or available[0] is not True:
+                    LOGGER.debug('Logical WAL progress messages are unavailable')
+                    return None
+
                 cur.execute(
                     'SELECT pg_catalog.pg_logical_emit_message(TRUE, %s, %s)',
                     (WAL_PROGRESS_MESSAGE_PREFIX, WAL_PROGRESS_MESSAGE_CONTENT)
                 )
                 emitted_lsn = cur.fetchone()
-        return lsn_to_int(emitted_lsn[0]) if emitted_lsn else None
-    except (psycopg2.errors.InsufficientPrivilege, psycopg2.errors.UndefinedFunction):
+        marker_lsn = lsn_to_int(emitted_lsn[0]) if emitted_lsn else None
+        return marker_lsn if marker_lsn is not None and marker_lsn > 0 else None
+    except (  # pylint: disable=no-member
+            psycopg2.errors.InsufficientPrivilege,
+            psycopg2.errors.UndefinedFunction):
         LOGGER.debug('Logical WAL progress messages are unavailable')
         return None
     except psycopg2.Error as ex:
@@ -640,6 +634,30 @@ def _write_lsn_state(state, logical_streams, lsn):
     return state
 
 
+def _start_replication(cur, logical_streams, slot, start_lsn, version):
+    if version >= 120000:
+        wal_sender_timeout = 10800000  # 10800000ms = 3 hours
+        LOGGER.info('Set session wal_sender_timeout = %i milliseconds', wal_sender_timeout)
+        cur.execute(f"SET SESSION wal_sender_timeout = {wal_sender_timeout}")
+
+    try:
+        # psycopg2 2.8.4 will send a keep-alive message to postgres every status_interval
+        cur.start_replication(slot_name=slot,
+                              decode=True,
+                              start_lsn=start_lsn,
+                              status_interval=FEEDBACK_POLL_INTERVAL,
+                              options={
+                                  'format-version': 2,
+                                  'include-transaction': True,
+                                  'include-timestamp': True,
+                                  'include-types': False,
+                                  'actions': 'insert,update,delete',
+                                  'add-tables': streams_to_wal2json_tables(logical_streams)
+                              })
+    except psycopg2.ProgrammingError as ex:
+        raise Exception(f"Unable to start replication with logical replication (slot {ex})") from ex
+
+
 def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
     target_acknowledged_lsn = _minimum_acknowledged_lsn(state, logical_streams)
     start_lsn = target_acknowledged_lsn
@@ -661,50 +679,30 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
             ['lsn'],
             record_update_mode=sync_common.PATCH_RECORD_UPDATE_MODE)
 
-    version = get_pg_version(conn_info)
-
     # Create replication connection and cursor
     conn = post_db.open_connection(conn_info, True, True)
-    cur = conn.cursor()
-
-    # Set session wal_sender_timeout for PG12 and above
-    if version >= 120000:
-        wal_sender_timeout = 10800000  # 10800000ms = 3 hours
-        LOGGER.info('Set session wal_sender_timeout = %i milliseconds', wal_sender_timeout)
-        cur.execute(f"SET SESSION wal_sender_timeout = {wal_sender_timeout}")
+    version = conn.server_version
+    cur = None
+    finalize_state = False
 
     try:
-        # psycopg2 2.8.4 will send a keep-alive message to postgres every status_interval
-        cur.start_replication(slot_name=slot,
-                              decode=True,
-                              start_lsn=start_lsn,
-                              status_interval=poll_interval,
-                              options={
-                                  'format-version': 2,
-                                  'include-transaction': True,
-                                  'include-timestamp': True,
-                                  'include-types': False,
-                                  'actions': 'insert,update,delete',
-                                  'add-tables': streams_to_wal2json_tables(logical_streams)
-                              })
+        cur = conn.cursor()
+        _start_replication(cur, logical_streams, slot, start_lsn, version)
 
-    except psycopg2.ProgrammingError as ex:
-        raise Exception(f"Unable to start replication with logical replication (slot {ex})") from ex
+        marker_lsn = emit_wal_progress_message(conn_info)
+        if marker_lsn is not None:
+            end_lsn = marker_lsn
 
-    marker_lsn = emit_wal_progress_message(conn_info)
-    if marker_lsn is not None:
-        end_lsn = marker_lsn
+        LOGGER.info('Request wal streaming from %s to %s (slot %s)',
+                    int_to_lsn(start_lsn),
+                    int_to_lsn(end_lsn),
+                    slot)
 
-    LOGGER.info('Request wal streaming from %s to %s (slot %s)',
-                int_to_lsn(start_lsn),
-                int_to_lsn(end_lsn),
-                slot)
+        lsn_received_timestamp = datetime.datetime.utcnow()
+        poll_timestamp = datetime.datetime.utcnow()
 
-    lsn_received_timestamp = datetime.datetime.utcnow()
-    poll_timestamp = datetime.datetime.utcnow()
-
-    completed_wal_progress_lsn = None
-    try:
+        completed_wal_progress_lsn = None
+        finalize_state = True
         while True:
             # Disconnect when no data received for logical_poll_total_seconds
             # needs to be long enough to wait for the largest single wal payload to avoid unplanned timeouts
@@ -774,6 +772,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
                 # The returned marker LSN is inside its transaction. Only a decoded
                 # commit at or beyond it proves a complete, restart-safe boundary.
                 if (marker_lsn is not None
+                        and completed_wal_progress_lsn is None
                         and message_payload.get('action') == 'C'
                         and msg.data_start >= marker_lsn):
                     lsn_last_processed = msg.data_start
@@ -813,24 +812,28 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
                         cur.send_feedback(write_lsn=lsn_to_flush, flush_lsn=lsn_to_flush, reply=True, force=True)
 
                 poll_timestamp = datetime.datetime.utcnow()
-
-        # Close replication connection and cursor
-        cur.close()
-        conn.close()
     finally:
-        if lsn_last_processed:
-            if target_acknowledged_lsn > lsn_last_processed:
-                LOGGER.info('Current lsn_last_processed %s is older than target-acknowledged lsn %s',
-                            int_to_lsn(lsn_last_processed),
-                            int_to_lsn(target_acknowledged_lsn))
-                lsn_last_processed = target_acknowledged_lsn
+        try:
+            if finalize_state:
+                if lsn_last_processed:
+                    if target_acknowledged_lsn > lsn_last_processed:
+                        LOGGER.info('Current lsn_last_processed %s is older than target-acknowledged lsn %s',
+                                    int_to_lsn(lsn_last_processed),
+                                    int_to_lsn(target_acknowledged_lsn))
+                        lsn_last_processed = target_acknowledged_lsn
 
-            LOGGER.info('Updating bookmarks for all streams to lsn = %s (%s)',
-                        lsn_last_processed,
-                        int_to_lsn(lsn_last_processed))
+                    LOGGER.info('Updating bookmarks for all streams to lsn = %s (%s)',
+                                lsn_last_processed,
+                                int_to_lsn(lsn_last_processed))
 
-            state = _write_lsn_state(state, logical_streams, lsn_last_processed)
-        else:
-            singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
+                    state = _write_lsn_state(state, logical_streams, lsn_last_processed)
+                else:
+                    singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
+        finally:
+            try:
+                if cur is not None:
+                    cur.close()
+            finally:
+                conn.close()
 
     return state

--- a/singer-connectors/tap-postgres/tests/integration/test_logical_replication.py
+++ b/singer-connectors/tap-postgres/tests/integration/test_logical_replication.py
@@ -357,34 +357,24 @@ class TestWalProgressMessageSlotAdvancement(unittest.TestCase):
         initial_lsn = state['bookmarks'][f'public-{self.selected_table}']['lsn']
 
         decoded_payloads = []
+        decoded_lsns = []
         original_consume_message = logical_replication.consume_message
         original_emit_wal_progress_message = logical_replication.emit_wal_progress_message
-        original_sync_tables = logical_replication.sync_tables
-        emitted_contents = []
-        later_contents = []
-        received_contents = []
+        emitted_lsns = []
         marker_commit_lsns = []
         marker_message_seen = False
 
         def capture_emitted_message(conn_info):
-            content = original_emit_wal_progress_message(conn_info)
-            emitted_contents.append(content)
-            later_contents.append(original_emit_wal_progress_message(conn_info))
-            return content
-
-        def capture_sync_tables(*args, wal_progress_content=None, **kwargs):
-            received_contents.append(wal_progress_content)
-            return original_sync_tables(
-                *args,
-                wal_progress_content=wal_progress_content,
-                **kwargs,
-            )
+            marker_lsn = original_emit_wal_progress_message(conn_info)
+            emitted_lsns.append(marker_lsn)
+            return marker_lsn
 
         def capture_message(streams_arg, state_arg, message, time_extracted, conn_info, *, message_payload=None):
             nonlocal marker_message_seen
             payload = json.loads(message.payload)
             decoded_payloads.append(payload)
-            if payload.get('action') == 'M' and payload.get('content') == emitted_contents[0]:
+            decoded_lsns.append(message.data_start)
+            if payload.get('action') == 'M' and message.data_start == emitted_lsns[0]:
                 marker_message_seen = True
             elif marker_message_seen and payload.get('action') == 'C':
                 marker_commit_lsns.append(message.data_start)
@@ -404,10 +394,6 @@ class TestWalProgressMessageSlotAdvancement(unittest.TestCase):
                 logical_replication,
                 'emit_wal_progress_message',
                 side_effect=capture_emitted_message,
-        ), unittest.mock.patch.object(
-                logical_replication,
-                'sync_tables',
-                side_effect=capture_sync_tables,
         ), unittest.mock.patch.object(logical_replication, 'consume_message', side_effect=capture_message), \
                 contextlib.redirect_stdout(output):
             state = tap_postgres.do_sync(
@@ -416,21 +402,15 @@ class TestWalProgressMessageSlotAdvancement(unittest.TestCase):
 
         new_lsn = state['bookmarks'][f'public-{self.selected_table}']['lsn']
         self.assertGreater(new_lsn, initial_lsn)
-        self.assertEqual(1, len(emitted_contents))
-        self.assertEqual(1, len(later_contents))
-        self.assertEqual(emitted_contents, received_contents)
+        self.assertEqual(1, len(emitted_lsns))
         self.assertEqual(marker_commit_lsns, [new_lsn])
         self.assertTrue(any(
             payload.get('action') == 'M'
             and payload.get('transactional') is True
             and payload.get('prefix') == 'pipelinewise'
-            and payload.get('content') == emitted_contents[0]
-            for payload in decoded_payloads
-        ))
-        self.assertFalse(any(
-            payload.get('action') == 'M'
-            and payload.get('content') == later_contents[0]
-            for payload in decoded_payloads
+            and payload.get('content') == 'wal_progress'
+            and message_lsn == emitted_lsns[0]
+            for payload, message_lsn in zip(decoded_payloads, decoded_lsns)
         ))
 
         messages = [json.loads(message) for message in output.getvalue().splitlines()]

--- a/singer-connectors/tap-postgres/tests/unit/test_common.py
+++ b/singer-connectors/tap-postgres/tests/unit/test_common.py
@@ -115,38 +115,30 @@ class TestLogicalProgressMarkers(TestCase):
             }],
         }
 
-    def test_each_database_gets_its_own_marker_and_boundary(self):
+    def test_each_database_gets_its_own_logical_sync(self):
         initial_stream = self._stream('initial', 'initial_db')
         logical_streams = [self._stream('logical_b', 'db_b'), self._stream('logical_a', 'db_a')]
         catalog = {'streams': [initial_stream, *logical_streams]}
         state = {'currently_syncing': None, 'bookmarks': {}}
         conn_config = {'dbname': 'configured_db'}
         fetched_databases = []
-        emitted_databases = []
         logical_calls = []
         traditional_boundaries = []
         events = []
-        lsn_values = iter([100, 210, 310])
 
         def fetch_current_lsn(config):
             fetched_databases.append(config['dbname'])
             events.append(f"fetch:{config['dbname']}")
-            return next(lsn_values)
-
-        def emit_wal_progress_message(config):
-            emitted_databases.append(config['dbname'])
-            events.append(f"emit:{config['dbname']}")
-            return f"marker:{config['dbname']}"
+            return 100
 
         def sync_traditional_stream(_config, _stream, current_state, _method, end_lsn):
             traditional_boundaries.append(end_lsn)
             events.append(f'traditional:{end_lsn}')
             return current_state
 
-        def sync_logical_streams(config, streams, current_state, end_lsn, _state_file, *, wal_progress_content):
-            logical_calls.append((config['dbname'], [stream['tap_stream_id'] for stream in streams],
-                                  end_lsn, wal_progress_content))
-            events.append(f"sync:{config['dbname']}:{end_lsn}:{wal_progress_content}")
+        def sync_logical_streams(config, streams, current_state, end_lsn, _state_file):
+            logical_calls.append((config['dbname'], [stream['tap_stream_id'] for stream in streams], end_lsn))
+            events.append(f"sync:{config['dbname']}:{end_lsn}")
             return current_state
 
         with patch('tap_postgres.is_selected_via_metadata', return_value=True), \
@@ -155,26 +147,19 @@ class TestLogicalProgressMarkers(TestCase):
                 patch('tap_postgres.sync_method_for_streams', return_value=(
                     {'initial': 'logical_initial'}, [initial_stream], logical_streams)), \
                 patch('tap_postgres.logical_replication.fetch_current_lsn', side_effect=fetch_current_lsn), \
-                patch('tap_postgres.logical_replication.emit_wal_progress_message',
-                      side_effect=emit_wal_progress_message), \
                 patch('tap_postgres.sync_traditional_stream', side_effect=sync_traditional_stream), \
                 patch('tap_postgres.sync_logical_streams', side_effect=sync_logical_streams):
             tap_postgres.do_sync(conn_config, catalog, 'LOG_BASED', state, 'state.json')
 
-        self.assertEqual(['configured_db', 'db_a', 'db_b'], fetched_databases)
-        self.assertEqual(['db_a', 'db_b'], emitted_databases)
+        self.assertEqual(['configured_db'], fetched_databases)
         self.assertEqual([100], traditional_boundaries)
         self.assertEqual([
-            ('db_a', ['logical_a'], 210, 'marker:db_a'),
-            ('db_b', ['logical_b'], 310, 'marker:db_b'),
+            ('db_a', ['logical_a'], 100),
+            ('db_b', ['logical_b'], 100),
         ], logical_calls)
         self.assertEqual([
             'fetch:configured_db',
             'traditional:100',
-            'emit:db_a',
-            'fetch:db_a',
-            'sync:db_a:210:marker:db_a',
-            'emit:db_b',
-            'fetch:db_b',
-            'sync:db_b:310:marker:db_b',
+            'sync:db_a:100',
+            'sync:db_b:100',
         ], events)

--- a/singer-connectors/tap-postgres/tests/unit/test_db.py
+++ b/singer-connectors/tap-postgres/tests/unit/test_db.py
@@ -2,12 +2,68 @@ import decimal
 import unittest
 
 import datetime
+from unittest.mock import MagicMock, patch
 
 from tap_postgres import db
 
 
 class TestDbFunctions(unittest.TestCase):
     maxDiff = None
+
+    def setUp(self):
+        self.conn_config = {
+            'host': 'primary.example.com',
+            'dbname': 'source_db',
+            'user': 'pipelinewise',
+            'password': 'secret',
+            'port': 5432,
+            'use_secondary': False,
+        }
+
+    @patch('tap_postgres.db.psycopg2.connect')
+    def test_open_connection_rejects_postgres_before_11_2(self, connect):
+        """Every connector connection rejects an unsupported source."""
+        connection = connect.return_value
+        connection.server_version = 110001
+
+        with self.assertRaisesRegex(
+                db.UnsupportedPostgresVersionError,
+                'PostgreSQL 11.2 or later is required; '
+                'connected server reports server_version_num 110001',
+        ):
+            db.open_connection(self.conn_config)
+
+        connection.close.assert_called_once_with()
+
+    @patch('tap_postgres.db.psycopg2.connect')
+    def test_open_connection_accepts_supported_versions(self, connect):
+        """The exact support floor and newer logical connections are accepted."""
+        cases = ((110002, False), (110002, True), (180000, True))
+
+        for server_version, logical_replication in cases:
+            with self.subTest(
+                    server_version=server_version,
+                    logical_replication=logical_replication,
+            ):
+                connect.reset_mock()
+                connection = MagicMock()
+                connection.server_version = server_version
+                connect.return_value = connection
+
+                result = db.open_connection(
+                    self.conn_config,
+                    logical_replication=logical_replication,
+                )
+
+                self.assertIs(connection, result)
+                connection.close.assert_not_called()
+                if logical_replication:
+                    self.assertIs(
+                        db.psycopg2.extras.LogicalReplicationConnection,
+                        connect.call_args.kwargs['connection_factory'],
+                    )
+                else:
+                    self.assertNotIn('connection_factory', connect.call_args.kwargs)
 
     def test_value_to_singer_value(self):
         """Test if every element converted from sql_datatype to the correct singer type"""
@@ -220,4 +276,3 @@ class TestDbFunctions(unittest.TestCase):
         expected_output = "foo AND n.nspname in ('bar_1','bar_2')"
         actual_output = db.filter_schemas_sql_clause(sql, filter_schemas)
         self.assertEqual(expected_output, actual_output)
-

--- a/singer-connectors/tap-postgres/tests/unit/test_full_table.py
+++ b/singer-connectors/tap-postgres/tests/unit/test_full_table.py
@@ -14,6 +14,7 @@ class TestFullTable(TestCase):
         super(TestFullTable, cls).setUpClass()
         cls.patcher = patch('psycopg2.connect')
         mocked_connect = cls.patcher.start()
+        mocked_connect.return_value.server_version = 110002
         mocked_connect.return_value.__enter__.return_value = MockedConnect()
 
     @classmethod

--- a/singer-connectors/tap-postgres/tests/unit/test_incremental.py
+++ b/singer-connectors/tap-postgres/tests/unit/test_incremental.py
@@ -16,6 +16,7 @@ class TestIncremental(TestCase):
         super(TestIncremental, cls).setUpClass()
         cls.patcher = patch('psycopg2.connect')
         mocked_connect = cls.patcher.start()
+        mocked_connect.return_value.server_version = 110002
         mocked_connect.return_value.__enter__.return_value = MockedConnect()
 
     @classmethod

--- a/singer-connectors/tap-postgres/tests/unit/test_logical_replication.py
+++ b/singer-connectors/tap-postgres/tests/unit/test_logical_replication.py
@@ -657,40 +657,51 @@ class TestLogicalReplication(unittest.TestCase):
                     call(lsn_query),
                 ], cursor.execute.call_args_list)
 
-    @patch('tap_postgres.sync_strategies.logical_replication.uuid.uuid4')
     @patch('tap_postgres.sync_strategies.logical_replication.post_db.open_connection')
-    def test_emit_wal_progress_message(self, mocked_open_connection, mocked_uuid):
-        """Emit a transactional marker through a primary connection when permitted."""
+    def test_emit_wal_progress_message(self, mocked_open_connection):
+        """Return the WAL position of a transactional marker."""
         connection = mocked_open_connection.return_value
         cursor = connection.cursor.return_value.__enter__.return_value
-        cursor.fetchone.return_value = (True,)
-        mocked_uuid.return_value.hex = 'unique_marker'
+        cursor.fetchone.return_value = ('1/2',)
 
         self.assertEqual(
-            'wal_progress:tap_id_value:unique_marker',
+            4294967298,
             logical_replication.emit_wal_progress_message(self.conn_info),
         )
 
         mocked_open_connection.assert_called_once_with(self.conn_info, False, True)
-        self.assertEqual(cursor.execute.call_count, 2)
+        self.assertEqual(cursor.execute.call_count, 1)
         self.assertEqual(
-            cursor.execute.call_args_list[-1],
+            cursor.execute.call_args,
             call(
                 'SELECT pg_catalog.pg_logical_emit_message(TRUE, %s, %s)',
-                ('pipelinewise', 'wal_progress:tap_id_value:unique_marker')
+                ('pipelinewise', 'wal_progress')
             )
         )
         connection.close.assert_called_once_with()
 
     @patch('tap_postgres.sync_strategies.logical_replication.post_db.open_connection')
-    def test_emit_wal_progress_message_skips_unavailable_function(self, mocked_open_connection):
-        """Old or restricted PostgreSQL sources retain the existing behavior."""
+    def test_emit_wal_progress_message_ignores_an_empty_result(self, mocked_open_connection):
+        """An empty result retains the existing fallback boundary."""
         connection = mocked_open_connection.return_value
         cursor = connection.cursor.return_value.__enter__.return_value
-        cursor.fetchone.return_value = (False,)
+        cursor.fetchone.return_value = None
 
         self.assertIsNone(logical_replication.emit_wal_progress_message(self.conn_info))
         self.assertEqual(cursor.execute.call_count, 1)
+        connection.close.assert_called_once_with()
+
+    @patch('tap_postgres.sync_strategies.logical_replication.post_db.open_connection')
+    def test_emit_wal_progress_message_skips_unavailable_function(self, mocked_open_connection):
+        """Missing function access retains the existing quiet fallback."""
+        connection = mocked_open_connection.return_value
+        cursor = connection.cursor.return_value.__enter__.return_value
+        cursor.execute.side_effect = psycopg2.errors.InsufficientPrivilege('permission denied')
+
+        with self.assertLogs('tap_postgres', level='DEBUG') as logs:
+            self.assertIsNone(logical_replication.emit_wal_progress_message(self.conn_info))
+
+        self.assertIn('Logical WAL progress messages are unavailable', logs.output[0])
         connection.close.assert_called_once_with()
 
     @patch('tap_postgres.sync_strategies.logical_replication.post_db.open_connection')
@@ -1164,9 +1175,11 @@ class TestLogicalReplication(unittest.TestCase):
         mocked_start_replication.side_effect = psycopg2.ProgrammingError(test_replication_slot)
         mocked_locate_rep_slot.return_value = test_replication_slot
 
-        with self.assertRaises(Exception) as exp:
+        with patch('tap_postgres.sync_strategies.logical_replication.emit_wal_progress_message') as emit_marker, \
+                self.assertRaises(Exception) as exp:
             logical_replication.sync_tables(self.conn_info, self.logical_streams, state, end_lsn, state_file)
         self.assertEqual(expected_message, str(exp.exception))
+        emit_marker.assert_not_called()
         send_schema_message.assert_called_once_with(
             self.logical_streams[0],
             ['lsn'],
@@ -1195,9 +1208,10 @@ class TestLogicalReplication(unittest.TestCase):
         mocked_datetime.utcnow().__sub__().total_seconds.return_value = test_poll_duration
         mocked_start_replication = mocked_connect.return_value.cursor.return_value.start_replication
 
-        actual_output = logical_replication.sync_tables(self.conn_info,
-                                                        self.logical_streams,
-                                                        state, end_lsn, state_file)
+        with patch('tap_postgres.sync_strategies.logical_replication.emit_wal_progress_message', return_value=None):
+            actual_output = logical_replication.sync_tables(self.conn_info,
+                                                            self.logical_streams,
+                                                            state, end_lsn, state_file)
 
         self.assertDictEqual(state, actual_output)
         mocked_start_replication.assert_called_with(
@@ -1236,9 +1250,10 @@ class TestLogicalReplication(unittest.TestCase):
 
         mocked_start_replication = mocked_connect.return_value.cursor.return_value.start_replication
         mocked_locate_rep_slot.return_value = rep_slot
-        actual_output = logical_replication.sync_tables(self.conn_info,
-                                                        self.logical_streams,
-                                                        state, end_lsn, state_file)
+        with patch('tap_postgres.sync_strategies.logical_replication.emit_wal_progress_message', return_value=None):
+            actual_output = logical_replication.sync_tables(self.conn_info,
+                                                            self.logical_streams,
+                                                            state, end_lsn, state_file)
 
         self.assertDictEqual(state, actual_output)
         mocked_start_replication.assert_called_with(
@@ -1272,7 +1287,8 @@ class TestLogicalReplication(unittest.TestCase):
         expected_message = 'FOO'
         mocked_connect.return_value.cursor.return_value.read_message.side_effect = Exception(expected_message)
 
-        with self.assertRaises(Exception) as exp:
+        with patch('tap_postgres.sync_strategies.logical_replication.emit_wal_progress_message', return_value=None), \
+                self.assertRaises(Exception) as exp:
             logical_replication.sync_tables(self.conn_info, self.logical_streams, state, end_lsn, state_file)
         self.assertEqual(expected_message, str(exp.exception))
 
@@ -1302,7 +1318,8 @@ class TestLogicalReplication(unittest.TestCase):
         expected_log_message = 'INFO:tap_postgres:Breaking - latest wal message ' \
                                f'{logical_replication.int_to_lsn(msg_data_start)} is' \
                                f' past end_lsn {logical_replication.int_to_lsn(end_lsn)}'
-        with self.assertLogs() as captured_log:
+        with patch('tap_postgres.sync_strategies.logical_replication.emit_wal_progress_message', return_value=None), \
+                self.assertLogs() as captured_log:
             actual_output = logical_replication.sync_tables(self.conn_info, self.logical_streams, state, end_lsn,
                                                             state_file)
             self.assertIn(expected_log_message, captured_log.output)
@@ -1329,8 +1346,9 @@ class TestLogicalReplication(unittest.TestCase):
         mocked_connect.return_value.cursor.return_value.read_message.return_value = None
         mocked_locate_rep_slot.return_value = 'mocked_value_for_replication_slot'
 
-        actual_output = logical_replication.sync_tables(self.conn_info, self.logical_streams, state, end_lsn,
-                                                        state_file)
+        with patch('tap_postgres.sync_strategies.logical_replication.emit_wal_progress_message', return_value=None):
+            actual_output = logical_replication.sync_tables(self.conn_info, self.logical_streams, state, end_lsn,
+                                                            state_file)
         self.assertEqual(state, actual_output)
 
     @patch('tap_postgres.sync_strategies.logical_replication.locate_replication_slot')
@@ -1358,9 +1376,10 @@ class TestLogicalReplication(unittest.TestCase):
         mocked_connect.return_value.cursor.return_value.read_message.return_value = test_message()
 
         mocked_locate_rep_slot.return_value = 'mocked_value_for_replication_slot'
-        actual_output = logical_replication.sync_tables(self.conn_info,
-                                                        self.logical_streams,
-                                                        state, end_lsn, state_file)
+        with patch('tap_postgres.sync_strategies.logical_replication.emit_wal_progress_message', return_value=None):
+            actual_output = logical_replication.sync_tables(self.conn_info,
+                                                            self.logical_streams,
+                                                            state, end_lsn, state_file)
 
         self.assertEqual(state, actual_output)
         mocked_send_feedback = mocked_connect.return_value.cursor.return_value.send_feedback
@@ -1453,8 +1472,7 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
 
         self.assertEqual(150, acknowledged_lsn)
 
-    def _run_sync(self, state, messages, state_reader, logical_streams=None,
-                  wal_progress_content='wal_progress:tap_id_value:current'):
+    def _run_sync(self, state, messages, state_reader, logical_streams=None, marker_lsn=None):
         termination = RuntimeError('unexpected replication termination')
         streams = self.logical_streams if logical_streams is None else logical_streams
 
@@ -1466,6 +1484,8 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
                 patch('tap_postgres.sync_strategies.logical_replication.locate_replication_slot',
                       return_value='replication_slot'), \
                 patch('tap_postgres.sync_strategies.logical_replication.get_pg_version', return_value=150000), \
+                patch('tap_postgres.sync_strategies.logical_replication.emit_wal_progress_message',
+                      return_value=marker_lsn) as mocked_emit_marker, \
                 patch('builtins.open', state_reader), \
                 patch('psycopg2.connect') as mocked_connect:
             cursor = mocked_connect.return_value.cursor.return_value
@@ -1479,11 +1499,11 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
                     state,
                     1000,
                     'state.json',
-                    wal_progress_content=wal_progress_content,
                 )
             except Exception as exc:  # The harness captures the intentional termination or regression failure.
                 error = exc
 
+        mocked_emit_marker.assert_called_once_with(self.conn_info)
         return list(cursor.send_feedback.call_args_list), error, termination, list(mocked_write.call_args_list)
 
     def test_consuming_wal_does_not_advance_feedback_past_target_state(self):
@@ -1523,14 +1543,14 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
             self._message('C', 220),
         ]
 
-        feedback, error, _, _ = self._run_sync(state, messages, state_reader)
+        feedback, error, _, _ = self._run_sync(state, messages, state_reader, marker_lsn=210)
 
         self.assertIsNone(error)
         self.assertEqual(220, state['bookmarks']['foo-bar']['lsn'])
         self.assertEqual(self._expected_feedback(100), feedback)
 
-    def test_stale_progress_message_does_not_end_current_sync(self):
-        """A marker from an earlier invocation cannot satisfy the current boundary."""
+    def test_commit_before_marker_position_does_not_end_current_sync(self):
+        """A commit older than the emitted marker cannot satisfy the boundary."""
         state = self._state({'foo-bar': 100})
         self.conn_info['break_at_end_lsn'] = True
         state_reader = mock_open(read_data=json.dumps(state))
@@ -1555,7 +1575,7 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
             self._message('C', 320),
         ]
 
-        feedback, error, _, _ = self._run_sync(state, messages, state_reader)
+        feedback, error, _, _ = self._run_sync(state, messages, state_reader, marker_lsn=310)
 
         self.assertIsNone(error)
         self.assertEqual(320, state['bookmarks']['foo-bar']['lsn'])
@@ -1583,7 +1603,8 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
             self._message('C', 220),
         ]
 
-        feedback, error, termination, written_messages = self._run_sync(state, messages, state_reader)
+        feedback, error, termination, written_messages = self._run_sync(
+            state, messages, state_reader, marker_lsn=210)
 
         self.assertIs(error, termination)
         self.assertEqual(220, state['bookmarks']['foo-bar']['lsn'])
@@ -1591,8 +1612,8 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
         self.assertEqual(2, len(written_messages))
         self.assertEqual(220, written_messages[0].args[0].value['bookmarks']['foo-bar']['lsn'])
 
-    def test_only_own_committed_progress_message_creates_boundary(self):
-        """Incomplete, foreign, and non-transactional messages are not safe boundaries."""
+    def test_only_commit_at_or_after_marker_position_creates_boundary(self):
+        """Marker content is irrelevant, but a qualifying commit remains mandatory."""
         cases = {
             'interrupted_before_commit': ([
                 self._message('B', 200),
@@ -1604,7 +1625,7 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
                     content='wal_progress:tap_id_value:current',
                 ),
             ], 200),
-            'foreign_tap': ([
+            'commit_before_marker': ([
                 self._message('B', 200),
                 self._message(
                     'M',
@@ -1612,17 +1633,6 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
                     transactional=True,
                     prefix='pipelinewise',
                     content='wal_progress:another_tap:current',
-                ),
-                self._message('C', 220),
-            ], 210),
-            'non_transactional': ([
-                self._message('B', 200),
-                self._message(
-                    'M',
-                    210,
-                    transactional=False,
-                    prefix='pipelinewise',
-                    content='wal_progress:tap_id_value:current',
                 ),
                 self._message('C', 220),
             ], 210),
@@ -1634,7 +1644,8 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
                 state = self._state({'foo-bar': 100})
                 state_reader = mock_open(read_data=json.dumps(state))
 
-                feedback, error, termination, _ = self._run_sync(state, messages, state_reader)
+                feedback, error, termination, _ = self._run_sync(
+                    state, messages, state_reader, marker_lsn=310)
 
                 self.assertIs(error, termination)
                 self.assertEqual(expected_lsn, state['bookmarks']['foo-bar']['lsn'])

--- a/singer-connectors/tap-postgres/tests/unit/test_logical_replication.py
+++ b/singer-connectors/tap-postgres/tests/unit/test_logical_replication.py
@@ -615,54 +615,52 @@ class TestLogicalReplication(unittest.TestCase):
         }, output)
 
     @patch('tap_postgres.sync_strategies.logical_replication.post_db.open_connection')
-    def test_fetch_current_lsn_raises_exception_on_different_versions_of_pg(self, mocked_open_connection):
-        """Test if it raises exception on unsupported versions"""
-        connection = mocked_open_connection.return_value.__enter__.return_value
-        cursor = connection.cursor.return_value.__enter__.return_value
-        test_versions = [110000, 100000, 90600, 90500, 90400, 90399]
-        for version in test_versions:
-            with self.subTest(version=version):
-                mocked_open_connection.reset_mock()
-                cursor.fetchone.return_value = [version]
-
-                self.assertRaises(Exception, logical_replication.fetch_current_lsn, self.conn_info)
-
-                mocked_open_connection.assert_called_once_with(self.conn_info, False, True)
-
-    @patch('tap_postgres.sync_strategies.logical_replication.post_db.open_connection')
     def test_fetch_current_lsn(self, mocked_open_connection):
-        """Fetch the version and current LSN through one primary connection."""
+        """Fetch the current LSN through one primary connection."""
         connection = mocked_open_connection.return_value.__enter__.return_value
         cursor = connection.cursor.return_value.__enter__.return_value
-        test_versions = [
-            (110002, 'SELECT pg_current_wal_lsn() AS current_lsn'),
-            (90421, 'SELECT pg_current_xlog_location() AS current_lsn'),
-        ]
         test_lsn = '1/2'
+        cursor.fetchone.return_value = [test_lsn]
 
         # Look at tap_postgres.sync_strategies.logical_replication.lsn_to_int to find out why!
         converted_lsn_to_int = 4294967298
 
-        for version, lsn_query in test_versions:
+        actual_value = logical_replication.fetch_current_lsn(self.conn_info)
+
+        self.assertEqual(converted_lsn_to_int, actual_value)
+        mocked_open_connection.assert_called_once_with(self.conn_info, False, True)
+        cursor.execute.assert_called_once_with(
+            'SELECT pg_current_wal_lsn() AS current_lsn'
+        )
+
+    def test_start_replication_sets_wal_sender_timeout_from_postgres_12(self):
+        """PostgreSQL 11.2 remains valid without the PostgreSQL 12 setting."""
+        for version, sets_timeout in ((110002, False), (120000, True)):
             with self.subTest(version=version):
-                mocked_open_connection.reset_mock()
-                cursor.fetchone.side_effect = [[version], [test_lsn]]
+                cursor = Mock()
 
-                actual_value = logical_replication.fetch_current_lsn(self.conn_info)
+                logical_replication._start_replication(
+                    cursor,
+                    self.logical_streams,
+                    'pipelinewise_slot',
+                    42,
+                    version,
+                )
 
-                self.assertEqual(converted_lsn_to_int, actual_value)
-                mocked_open_connection.assert_called_once_with(self.conn_info, False, True)
-                self.assertEqual([
-                    call("SELECT setting::int AS version FROM pg_settings WHERE name='server_version_num'"),
-                    call(lsn_query),
-                ], cursor.execute.call_args_list)
+                if sets_timeout:
+                    cursor.execute.assert_called_once_with(
+                        'SET SESSION wal_sender_timeout = 10800000'
+                    )
+                else:
+                    cursor.execute.assert_not_called()
+                cursor.start_replication.assert_called_once()
 
     @patch('tap_postgres.sync_strategies.logical_replication.post_db.open_connection')
     def test_emit_wal_progress_message(self, mocked_open_connection):
         """Return the WAL position of a transactional marker."""
         connection = mocked_open_connection.return_value
         cursor = connection.cursor.return_value.__enter__.return_value
-        cursor.fetchone.return_value = ('1/2',)
+        cursor.fetchone.side_effect = [(True,), ('1/2',)]
 
         self.assertEqual(
             4294967298,
@@ -670,9 +668,12 @@ class TestLogicalReplication(unittest.TestCase):
         )
 
         mocked_open_connection.assert_called_once_with(self.conn_info, False, True)
-        self.assertEqual(cursor.execute.call_count, 1)
+        self.assertEqual(cursor.execute.call_count, 2)
+        availability_query = cursor.execute.call_args_list[0].args[0]
+        self.assertIn('pg_logical_emit_message(boolean,text,text,boolean)', availability_query)
+        self.assertIn('pg_logical_emit_message(boolean,text,text)', availability_query)
         self.assertEqual(
-            cursor.execute.call_args,
+            cursor.execute.call_args_list[1],
             call(
                 'SELECT pg_catalog.pg_logical_emit_message(TRUE, %s, %s)',
                 ('pipelinewise', 'wal_progress')
@@ -685,10 +686,10 @@ class TestLogicalReplication(unittest.TestCase):
         """An empty result retains the existing fallback boundary."""
         connection = mocked_open_connection.return_value
         cursor = connection.cursor.return_value.__enter__.return_value
-        cursor.fetchone.return_value = None
+        cursor.fetchone.side_effect = [(True,), None]
 
         self.assertIsNone(logical_replication.emit_wal_progress_message(self.conn_info))
-        self.assertEqual(cursor.execute.call_count, 1)
+        self.assertEqual(cursor.execute.call_count, 2)
         connection.close.assert_called_once_with()
 
     @patch('tap_postgres.sync_strategies.logical_replication.post_db.open_connection')
@@ -696,12 +697,38 @@ class TestLogicalReplication(unittest.TestCase):
         """Missing function access retains the existing quiet fallback."""
         connection = mocked_open_connection.return_value
         cursor = connection.cursor.return_value.__enter__.return_value
-        cursor.execute.side_effect = psycopg2.errors.InsufficientPrivilege('permission denied')
+        cursor.fetchone.return_value = (False,)
 
         with self.assertLogs('tap_postgres', level='DEBUG') as logs:
             self.assertIsNone(logical_replication.emit_wal_progress_message(self.conn_info))
 
         self.assertIn('Logical WAL progress messages are unavailable', logs.output[0])
+        self.assertEqual(cursor.execute.call_count, 1)
+        connection.close.assert_called_once_with()
+
+    @patch('tap_postgres.sync_strategies.logical_replication.post_db.open_connection')
+    def test_emit_wal_progress_message_handles_availability_race(self, mocked_open_connection):
+        """A privilege change after the capability check retains the quiet fallback."""
+        connection = mocked_open_connection.return_value
+        cursor = connection.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = (True,)
+        cursor.execute.side_effect = [None, psycopg2.errors.InsufficientPrivilege('permission denied')]
+
+        with self.assertLogs('tap_postgres', level='DEBUG') as logs:
+            self.assertIsNone(logical_replication.emit_wal_progress_message(self.conn_info))
+
+        self.assertIn('Logical WAL progress messages are unavailable', logs.output[0])
+        self.assertEqual(cursor.execute.call_count, 2)
+        connection.close.assert_called_once_with()
+
+    @patch('tap_postgres.sync_strategies.logical_replication.post_db.open_connection')
+    def test_emit_wal_progress_message_rejects_zero_lsn(self, mocked_open_connection):
+        """A zero marker cannot replace the captured fallback boundary."""
+        connection = mocked_open_connection.return_value
+        cursor = connection.cursor.return_value.__enter__.return_value
+        cursor.fetchone.side_effect = [(True,), ('0/0',)]
+
+        self.assertIsNone(logical_replication.emit_wal_progress_message(self.conn_info))
         connection.close.assert_called_once_with()
 
     @patch('tap_postgres.sync_strategies.logical_replication.post_db.open_connection')
@@ -762,6 +789,8 @@ class TestLogicalReplication(unittest.TestCase):
     def test_int_to_lsn(self):
         """Test if int_to_lsn returns expected values"""
         values_to_test = [(None, None),
+                          (0, '0/0'),
+                          (1, '0/1'),
                           (12, '0/C'),  # length < 32
                           (2 ** 123, '80000000000000000000000/0')  # Length > 32
                           ]
@@ -798,6 +827,7 @@ class TestLogicalReplication(unittest.TestCase):
     @patch("psycopg2.connect")
     def test_create_hstore_elem(self, mocked_connect):
         """Test if the output of create_hstore_elem is as expected"""
+        mocked_connect.return_value.server_version = 110002
         mocked_cursor = mocked_connect.return_value.__enter__.return_value.cursor
         mocked_fetchone = mocked_cursor.return_value.__enter__.return_value.fetchone
         mocked_fetchone.return_value = (['foo', 'bar'],)
@@ -809,6 +839,7 @@ class TestLogicalReplication(unittest.TestCase):
     @patch("psycopg2.connect")
     def test_create_array_elem(self, mocked_connect):
         """Test if the output of create_array_elem is as expected"""
+        mocked_connect.return_value.server_version = 110002
         mocked_cursor = mocked_connect.return_value.__enter__.return_value.cursor
         mocked_fetchone = mocked_cursor.return_value.__enter__.return_value.fetchone
         test_values = [('foo', '{bar}', ['bar']),
@@ -855,6 +886,7 @@ class TestLogicalReplication(unittest.TestCase):
     @patch("psycopg2.connect")
     def test_selected_value_to_singer_value(self, mocked_connect):
         """Test if selected_value_to_singer_value returns expected value"""
+        mocked_connect.return_value.server_version = 110002
         mocked_cursor = mocked_connect.return_value.__enter__.return_value.cursor
         mocked_fetchone = mocked_cursor.return_value.__enter__.return_value.fetchone
         mocked_fetchone.return_value = (['foo'],)
@@ -901,6 +933,7 @@ class TestLogicalReplication(unittest.TestCase):
     @patch("psycopg2.connect")
     def test_locate_replication_slot(self, mocked_connect):
         """Test locate_replication_slot returns excpected value"""
+        mocked_connect.return_value.server_version = 110002
         mocked_cursor = mocked_connect.return_value.__enter__.return_value.cursor
         mocked_fetchall = mocked_cursor.return_value.__enter__.return_value.fetchall
         mocked_fetchall.return_value = ['foo']
@@ -1020,6 +1053,7 @@ class TestLogicalReplication(unittest.TestCase):
     @patch("psycopg2.connect")
     def test_impl_with_sql_datatype_is_hstore(self, mocked_connect):
         """Test selected_value_to_singer_value_impl if datatype is hstore"""
+        mocked_connect.return_value.server_version = 110002
         mocked_cursor = mocked_connect.return_value.__enter__.return_value.cursor
         mocked_fetchone = mocked_cursor.return_value.__enter__.return_value.fetchone
         mocked_fetchone.return_value = (['1', '0', '2', '1'],)
@@ -1153,11 +1187,9 @@ class TestLogicalReplication(unittest.TestCase):
 
     @patch('tap_postgres.sync_strategies.logical_replication.sync_common.send_schema_message')
     @patch('tap_postgres.sync_strategies.logical_replication.locate_replication_slot')
-    @patch('tap_postgres.sync_strategies.logical_replication.get_pg_version')
     @patch("psycopg2.connect")
     def test_sync_tables_raises_exception_if_psycopg2_programming_error(self,
                                                                         mocked_connect,
-                                                                        mocked_version,
                                                                         mocked_locate_rep_slot,
                                                                         send_schema_message):
         """Test if sync_tables raises exception on psycopg2.ProgrammingError"""
@@ -1171,7 +1203,7 @@ class TestLogicalReplication(unittest.TestCase):
         test_replication_slot = 'foo_slot'
         expected_message = 'Unable to start replication with logical replication' \
                            f' (slot {test_replication_slot})'
-        mocked_version.return_value = 150000
+        mocked_connect.return_value.server_version = 150000
         mocked_start_replication.side_effect = psycopg2.ProgrammingError(test_replication_slot)
         mocked_locate_rep_slot.return_value = test_replication_slot
 
@@ -1180,6 +1212,8 @@ class TestLogicalReplication(unittest.TestCase):
             logical_replication.sync_tables(self.conn_info, self.logical_streams, state, end_lsn, state_file)
         self.assertEqual(expected_message, str(exp.exception))
         emit_marker.assert_not_called()
+        mocked_connect.return_value.cursor.return_value.close.assert_called_once_with()
+        mocked_connect.return_value.close.assert_called_once_with()
         send_schema_message.assert_called_once_with(
             self.logical_streams[0],
             ['lsn'],
@@ -1187,11 +1221,9 @@ class TestLogicalReplication(unittest.TestCase):
 
     @patch('tap_postgres.sync_strategies.logical_replication.datetime.datetime')
     @patch('tap_postgres.sync_strategies.logical_replication.locate_replication_slot')
-    @patch('tap_postgres.sync_strategies.logical_replication.get_pg_version')
     @patch("psycopg2.connect")
     def test_sync_tables_if_poll_duration_greater_than_logical_poll_total_seconds(self,
                                                                                   mocked_connect,
-                                                                                  mocked_version,
                                                                                   mocked_locate_rep_slot,
                                                                                   mocked_datetime):
         """Test sync_table works as expected if poll_duration greater than the logical_poll_total_seconds"""
@@ -1203,7 +1235,7 @@ class TestLogicalReplication(unittest.TestCase):
         end_lsn = 8
         state_file = 5
         rep_slot = 'foo_slot'
-        mocked_version.return_value = 150000
+        mocked_connect.return_value.server_version = 150000
         mocked_locate_rep_slot.return_value = rep_slot
         mocked_datetime.utcnow().__sub__().total_seconds.return_value = test_poll_duration
         mocked_start_replication = mocked_connect.return_value.cursor.return_value.start_replication
@@ -1230,11 +1262,9 @@ class TestLogicalReplication(unittest.TestCase):
 
     @patch('tap_postgres.sync_strategies.logical_replication.datetime.datetime')
     @patch('tap_postgres.sync_strategies.logical_replication.locate_replication_slot')
-    @patch('tap_postgres.sync_strategies.logical_replication.get_pg_version')
     @patch("psycopg2.connect")
     def test_sync_tables_if_reached_max_run_seconds(self,
                                                     mocked_connect,
-                                                    mocked_version,
                                                     mocked_locate_rep_slot,
                                                     mocked_datetime):
         """Test sync_table if reached the max_run_seconds"""
@@ -1245,7 +1275,7 @@ class TestLogicalReplication(unittest.TestCase):
         state = {'bookmarks': {'foo-bar': {'foo': 'bar', 'version': 'foo', 'lsn': 4}}}
         end_lsn = 4
         state_file = 5
-        mocked_version.return_value = 150000
+        mocked_connect.return_value.server_version = 150000
         rep_slot = 'foo_slot'
 
         mocked_start_replication = mocked_connect.return_value.cursor.return_value.start_replication
@@ -1272,18 +1302,16 @@ class TestLogicalReplication(unittest.TestCase):
         )
 
     @patch('tap_postgres.sync_strategies.logical_replication.locate_replication_slot')
-    @patch('tap_postgres.sync_strategies.logical_replication.get_pg_version')
     @patch("psycopg2.connect")
     def test_sync_tables_raise_exception_if_error_in_message_read(self,
                                                                   mocked_connect,
-                                                                  mocked_version,
                                                                   _):
         """Test sync_tables raises exception if error in the message_read"""
         state = {'bookmarks': {'foo-bar': {'foo': 'bar', 'lsn': 4}}}
         end_lsn = 8
         state_file = 5
 
-        mocked_version.return_value = 150000
+        mocked_connect.return_value.server_version = 150000
         expected_message = 'FOO'
         mocked_connect.return_value.cursor.return_value.read_message.side_effect = Exception(expected_message)
 
@@ -1291,13 +1319,36 @@ class TestLogicalReplication(unittest.TestCase):
                 self.assertRaises(Exception) as exp:
             logical_replication.sync_tables(self.conn_info, self.logical_streams, state, end_lsn, state_file)
         self.assertEqual(expected_message, str(exp.exception))
+        mocked_connect.return_value.cursor.return_value.close.assert_called_once_with()
+        mocked_connect.return_value.close.assert_called_once_with()
 
     @patch('tap_postgres.sync_strategies.logical_replication.locate_replication_slot')
-    @patch('tap_postgres.sync_strategies.logical_replication.get_pg_version')
+    @patch("psycopg2.connect")
+    def test_sync_tables_closes_replication_resources_if_marker_emission_fails(self,
+                                                                               mocked_connect,
+                                                                               mocked_locate_rep_slot):
+        """An unexpected marker error cannot leak the active replication connection."""
+        state = {'bookmarks': {'foo-bar': {'foo': 'bar', 'version': 'foo', 'lsn': 4}}}
+        mocked_connect.return_value.server_version = 150000
+        mocked_locate_rep_slot.return_value = 'foo_slot'
+        marker_error = RuntimeError('unable to create marker')
+
+        with patch(
+                'tap_postgres.sync_strategies.logical_replication.emit_wal_progress_message',
+                side_effect=marker_error,
+        ), patch('tap_postgres.sync_strategies.logical_replication.singer.write_message') as write_message, \
+                self.assertRaises(RuntimeError) as exp:
+            logical_replication.sync_tables(self.conn_info, self.logical_streams, state, 8, 'state.json')
+
+        self.assertIs(marker_error, exp.exception)
+        write_message.assert_not_called()
+        mocked_connect.return_value.cursor.return_value.close.assert_called_once_with()
+        mocked_connect.return_value.close.assert_called_once_with()
+
+    @patch('tap_postgres.sync_strategies.logical_replication.locate_replication_slot')
     @patch("psycopg2.connect")
     def test_sync_tables_if_break_at_end_lsn_and_msg_data_start_greater_than_end_lsn(self,
                                                                                      mocked_connect,
-                                                                                     mocked_version,
                                                                                      mocked_locate_rep_slot):
         """Test sync_table if there is break_at_the_end_lsn and message  data_start greater than lsn"""
         end_lsn = 4
@@ -1310,7 +1361,7 @@ class TestLogicalReplication(unittest.TestCase):
         self.conn_info['break_at_end_lsn'] = True
         state_file = 5
 
-        mocked_version.return_value = 150000
+        mocked_connect.return_value.server_version = 150000
 
         mocked_connect.return_value.cursor.return_value.read_message.return_value = test_message()
 
@@ -1326,13 +1377,11 @@ class TestLogicalReplication(unittest.TestCase):
             self.assertEqual(state, actual_output)
 
     @patch('tap_postgres.sync_strategies.logical_replication.locate_replication_slot')
-    @patch('tap_postgres.sync_strategies.logical_replication.get_pg_version')
     @patch('tap_postgres.sync_strategies.logical_replication.select')
     @patch("psycopg2.connect")
     def test_sync_tables_if_no_message_and_raised_interrupted_error(self,
                                                                     mocked_connect,
                                                                     mocked_select,
-                                                                    mocked_version,
                                                                     mocked_locate_rep_slot):
         """Test sync_tables if there is no message and InterruptedError is raised"""
         end_lsn = 4
@@ -1342,7 +1391,7 @@ class TestLogicalReplication(unittest.TestCase):
         state_file = 5
 
         mocked_select.side_effect = InterruptedError()
-        mocked_version.return_value = 150000
+        mocked_connect.return_value.server_version = 150000
         mocked_connect.return_value.cursor.return_value.read_message.return_value = None
         mocked_locate_rep_slot.return_value = 'mocked_value_for_replication_slot'
 
@@ -1352,11 +1401,9 @@ class TestLogicalReplication(unittest.TestCase):
         self.assertEqual(state, actual_output)
 
     @patch('tap_postgres.sync_strategies.logical_replication.locate_replication_slot')
-    @patch('tap_postgres.sync_strategies.logical_replication.get_pg_version')
     @patch("psycopg2.connect")
     def test_sync_tables_if_msg_and_some_specific_cases_for_lsn(self,
                                                                 mocked_connect,
-                                                                mocked_version,
                                                                 mocked_locate_rep_slot):
         """Test sync_table if there is message and lsn_currently_processing is None
          and lsn_currently_processing is less than lsn_to_flush"""
@@ -1371,7 +1418,7 @@ class TestLogicalReplication(unittest.TestCase):
         self.conn_info['break_at_end_lsn'] = False
         state_file = 55
 
-        mocked_version.return_value = 150000
+        mocked_connect.return_value.server_version = 150000
 
         mocked_connect.return_value.cursor.return_value.read_message.return_value = test_message()
 
@@ -1483,11 +1530,11 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
                       side_effect=self._consume_message), \
                 patch('tap_postgres.sync_strategies.logical_replication.locate_replication_slot',
                       return_value='replication_slot'), \
-                patch('tap_postgres.sync_strategies.logical_replication.get_pg_version', return_value=150000), \
                 patch('tap_postgres.sync_strategies.logical_replication.emit_wal_progress_message',
                       return_value=marker_lsn) as mocked_emit_marker, \
                 patch('builtins.open', state_reader), \
                 patch('psycopg2.connect') as mocked_connect:
+            mocked_connect.return_value.server_version = 150000
             cursor = mocked_connect.return_value.cursor.return_value
             cursor.read_message.side_effect = [*messages, termination]
 
@@ -1582,13 +1629,15 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
         self.assertEqual(self._expected_feedback(100), feedback)
 
     def test_progress_message_does_not_end_continuous_sync(self):
-        """A continuous tap publishes and flushes a target-acknowledged marker."""
+        """A continuous tap publishes its marker boundary only once."""
         state = self._state({'foo-bar': 100})
         old_state = mock_open(read_data=json.dumps(state))
         acknowledged_marker = mock_open(read_data=json.dumps(self._state({'foo-bar': 220})))
         state_reader = Mock(side_effect=[
             old_state.return_value,
             old_state.return_value,
+            acknowledged_marker.return_value,
+            acknowledged_marker.return_value,
             acknowledged_marker.return_value,
         ])
         messages = [
@@ -1601,16 +1650,19 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
                 content='wal_progress:tap_id_value:current'
             ),
             self._message('C', 220),
+            self._message('B', 300),
+            self._message('C', 320),
         ]
 
         feedback, error, termination, written_messages = self._run_sync(
             state, messages, state_reader, marker_lsn=210)
 
         self.assertIs(error, termination)
-        self.assertEqual(220, state['bookmarks']['foo-bar']['lsn'])
+        self.assertEqual(300, state['bookmarks']['foo-bar']['lsn'])
         self.assertEqual(self._expected_feedback(100, 220), feedback)
         self.assertEqual(2, len(written_messages))
         self.assertEqual(220, written_messages[0].args[0].value['bookmarks']['foo-bar']['lsn'])
+        self.assertEqual(300, written_messages[1].args[0].value['bookmarks']['foo-bar']['lsn'])
 
     def test_only_commit_at_or_after_marker_position_creates_boundary(self):
         """Marker content is irrelevant, but a qualifying commit remains mandatory."""

--- a/singer-connectors/tap-postgres/tests/unit/test_logical_replication.py
+++ b/singer-connectors/tap-postgres/tests/unit/test_logical_replication.py
@@ -1596,6 +1596,26 @@ class TestLogicalReplicationFeedback(unittest.TestCase):
         self.assertEqual(220, state['bookmarks']['foo-bar']['lsn'])
         self.assertEqual(self._expected_feedback(100), feedback)
 
+    def test_finalization_writes_zero_lsn_to_every_stream(self):
+        """A valid zero LSN is distinct from the uninitialized sentinel."""
+        streams = [self._stream('foo-bar', 'foo_table'), self._stream('foo-baz', 'baz_table')]
+        state = self._state({'foo-bar': 0, 'foo-baz': 5})
+        state_reader = mock_open(read_data=json.dumps(state))
+        messages = [self._message('B', 0), self._message('B', 1)]
+
+        feedback, error, termination, written_messages = self._run_sync(
+            state,
+            messages,
+            state_reader,
+            logical_streams=streams,
+        )
+
+        self.assertIs(error, termination)
+        self.assertEqual(0, state['bookmarks']['foo-bar']['lsn'])
+        self.assertEqual(0, state['bookmarks']['foo-baz']['lsn'])
+        self.assertEqual(self._expected_feedback(0), feedback)
+        self.assertEqual(0, written_messages[-1].args[0].value['bookmarks']['foo-baz']['lsn'])
+
     def test_commit_before_marker_position_does_not_end_current_sync(self):
         """A commit older than the emitted marker cannot satisfy the boundary."""
         state = self._state({'foo-bar': 100})

--- a/tests/units/cli/test_cli_2.py
+++ b/tests/units/cli/test_cli_2.py
@@ -109,4 +109,7 @@ class TestCli2:
         assert silentremove.call_args_list == [ call(f'{CONFIG_DIR}/target_two/tap_four')]
 
         # called because the deleted tap is a tap-postgres
-        drop_slot.assert_called_once()
+        drop_slot.assert_called_once_with(
+            {'host': 'localhost'},
+            allow_unsupported_version_for_config_removal=True,
+        )

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -140,47 +140,50 @@ class TestFastSyncTapPostgres(TestCase):  # pylint: disable=too-many-public-meth
         with patch.object(
             self.postgres, 'get_connection', return_value=primary_connection
         ), patch.object(
-            self.postgres, 'primary_host_query', return_value=[{'version': 120000}]
-        ), patch.object(
             self.postgres, 'create_replication_slot'
         ) as create_replication_slot, patch.object(
             self.postgres, 'query', return_value=[{'current_lsn': '0/2A'}]
-        ):
+        ) as query:
             bookmark = self.postgres.fetch_current_log_pos()
 
         self.assertEqual({'lsn': 42, 'version': 1}, bookmark)
         create_replication_slot.assert_called_once_with()
+        query.assert_called_once_with('SELECT pg_current_wal_lsn() AS current_lsn')
         primary_connection.close.assert_called_once_with()
         self.assertIsNone(self.postgres.primary_host_conn)
 
+    def test_fetch_current_log_pos_uses_current_wal_function_on_replica(self):
+        """Supported replicas use the current WAL function name."""
+        self.postgres.connection_config['replica_host'] = 'replica'
+        primary_connection = Mock()
+
+        with patch.object(
+            self.postgres, 'get_connection', return_value=primary_connection
+        ), patch.object(
+            self.postgres, 'create_replication_slot'
+        ), patch.object(
+            self.postgres, 'query', return_value=[{'current_lsn': '0/2A'}]
+        ) as query:
+            bookmark = self.postgres.fetch_current_log_pos()
+
+        self.assertEqual({'lsn': 42, 'version': 1}, bookmark)
+        query.assert_called_once_with('SELECT pg_last_wal_replay_lsn() AS current_lsn')
+
     def test_fetch_current_log_pos_closes_primary_connection_on_failure(self):
-        """Primary setup, metadata, and replication-slot failures cannot leak their connection."""
-        failures = ('metadata', 'replication_slot')
+        """A replication-slot failure cannot leak the primary connection."""
+        primary_connection = Mock()
 
-        for failure in failures:
-            with self.subTest(failure=failure):
-                primary_connection = Mock()
-                error_message = f'{failure.replace("_", " ")} failed'
-                primary_connection.cursor.side_effect = (
-                    RuntimeError(error_message) if failure == 'cursor' else None
-                )
-                primary_query_error = RuntimeError(error_message) if failure == 'metadata' else None
-                slot_error = RuntimeError(error_message) if failure == 'replication_slot' else None
+        with patch.object(
+            self.postgres, 'get_connection', return_value=primary_connection
+        ), patch.object(
+            self.postgres,
+            'create_replication_slot',
+            side_effect=RuntimeError('replication slot failed'),
+        ), self.assertRaisesRegex(RuntimeError, 'replication slot failed'):
+            self.postgres.fetch_current_log_pos()
 
-                with patch.object(
-                    self.postgres, 'get_connection', return_value=primary_connection
-                ), patch.object(
-                    self.postgres,
-                    'primary_host_query',
-                    return_value=[{'version': 120000}],
-                    side_effect=primary_query_error,
-                ), patch.object(
-                    self.postgres, 'create_replication_slot', side_effect=slot_error
-                ), self.assertRaisesRegex(RuntimeError, error_message):
-                    self.postgres.fetch_current_log_pos()
-
-                primary_connection.close.assert_called_once_with()
-                self.assertIsNone(self.postgres.primary_host_conn)
+        primary_connection.close.assert_called_once_with()
+        self.assertIsNone(self.postgres.primary_host_conn)
 
     def test_create_replication_slot_1(self):
         """
@@ -239,6 +242,7 @@ class TestFastSyncTapPostgres(TestCase):  # pylint: disable=too-many-public-meth
         """
         Check that get connection uses the right credentials to connect to primary
         """
+        connect_mock.return_value.server_version = 110002
         creds = {
             'host': 'my_primary_host',
             'user': 'my_primary_user',
@@ -257,13 +261,101 @@ class TestFastSyncTapPostgres(TestCase):  # pylint: disable=too-many-public-meth
             f"dbname='{creds['dbname']}'"
         )
 
-        self.assertTrue(connect_mock.autocommit)
+        self.assertTrue(connect_mock.return_value.autocommit)
+
+    @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
+    def test_get_connection_rejects_postgres_before_11_2(self, connect_mock):
+        """Every FastSync source connection enforces the PostgreSQL floor."""
+        connect_mock.return_value.server_version = 110001
+        creds = {
+            'host': 'my_primary_host',
+            'user': 'my_primary_user',
+            'password': 'my_primary_user',
+            'dbname': 'my_db',
+            'port': 'my_primary_port',
+        }
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'PostgreSQL 11.2 or later.*server_version_num 110001',
+        ):
+            FastSyncTapPostgres.get_connection(creds, prioritize_primary=True)
+
+        connect_mock.return_value.close.assert_called_once_with()
+
+    @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
+    def test_get_connection_allows_unsupported_version_for_config_removal(
+        self, connect_mock
+    ):
+        """Removed-tap cleanup can still connect to an obsolete source."""
+        connect_mock.return_value.server_version = 110001
+        creds = {
+            'host': 'my_primary_host',
+            'user': 'my_primary_user',
+            'password': 'my_primary_user',
+            'dbname': 'my_db',
+            'port': 'my_primary_port',
+        }
+
+        connection = FastSyncTapPostgres.get_connection(
+            creds,
+            prioritize_primary=True,
+            allow_unsupported_version_for_config_removal=True,
+        )
+
+        self.assertIs(connect_mock.return_value, connection)
+        connect_mock.return_value.close.assert_not_called()
+        self.assertTrue(connection.autocommit)
+
+    def test_drop_slot_forwards_only_the_config_removal_bypass(self):
+        """Slot cleanup forwards the explicit removed-config exception."""
+        connection = MagicMock()
+        connection.cursor.return_value.__enter__.return_value.rowcount = 0
+        creds = {
+            'dbname': 'my_db',
+            'tap_id': 'my_tap',
+        }
+
+        with patch.object(
+            FastSyncTapPostgres, 'get_connection', return_value=connection
+        ) as get_connection:
+            FastSyncTapPostgres.drop_slot(
+                creds,
+                allow_unsupported_version_for_config_removal=True,
+            )
+
+        get_connection.assert_called_once_with(
+            creds,
+            prioritize_primary=True,
+            allow_unsupported_version_for_config_removal=True,
+        )
+        connection.close.assert_called_once_with()
+
+    @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
+    def test_drop_slot_validates_version_by_default(self, connect_mock):
+        """FastSync resync slot cleanup must retain source-version validation."""
+        connect_mock.return_value.server_version = 110001
+        creds = {
+            'host': 'my_primary_host',
+            'user': 'my_primary_user',
+            'password': 'my_primary_user',
+            'dbname': 'my_db',
+            'port': 'my_primary_port',
+            'tap_id': 'my_tap',
+        }
+
+        with self.assertRaisesRegex(RuntimeError, 'PostgreSQL 11.2 or later'):
+            FastSyncTapPostgres.drop_slot(creds)
+
+        connect_mock.return_value.close.assert_called_once_with()
+        connect_mock.return_value.cursor.assert_not_called()
 
     @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
     def test_get_connection_to_sec(self, connect_mock):
         """
         Check that get connection uses the right credentials to connect to secondary if present
         """
+        connect_mock.return_value.server_version = 110002
         creds = {
             'host': 'my_primary_host',
             'replica_host': 'my_replica_host',
@@ -287,13 +379,14 @@ class TestFastSyncTapPostgres(TestCase):  # pylint: disable=too-many-public-meth
             f"dbname='{creds['dbname']}'"
         )
 
-        self.assertTrue(connect_mock.autocommit)
+        self.assertTrue(connect_mock.return_value.autocommit)
 
     @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
     def test_get_connection_fallback(self, connect_mock):
         """
         Check that get connection uses the primary server credentials as a fallback
         """
+        connect_mock.return_value.server_version = 110002
         creds = {
             'host': 'my_primary_host',
             'replica_host': 'my_replica_host',
@@ -313,13 +406,14 @@ class TestFastSyncTapPostgres(TestCase):  # pylint: disable=too-many-public-meth
             f"='{creds['password']}' dbname='{creds['dbname']}'"
         )
 
-        self.assertTrue(connect_mock.autocommit)
+        self.assertTrue(connect_mock.return_value.autocommit)
 
     @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
     def test_get_connection_ssl(self, connect_mock):
         """
         Check that get connection uses ssl when present
         """
+        connect_mock.return_value.server_version = 110002
         creds = {
             'host': 'my_primary_host',
             'user': 'my_primary_user',
@@ -339,7 +433,7 @@ class TestFastSyncTapPostgres(TestCase):  # pylint: disable=too-many-public-meth
             f"='{creds['password']}' dbname='{creds['dbname']}' sslmode='require'"
         )
 
-        self.assertTrue(connect_mock.autocommit)
+        self.assertTrue(connect_mock.return_value.autocommit)
 
     @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
     def test_drop_slot_v15(self, connect_mock):
@@ -370,6 +464,7 @@ class TestFastSyncTapPostgres(TestCase):  # pylint: disable=too-many-public-meth
 
         # mock PG connection instance with ability to open cursor
         pg_con = Mock()
+        pg_con.server_version = 110002
         pg_con.cursor.return_value = cursor_mock
 
         connect_mock.return_value = pg_con
@@ -411,6 +506,7 @@ class TestFastSyncTapPostgres(TestCase):  # pylint: disable=too-many-public-meth
 
         # mock PG connection instance with ability to open cursor
         pg_con = Mock()
+        pg_con.server_version = 110002
         pg_con.cursor.return_value = cursor_mock
 
         connect_mock.return_value = pg_con


### PR DESCRIPTION
## Context

PostgreSQL LOG_BASED taps need a restart-safe way to advance an idle replication
slot without acknowledging WAL before the target has committed it. The previous
per-run logical-message matching was more complex than necessary and behaved
unexpectedly on PostgreSQL 18. The same source path also retained compatibility
branches for PostgreSQL releases older than the new supported floor.

## Changes

- Emit a transactional WAL progress marker only after replication starts, then
  use PostgreSQL's returned marker LSN and the first decoded commit at or beyond
  it as the safe bookmark boundary.
- Check the PostgreSQL 11-16 and 17-18 marker function identities and execution
  privilege before emission, while retaining the existing current-WAL fallback
  when markers are unavailable.
- Keep replication feedback bounded by target-acknowledged state, emit the
  continuous-mode marker checkpoint once, and close replication resources on
  every exit path.
- Require PostgreSQL 11.2 or later for Singer source replication, FullSync, and
  PartialSync; remove pre-11 WAL APIs and version bands.
- Allow only deleted-tap cleanup to connect below the version floor so obsolete
  replication slots can still be released.
- Update source documentation, regression coverage, versioning, and legacy
  connector Pylint guidance.

See the [0.85.0 CHANGELOG entry](https://github.com/transferwise/pipelinewise/blob/AP-3173-revisit/CHANGELOG.md#0850-2026-09-08).

## Type of change

- [x] Bug fix
- [x] Maintenance, dependency, or CI
- [x] Documentation
- [x] Breaking change

## Compatibility and operations

PostgreSQL replication sources must be version 11.2 or later for every Singer
replication method, FullSync, and PartialSync. PostgreSQL targets, the
PipelineWise backend, and data-diff connections are unaffected. Removing a tap
can still connect to an older source solely to drop its WAL-retaining replication
slot; resync remains unsupported below 11.2.

Existing Singer state and target data require no migration. Replication feedback
still advances only after the target-written state acknowledges the LSN. If
logical marker emission is unavailable or unauthorized, PipelineWise retains the
current-WAL fallback. Rollback needs no state or schema conversion.

## Validation

| Command or check | Result |
|---|---|
| `ruff check pipelinewise tests` | Passed |
| `pylint pipelinewise tests` | Passed — 10.00/10 |
| `flake8 pipelinewise --count --select=E9,F63,F7,F82 --show-source --statistics` | Passed — 0 |
| `flake8 pipelinewise --count --max-complexity=15 --max-line-length=120 --statistics` | Passed — 0 |
| `pytest --cov=pipelinewise --cov-fail-under=77 -v tests/units` | 1 known multiprocessing timing failure; 1,328 passed and 145 subtests passed |
| Isolated rerun of `test_save_state_file_serializes_independent_processes` | Passed — 1 test |
| tap-postgres `make pylint` | Master baseline retained — 9.96/10; exits non-zero on the same obsolete config warnings and 5 source findings as `origin/master` |
| tap-postgres `make unit_test_cov` | Passed — 145 tests and 17 subtests; 66% coverage, 58% required |
| tap-postgres integration suite using the dev-project PostgreSQL service | Passed — 20 tests; 63% coverage, 63% required |
| tap-postgres `make total_cov` | Passed — 88% coverage, 85% required |
| Raw tap-postgres `make integration_test_cov` inside the CLI container | Unavailable in that topology — its standalone defaults target `127.0.0.1:5432`; all 20 cases failed before behavior on connection refusal. The topology-adjusted run above passed. |
| `pipelinewise validate --dir dev-project/pipelinewise-config` | Passed |
| `cd docs && make check` | Passed — 6 reference checks and strict 46-page Sphinx build |
| PostgreSQL target and stream-buffer E2E | Passed across corrected runs — 9 tests; 1 S3-dependent test skipped. One stale inactive dev-test slot was removed before the stream-buffer retry. |
| Disposable PostgreSQL 11.2 boundary check | Passed — Singer/FastSync connections and `pg_current_wal_lsn()` accepted; PostgreSQL 11.1 rejection is unit-tested |
| Disposable PostgreSQL 18 marker ACL check | Passed — the 3-argument call used the checked 4-argument function identity with its defaulted final argument |
| `git diff --check origin/master` | Passed |

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] This pull request is focused and can be reviewed and reverted
      independently.
- [x] Behavioural changes have regression tests, or I explained why tests are not
      applicable.
- [x] Relevant documentation and changelog entries are updated, or I explained
      why they are not applicable.
- [x] Applicable local checks pass; failures, skips, and unavailable checks are
      documented above.
- [x] The change contains no credentials, private keys, production identifiers,
      or source records.
- [x] Breaking and compatibility impacts are identified above.
