### PR TITLE
AP-3173 Document wal2json stream abort recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Documentation only
+------------------
+
+**PostgreSQL logical replication**
+
+- Document recovery from wal2json ``stream_abort_cb`` failures by increasing
+  ``logical_decoding_work_mem`` and retrying without discarding replication-slot
+  state
+
 0.85.0 (2026-09-08)
 -------------------
 

--- a/docs/user_guide/troubleshooting.rst
+++ b/docs/user_guide/troubleshooting.rst
@@ -35,6 +35,10 @@ Symptom index
    * - :ref:`PGRES_COPY_BOTH <troubleshooting_postgres_pgres_copy_both>`
      - PostgreSQL LOG_BASED
      - Source logs, network, timeout, and target backpressure.
+   * - :ref:`stream_abort_cb callback missing
+       <troubleshooting_postgres_stream_abort_callback>`
+     - PostgreSQL LOG_BASED
+     - ``logical_decoding_work_mem`` and large or concurrent transactions.
    * - :ref:`LOG_BASED throughput falls behind without errors
        <troubleshooting_postgres_logical_decoding_spill>`
      - PostgreSQL LOG_BASED
@@ -338,6 +342,33 @@ interval before changing timeouts or state.
   ``stream_buffer_size``.** This buffer decouples reading from loading. It cannot
   compensate indefinitely for a blocked target or an unsuitable timeout, so fix
   those causes first.
+
+.. _troubleshooting_postgres_stream_abort_callback:
+
+logical streaming requires a stream_abort_cb callback
+"""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+*Log message:*
+
+.. code-block:: text
+
+    psycopg2.errors.ObjectNotInPrerequisiteState:
+    logical streaming requires a stream_abort_cb callback
+
+*Why it happens:*
+PostgreSQL can start streaming an in-progress transaction when decoded changes
+exceed ``logical_decoding_work_mem``. On affected PostgreSQL and wal2json
+combinations, aborting that transaction can expose a missing wal2json streaming
+callback and stop replication.
+
+*How to fix:*
+Work with the source database administrator to increase
+``logical_decoding_work_mem`` above the decoded working set of large or concurrent
+transactions. Use the incremental tuning and memory guidance in
+:ref:`troubleshooting_postgres_logical_decoding_spill`, then restart and retry the
+same tap so its replication connection receives the new value. Do not drop,
+recreate, or advance the slot; that can discard changes that PipelineWise has not
+acknowledged.
 
 .. _troubleshooting_postgres_logical_decoding_spill:
 


### PR DESCRIPTION
## Context

Affected PostgreSQL and wal2json combinations can stop LOG_BASED replication
with `psycopg2.errors.ObjectNotInPrerequisiteState: logical streaming requires a
stream_abort_cb callback` after decoded changes cross
`logical_decoding_work_mem`. Operators need a discoverable recovery procedure
that does not risk discarding unacknowledged WAL.

## Changes

- Add the exact `stream_abort_cb` failure to the troubleshooting symptom index.
- Explain its relationship to large or concurrent decoded transactions and
  `logical_decoding_work_mem`.
- Direct operators to increase the setting incrementally, restart and retry the
  same tap, and preserve the existing replication slot.
- Record the guidance under the future
  [Documentation only changelog entry](https://github.com/transferwise/pipelinewise/blob/AP-3173-stream-abort-docs/CHANGELOG.md#documentation-only).

## Type of change

- [x] Documentation

## Compatibility and operations

This PR changes documentation only. It does not change runtime behaviour,
configuration, schemas, package versions, or release versions.

The documented mitigation increases memory available to each affected logical
decoding connection, so operators should test incremental values against source
transaction size and concurrency. The tap must reconnect to receive a changed
role or database default. Existing replication slots must not be dropped,
recreated, or manually advanced during recovery.

Rollback consists only of reverting the documentation commit.

## Validation

| Command or check | Result |
|---|---|
| `cd docs && make check` | Passed — 6 reference checks and a strict Sphinx build of 46 source files, with 0 warnings |
| `git diff --check origin/master...HEAD` | Passed |
| Unit and E2E tests | Not run — no application code or executable configuration changed |

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] This pull request is focused and can be reviewed and reverted
      independently.
- [x] Behavioural changes have regression tests, or I explained why tests are not
      applicable.
- [x] Relevant documentation and changelog entries are updated, or I explained
      why they are not applicable.
- [x] Applicable local checks pass; failures, skips, and unavailable checks are
      documented above.
- [x] The change contains no credentials, private keys, production identifiers,
      or source records.
- [x] Breaking and compatibility impacts are identified above.
