### PR TITLE
AP-3335: Reset PostgreSQL slots before whole-tap resyncs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
   isolation, durable backups, drop/create failures and lost responses,
   managed-Iceberg recovery guards, retained-slot paths, pre-reset size checks,
   and unchanged PartialSync selection with or without ``--force``
+- Keep the PostgreSQL split-file E2E tap within the source-slot name limit and
+  verify acceptance at 63 characters and rejection at 64 before mutation
+- Expose FastSync preflight failures in E2E output before checking worker logs
 
 0.85.0 (2026-09-08)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,40 @@
-Documentation only
-------------------
+0.85.1 (2026-09-12)
+-------------------
+
+**PostgreSQL FastSync**
+
+- Restore PostgreSQL source-slot reset for explicit unfiltered ``fast_sync`` on
+  taps containing LOG_BASED tables, with or without ``--force``: preflight the
+  resync and source slot, back up and clear every tap bookmark, then drop and
+  recreate the tap-specific slot once before workers start
+- Reject legacy database-wide, active, and incompatible slots before changing
+  state, preventing a resync from dropping a slot shared by other taps
+- Preserve unique pre-reset state backups across retries and report the failed
+  reset phase without restoring stale bookmarks after a failed or ambiguous drop
+- Retain the slot when ``--tables`` or a non-default ``--replication_method_only``
+  is specified, even if every table is listed; also retain it for automatic
+  initial loads, standalone PartialSync, and taps without LOG_BASED tables
+- Preflight the PostgreSQL-to-Snowflake FullSync size limit before resetting the
+  slot or bookmarks; keep ``--force`` as the size-limit override and honour
+  configured ``sync_start_from`` ranges with or without it
+- Refuse a managed-Iceberg slot reset while publication or conversion recovery
+  is pending, without changing source or state, so the corresponding filtered
+  FastSync or conversion command can finish recovery before the whole-tap resync
+  is retried
 
 **PostgreSQL logical replication**
 
 - Document recovery from wal2json ``stream_abort_cb`` failures by increasing
   ``logical_decoding_work_mem`` and retrying without discarding replication-slot
   state
+
+**Tests**
+
+- Verify that only an explicit unfiltered PostgreSQL ``fast_sync`` resets the
+  tap-specific logical replication slot, including source preflight, legacy-slot
+  isolation, durable backups, drop/create failures and lost responses,
+  managed-Iceberg recovery guards, retained-slot paths, pre-reset size checks,
+  and unchanged PartialSync selection with or without ``--force``
 
 0.85.0 (2026-09-08)
 -------------------

--- a/docs/concept/fastsync.rst
+++ b/docs/concept/fastsync.rst
@@ -154,6 +154,13 @@ Explicit FullSync
 This operation can replace target data and reset replication bookmarks. Review
 :ref:`resync` before running it against a large or actively written table.
 
+An unfiltered PostgreSQL ``fast_sync`` containing LOG_BASED tables resets the
+tap-specific slot once before workers start, with or without ``--force``.
+Filtered FastSync, automatic initial loads, and standalone PartialSync retain
+it. ``--force`` only bypasses the resync size limit; configured
+``sync_start_from`` ranges remain in effect. See :ref:`resync_postgres_slot_reset`
+for exact commands, safety checks, pending-Iceberg guards, and failure recovery.
+
 
 .. _defined_partial_sync:
 

--- a/docs/connectors/taps/postgres.rst
+++ b/docs/connectors/taps/postgres.rst
@@ -38,9 +38,15 @@ LOG_BASED replication also requires:
   version 2 support; and
 - permission to create and consume a logical replication slot.
 
-PipelineWise creates one slot for the tap database. PostgreSQL retains WAL needed
+PipelineWise creates one tap-specific slot in the source database. PostgreSQL retains WAL needed
 by that slot, so monitor retained WAL and do not remove the slot while the tap is
 active.
+
+An explicit, unfiltered ``fast_sync`` on a tap containing LOG_BASED tables
+resets the tap-specific slot once before workers start, with or without
+``--force``. Filtered FastSync, automatic initial loads, and standalone PartialSync
+retain it. See :ref:`resync_postgres_slot_reset` for exact commands, legacy-slot
+safety, state backups, pending-Iceberg guards, and non-atomic reset recovery.
 
 
 Configuration

--- a/docs/user_guide/cli.rst
+++ b/docs/user_guide/cli.rst
@@ -235,13 +235,20 @@ state after an unexpected interruption.
    * - ``--tables``
      - Limits work to comma-separated source ``schema.table`` names.
    * - ``--force``
-     - Overrides ``allowed_resync_max_size``.
+     - Overrides ``allowed_resync_max_size`` only. Does not override
+       ``sync_start_from`` or bypass slot-reset safety checks.
    * - ``--replication_method_only``
      - Selects tables with ``full_table``, ``incremental``, or ``log_based``.
 
 The command fails when FullSync is unavailable for the route. It never falls
 back to Singer. A table with ``sync_start_from`` uses PartialSync. ``sync_tables``
-remains a deprecated alias.
+remains a deprecated alias. Supplying ``--tables`` or setting
+``--replication_method_only`` to anything other than ``*`` makes the resync
+filtered and retains the PostgreSQL replication slot, even if ``--tables`` lists
+every table. An unfiltered whole-tap PostgreSQL run with LOG_BASED tables resets
+its tap-specific slot once before workers start, with or without ``--force``.
+See :ref:`resync_postgres_slot_reset` for safety checks, backups, pending-Iceberg
+guards, and non-atomic reset recovery.
 
 
 .. _cli_partial_sync_table:

--- a/docs/user_guide/partial_sync.rst
+++ b/docs/user_guide/partial_sync.rst
@@ -7,6 +7,13 @@ PartialSync exports a bounded source range, loads a temporary target table, and
 merges that range into the existing target. It is available from MariaDB/MySQL or
 PostgreSQL to Snowflake.
 
+A table configured with ``sync_start_from`` also uses PartialSync during
+``fast_sync``, including ``fast_sync --force``. The flag bypasses the FullSync
+size limit; it does not override the configured range or request a full-table
+reload. An unfiltered whole-tap PostgreSQL ``fast_sync`` still resets its
+LOG_BASED source slot before workers start; standalone ``partial_sync_table``
+retains it. See :ref:`resync_postgres_slot_reset`.
+
 
 Range semantics
 ---------------

--- a/docs/user_guide/resync.rst
+++ b/docs/user_guide/resync.rst
@@ -62,11 +62,88 @@ Full resync
 The command requires a FullSync-capable route and fails rather than falling back
 to Singer. ``--replication_method_only <method>`` filters by configured method.
 ``--force`` overrides ``allowed_resync_max_size`` after the operator accepts the
-source and target impact.
+source and target impact. It does not override ``sync_start_from`` or change a
+configured PartialSync into a full-table reload.
+
+.. _resync_postgres_slot_reset:
+
+PostgreSQL source-slot reset
+''''''''''''''''''''''''''''
+
+For a PostgreSQL tap containing LOG_BASED tables, this command drops and
+recreates the tap-specific source slot once before any worker starts:
+
+.. code-block:: bash
+
+   pipelinewise fast_sync --tap <tap_id> --target <target_id>
+
+Omit ``--tables`` and leave ``--replication_method_only`` at its ``*`` default
+so every selected table is rebuilt. The deprecated ``sync_tables`` alias has
+the same behaviour. ``--force`` is not required for the reset: it only bypasses
+the resync size limit. Taps without LOG_BASED tables do not reset a slot.
+
+.. list-table:: PostgreSQL slot behaviour during replication
+   :header-rows: 1
+
+   * - Command or operation
+     - Source slot
+   * - Unfiltered ``fast_sync`` (with or without ``--force``)
+     - Drop and recreate once, after safety checks.
+   * - ``fast_sync --tables ...`` (even if every table is listed, or ``--force`` is supplied)
+     - Retain.
+   * - ``fast_sync --replication_method_only log_based`` (or another non-default filter, with or without ``--force``)
+     - Retain.
+   * - ``partial_sync_table`` or automatic initial sync of individual/new tables
+     - Retain.
+
+PipelineWise validates local configuration, preflights the FullSync size limit
+unless ``--force`` is supplied, and checks the source connection and slot before
+changing state. A preflight size-limit rejection leaves the slot and bookmarks
+unchanged. An active slot or a slot with an unexpected database
+or output plugin blocks the reset. Any legacy database-wide slot
+(``pipelinewise_<dbname>``) also blocks it, even if a tap-specific slot exists:
+the legacy slot may serve other taps and is preferred by the replication reader.
+Coordinate any legacy-slot migration with your DBA and all affected taps; this
+command does not migrate or delete a legacy slot.
+
+After these checks, PipelineWise saves a unique
+``state.json.before-slot-reset-<id>.bak`` alongside the state file, clears every
+tap bookmark, then drops and recreates the tap-specific slot. Backups are retained
+across retries. No FullSync or configured PartialSync worker starts until slot
+creation succeeds.
+
+.. warning::
+
+   Dropping and recreating a slot is not atomic. A source error, lost response,
+   or process interruption after state invalidation can leave the slot unchanged,
+   absent, or replaced; bookmarks remain cleared. Keep scheduled replication
+   stopped, resolve the error, then retry the unfiltered ``fast_sync``
+   and complete the whole-tap resync. A state backup cannot recover discarded
+   WAL: never restore old LOG_BASED bookmarks after a completed or uncertain drop.
+   Reset errors report the failed phase and backup path when available.
+   Add ``--force`` only if the resync size limit needs to be bypassed.
+
+For managed Iceberg, a pending publication or conversion recovery stops the
+whole-tap reset before source or state changes. Resume the corresponding filtered
+FastSync or conversion command to finish recovery, then retry the unfiltered
+``fast_sync``.
+
+Separately, ``import_config`` removes a deleted PostgreSQL tap's source slot
+when it removes that tap's runtime configuration; this is cleanup, not a resync.
+
+
+Configured PartialSync and replicas
+'''''''''''''''''''''''''''''''''''
 
 A table with ``sync_start_from`` uses PartialSync instead of FullSync. MariaDB,
 MySQL, and PostgreSQL sources can use ``replica_host`` for the FastSync read while
 ongoing LOG_BASED replication remains on the primary.
+
+``--force`` preserves that configured range and loading method. Existing rows
+outside the range remain unless ``drop_target_table: true`` is configured.
+A whole-tap PostgreSQL resync still resets the shared WAL position, so ensure
+the configured ranges cover the changes that need rebuilding; retained rows
+outside those ranges are not revalidated or refreshed.
 
 For a managed Iceberg v3 target, an exactly compatible table uses
 ``INSERT OVERWRITE`` and retains its object identity. A new nullable column is

--- a/docs/user_guide/troubleshooting.rst
+++ b/docs/user_guide/troubleshooting.rst
@@ -525,13 +525,21 @@ Unable to find replication slot
 """""""""""""""""""""""""""""""
 
 *How to fix:*
-Run ``pipelinewise fast_sync --tap <tap_id> --target <target_id>`` to resync the
-tap and recreate the replication slot. See :ref:`resync` before proceeding.
+Run ``pipelinewise fast_sync --tap <tap_id> --target <target_id>`` with
+no ``--tables`` and the default ``--replication_method_only '*'`` to resync the
+whole tap and recreate its slot. Add ``--force`` only to bypass the resync size
+limit; ``sync_start_from`` remains effective either way. See
+:ref:`resync_postgres_slot_reset` for preflight checks, backups, and
+pending-Iceberg recovery before proceeding.
 
 .. warning::
 
-    Triggering a resync of a PostgreSQL tap using ``fast_sync`` will drop the
-    replication slot.
+    This command drops an existing tap-specific slot, with or without ``--force``.
+    Slot replacement is not atomic: a failure during drop or recreation leaves
+    bookmarks invalidated, and the slot may be absent or replaced.
+    Stop scheduled replication and complete
+    the whole-tap resync; do not restore old LOG_BASED bookmarks after a completed
+    or uncertain drop.
 
 
 FastSync Errors

--- a/pipelinewise/cli/__init__.py
+++ b/pipelinewise/cli/__init__.py
@@ -278,7 +278,7 @@ def main():
     parser.add_argument('--target', type=str, default='*', help='Name of the target')
     parser.add_argument('--tap', type=str, default='*', help='Name of the tap')
     parser.add_argument('--taps', type=str, default='*', help='Comma separated list of tap IDs to import')
-    parser.add_argument('--tables', type=str, help='List of tables to sync')
+    parser.add_argument('--tables', type=str, help='List of tables to sync; specifying it retains the PostgreSQL slot')
     parser.add_argument(
         '--dir', type=str, default='*', help='Path to directory with config'
     )
@@ -340,7 +340,8 @@ def main():
     parser.add_argument('--start_value', type=str, default='*', help='Start value of the column to partial sync')
     parser.add_argument('--end_value', type=str, default=None, help='End value of the column to partial sync')
     parser.add_argument('--force', default=False, required=False,
-                        help='Force fast_sync or a completed data-diff slot',
+                        help='Override fast_sync size limits without overriding sync_start_from, '
+                             'or rerun a completed data-diff slot',
                         action='store_true'
                         )
     parser.add_argument('--replication_method_only', default='*', type=str,

--- a/pipelinewise/cli/commands.py
+++ b/pipelinewise/cli/commands.py
@@ -413,7 +413,6 @@ def build_fastsync_command(
     tables: str = None,
     profiling_mode: bool = False,
     profiling_dir: str = None,
-    drop_pg_slot: bool = False,
     autoresync_size: int = None
 ) -> str:
     """
@@ -421,7 +420,6 @@ def build_fastsync_command(
     given target with optional transformations.
 
     Args:
-        drop_pg_slot: flag for fastsync to indicate whether to drop or not PG replication slot
         profiling_dir: directory where profiling output should be dumped
         profiling_mode: Flag to indicate whether build the command with profiling
         tap: NamedTuple with tap properties
@@ -452,7 +450,6 @@ def build_fastsync_command(
                     if transform.config and os.path.isfile(transform.config)
                     else '',
                     f'--tables {tables}' if tables else '',
-                    '--drop_pg_slot' if drop_pg_slot else '',
                     f'--autoresync_size {autoresync_size}' if autoresync_size else ''
                 ],
             )

--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -8,12 +8,14 @@ import signal
 import sys
 import json
 import copy
+from contextlib import ExitStack, contextmanager
 
 import psutil
 import pidfile
 
 from datetime import datetime
 from time import time
+from uuid import uuid4
 from typing import Dict, Optional, List, Any, NoReturn, Tuple
 from joblib import Parallel, delayed, parallel_backend
 from tabulate import tabulate
@@ -37,6 +39,7 @@ from .errors import (
 )
 
 from pipelinewise.fastsync.commons.tap_postgres import FastSyncTapPostgres
+from pipelinewise.fastsync.commons import utils as fastsync_utils
 from pipelinewise.cli.multiprocess import Process
 from pipelinewise.data_diff.repository import DataDiffRepository
 from pipelinewise.data_diff.runner import rerun_failed_check, run_due_checks
@@ -64,7 +67,6 @@ class PipelineWise:
 
         self.profiling_mode = args.profiler
         self.profiling_dir = profiling_dir
-        self.drop_pg_slot = False
         self.args = args
         self.logger = logging.getLogger(__name__)
         self.config_dir = config_dir
@@ -1133,9 +1135,7 @@ class PipelineWise:
         Generating and running shell command to sync tables using the native fastsync components
         """
         # Build the fastsync executable command
-        max_autoresync_table_size = None
-        if tap.type in ('tap-mysql', 'tap-postgres') and target.type == 'target-snowflake' and not self.force_fast_sync:
-            max_autoresync_table_size = self.config.get('allowed_resync_max_size', {}).get('table_mb')
+        max_autoresync_table_size = self._get_fastsync_size_limit(tap.type, target.type)
 
         command = commands.build_fastsync_command(
             tap=tap,
@@ -1146,7 +1146,6 @@ class PipelineWise:
             tables=self.args.tables,
             profiling_mode=self.profiling_mode,
             profiling_dir=self.profiling_dir,
-            drop_pg_slot=self.drop_pg_slot,
             autoresync_size=max_autoresync_table_size
         )
 
@@ -1414,12 +1413,35 @@ class PipelineWise:
         self.force_fast_sync = self.args.force
         try:
             with pidfile.PIDFile(self.tap['files']['pidfile']):
-                self.do_sync_tables()
+                self.do_sync_tables(
+                    reset_postgres_slot=self._should_reset_postgres_slot_for_fast_sync()
+                )
         except pidfile.AlreadyRunningError as exc:
             self.logger.error('Another instance of the tap is already running.')
             raise SystemExit(1) from exc
 
-    def do_sync_tables(self, fastsync_stream_ids=None):
+    def _get_fastsync_size_limit(self, tap_type, target_type):
+        """Use the same size-limit policy for preflight and the FullSync worker."""
+        if tap_type in ('tap-mysql', 'tap-postgres') and target_type == 'target-snowflake' and not self.force_fast_sync:
+            return self.config.get('allowed_resync_max_size', {}).get('table_mb')
+        return None
+
+    def _should_reset_postgres_slot_for_fast_sync(self) -> bool:
+        """Return whether this command is an unfiltered PostgreSQL resync."""
+        if (
+            self.tap['type'] != ConnectorType.TAP_POSTGRES.value
+            or self.args.tables is not None
+            or self.args.replication_method_only != '*'
+        ):
+            return False
+
+        selection = utils.load_json(self.tap['files']['selection']) or {}
+        return any(
+            table.get('replication_method') == self.LOG_BASED
+            for table in selection.get('selection', [])
+        )
+
+    def do_sync_tables(self, fastsync_stream_ids=None, reset_postgres_slot: bool = False):
         """
         syncing tables by using fast sync
         """
@@ -1435,6 +1457,14 @@ class PipelineWise:
             self._check_target_table_format_supports_fastsync('partial_sync')
         if selected_tables['full_sync']:
             self._check_target_table_format_supports_fastsync('full_sync')
+
+        if reset_postgres_slot:
+            tap_config, target_config = self._preflight_postgres_slot_reset(selected_tables)
+            with self._guard_postgres_slot_reset_from_iceberg_recovery(selected_tables, target_config):
+                FastSyncTapPostgres.reset_slot(
+                    tap_config,
+                    before_reset=self._clear_tap_bookmarks_before_postgres_slot_reset,
+                )
 
         processes_list = []
         if selected_tables['partial_sync']:
@@ -1457,6 +1487,125 @@ class PipelineWise:
                 raise Exception(error)
             if process.exitcode != 0:
                 raise SystemExit(process.exitcode)
+
+    def _preflight_postgres_slot_reset(self, selected_tables):
+        """Validate every local reset dependency before changing source or state."""
+        # pylint: disable=import-outside-toplevel
+        self._check_if_tap_is_enabled()
+
+        tap_type = self.tap['type']
+        target_type = self.target['type']
+        if selected_tables['partial_sync']:
+            self._check_supporting_tap_and_target_for_partial_sync()
+        for operation, get_bin in (
+            ('partial_sync', utils.get_partialsync_bin),
+            ('full_sync', utils.get_fastsync_bin),
+        ):
+            if selected_tables[operation]:
+                self._check_if_complete_tap_configuration(
+                    get_bin(self.venv_dir, tap_type, target_type), tap_type, target_type,
+                )
+
+        tap_config = self._load_required_json_object(self.tap['files']['config'], 'tap configuration')
+        target_config = self._load_required_json_object(self.target['files']['config'], 'target configuration')
+        target_config.update(self._load_required_json_object(
+            self.tap['files']['inheritable_config'], 'tap inheritable configuration',
+        ))
+        properties = self._load_required_json_object(self.tap['files']['properties'], 'tap catalog')
+        self._validate_tap_catalog(properties, self.tap['files']['properties'])
+        catalog_tables = fastsync_utils.get_tables_from_properties(properties)
+        requested_tables = set(selected_tables['full_sync']) | set(selected_tables['partial_sync'])
+        for table in sorted(requested_tables):
+            if table not in catalog_tables:
+                raise fastsync_utils.NotSelectedTableException(table, catalog_tables)
+
+        if target_type == ConnectorType.TARGET_SNOWFLAKE.value:
+            # Local imports keep route entry points out of CLI module initialization.
+            from pipelinewise.fastsync import postgres_to_snowflake
+            from pipelinewise.fastsync.commons import snowflake_iceberg_routes
+
+            required_config = postgres_to_snowflake.REQUIRED_CONFIG_KEYS
+            snowflake_iceberg_routes.validate_route_config(target_config)
+        elif target_type == ConnectorType.TARGET_POSTGRES.value:
+            from pipelinewise.fastsync import postgres_to_postgres
+
+            required_config = postgres_to_postgres.REQUIRED_CONFIG_KEYS
+        else:
+            raise PreRunChecksException(f'Unsupported target for PostgreSQL slot reset: {target_type}')
+
+        fastsync_utils.check_config(tap_config, required_config['tap'])
+        fastsync_utils.check_config(target_config, required_config['target'])
+        if target_type == ConnectorType.TARGET_SNOWFLAKE.value:
+            size_errors = postgres_to_snowflake.get_resync_size_errors(
+                tap_config, selected_tables['full_sync'], self._get_fastsync_size_limit(tap_type, target_type),
+            )
+            if size_errors:
+                raise PreRunChecksException('\n'.join(size_errors) + ' No source or state changes were made.')
+        return tap_config, target_config
+
+    @staticmethod
+    def _load_required_json_object(path, description):
+        """Load a generated JSON object or fail before a source-side reset."""
+        value = utils.load_json(path)
+        if not isinstance(value, dict):
+            raise PreRunChecksException(
+                f'Missing or invalid {description}: {path}. No source changes were made.'
+            )
+        return value
+
+    @contextmanager
+    def _guard_postgres_slot_reset_from_iceberg_recovery(  # pylint: disable=import-outside-toplevel
+        self, selected_tables, target_config,
+    ):
+        """Hold selected Iceberg target locks and reject persisted recovery state."""
+        if target_config.get('target_table_format') != Config.TABLE_FORMAT_ICEBERG:
+            yield
+            return
+
+        # Local imports avoid a CLI import cycle through FastSync state helpers.
+        from pipelinewise.fastsync.commons.snowflake_iceberg_coordination import RecoveryCoordinator
+        from pipelinewise.fastsync.commons.snowflake_iceberg_model import SnowflakeObjectName
+
+        targets = sorted({
+            SnowflakeObjectName(
+                target_config['dbname'].upper(),
+                fastsync_utils.get_target_schema(target_config, table).upper(),
+                fastsync_utils.tablename_to_dict(table)['table_name'].upper(),
+            )
+            for table in set(selected_tables['full_sync']) | set(selected_tables['partial_sync'])
+        }, key=lambda target: target.key)
+
+        coordinator = RecoveryCoordinator(self.get_target_dir(self.target['id']))
+        with ExitStack() as locks:
+            for target in targets:
+                locks.enter_context(coordinator.table_lock(target))
+
+            for target in targets:
+                store = coordinator.recovery_store(target)
+                if store.load_locked() is not None or store.load_fastsync_target_pointer() is not None:
+                    raise PreRunChecksException(
+                        'Cannot reset the PostgreSQL replication slot while an '
+                        'Iceberg publication or conversion attempt is pending. '
+                        'Complete it with the corresponding filtered FastSync or '
+                        'conversion command, then rerun the unfiltered fast_sync. '
+                        'No source or state changes were made.'
+                    )
+            yield
+
+    def _clear_tap_bookmarks_before_postgres_slot_reset(self):
+        """Durably back up and invalidate state before replacing the tap-wide slot."""
+        state_path = self.tap['files']['state']
+        if not os.path.exists(state_path):
+            return None
+        state = self._load_required_json_object(state_path, 'tap state')
+        # Unique backups preserve the original bookmarks even after a failed reset is retried.
+        backup_path = f'{state_path}.before-slot-reset-{uuid4().hex}.bak'
+        fastsync_utils.save_dict_to_json(backup_path, state)
+        self.logger.info('Pre-reset tap state backed up to %s', backup_path)
+        state['bookmarks'] = {}
+        state['currently_syncing'] = None
+        fastsync_utils.save_dict_to_json(state_path, state)
+        return backup_path
 
     def sync_tables_fast_sync(self, selected_tables):
         """
@@ -1499,10 +1648,6 @@ class PipelineWise:
             tap_state = self.tap['files']['state']
             tap_transformation = self.tap['files']['transformation']
             target_config = self.target['files']['config']
-
-            # Set drop_pg_slot to True if we want to sync the whole tap
-            # This flag will be used by FastSync PG to (PG/SF)
-            self.drop_pg_slot = bool(not self.args.tables)
 
             # Some target attributes can be passed and override by tap (aka. inheritable config)
             # We merge the two configs and use that with the target
@@ -2112,8 +2257,6 @@ class PipelineWise:
             tap_state = self.tap['files']['state']
             tap_transformation = self.tap['files']['transformation']
             target_config = self.target['files']['config']
-
-            self.drop_pg_slot = False
 
             cons_target_config = self.create_consumable_target_config(
                 target_config, tap_inheritable_config

--- a/pipelinewise/fastsync/commons/tap_postgres.py
+++ b/pipelinewise/fastsync/commons/tap_postgres.py
@@ -9,7 +9,7 @@ import psycopg2
 import psycopg2.extras
 
 from argparse import Namespace
-from typing import Dict
+from typing import Callable, Dict, Optional
 
 
 from . import utils, split_gzip
@@ -142,6 +142,70 @@ class FastSyncTapPostgres:
 
         finally:
             connection.close()
+
+    @classmethod
+    def reset_slot(cls, connection_config: Dict, *, before_reset: Callable[[], Optional[str]]) -> None:
+        """Validate one tap-specific slot, invalidate state, then replace the slot."""
+        LOGGER.info('Attempting to reset slot ...')
+
+        connection = cls.get_connection(connection_config, prioritize_primary=True)
+        try:
+            with connection.cursor() as cur:
+                slot_name, slot_exists = cls._preflight_slot_reset(cur, connection_config)
+                # State must be durable before DROP: losing its response cannot restore the old WAL boundary.
+                backup_path = before_reset()
+                phase = 'drop' if slot_exists else 'create'
+                try:
+                    if slot_exists:
+                        LOGGER.info('Dropping the slot "%s"', slot_name)
+                        cur.execute('SELECT pg_drop_replication_slot(%s)', (slot_name,))
+                    phase = 'create'
+                    LOGGER.info('Creating the slot "%s"', slot_name)
+                    cur.execute(
+                        'SELECT * FROM pg_create_logical_replication_slot(%s, %s)',
+                        (slot_name, 'wal2json'),
+                    )
+                except psycopg2.Error as exc:
+                    raise RuntimeError(
+                        f'PostgreSQL slot reset failed during {phase} for "{slot_name}"; '
+                        'the source-side outcome may be uncertain. Tap bookmarks remain invalidated. '
+                        f'Pre-reset state backup: {backup_path or "no previous state file"}. '
+                        'Keep scheduled replication stopped, resolve the source error, and rerun '
+                        'the unfiltered fast_sync (adding --force only to bypass the size limit). '
+                        'Do not restore old LOG_BASED bookmarks '
+                        'after a completed or uncertain slot drop.'
+                    ) from exc
+        finally:
+            connection.close()
+
+    @classmethod
+    def _preflight_slot_reset(cls, cursor, connection_config):
+        """Reject shared, active, or incompatible slots before invalidating state."""
+        database = connection_config['dbname']
+        legacy_name = cls.generate_replication_slot_name(database)
+        slot_name = cls.generate_replication_slot_name(database, connection_config['tap_id'])
+        if slot_name == legacy_name or len(slot_name) > 63:
+            raise RuntimeError('Slot reset requires a distinct tap-specific slot name of at most 63 characters.')
+        cursor.execute(
+            'SELECT slot_name, database, plugin, active FROM pg_replication_slots '
+            'WHERE slot_name IN (%s, %s)',
+            (legacy_name, slot_name),
+        )
+        slots = {row[0]: row[1:] for row in cursor.fetchall()}
+        if legacy_name in slots:
+            raise RuntimeError(
+                f'Cannot reset legacy PostgreSQL slot "{legacy_name}": it may be shared by other taps. '
+                'Coordinate migration to tap-specific slots with your DBA before retrying. '
+                'No source or state changes were made.'
+            )
+        if slot_name in slots:
+            slot_database, plugin, active = slots[slot_name]
+            if active or slot_database != database or plugin != 'wal2json':
+                raise RuntimeError(
+                    f'Cannot reset PostgreSQL slot "{slot_name}": it must be inactive, use wal2json, '
+                    'and belong to the configured database. No source or state changes were made.'
+                )
+        return slot_name, slot_name in slots
 
     @classmethod
     def get_connection(

--- a/pipelinewise/fastsync/commons/utils.py
+++ b/pipelinewise/fastsync/commons/utils.py
@@ -735,7 +735,6 @@ def parse_args(required_config_keys: Dict) -> argparse.Namespace:
     --transform         Transformations Config file
     --tables            Tables to sync. (Separated by comma)
     --temp_dir          Directory to create temporary csv exports. Defaults to current work dir.
-    --drop_pg_slot      flag to drop or not the Postgres replication slot before starting the resync
 
     Returns the parsed args object from argparse. For each argument that
     point to JSON files (tap, state, properties, target, transform),
@@ -750,11 +749,6 @@ def parse_args(required_config_keys: Dict) -> argparse.Namespace:
     parser.add_argument('--tables', help='Sync only specific tables')
     parser.add_argument(
         '--temp_dir', help='Temporary directory required for CSV exports'
-    )
-    parser.add_argument(
-        '--drop_pg_slot',
-        help='Drop pg replication slot before starting resync',
-        action='store_true',
     )
     parser.add_argument('--autoresync_size', help='maximum value for table size to resync', )
 

--- a/pipelinewise/fastsync/partialsync/utils.py
+++ b/pipelinewise/fastsync/partialsync/utils.py
@@ -429,12 +429,6 @@ def _get_args_parser_for_partialsync():
     parser.add_argument(
         '--temp_dir', help='Temporary directory required for CSV exports'
     )
-    parser.add_argument(
-        '--drop_pg_slot',
-        help='Drop pg replication slot before starting resync',
-        action='store_true',
-    )
-
     return parser
 
 

--- a/pipelinewise/fastsync/postgres_to_postgres.py
+++ b/pipelinewise/fastsync/postgres_to_postgres.py
@@ -170,10 +170,6 @@ def main_impl():
         pool_size,
     )
 
-    # if internal arg drop_pg_slot is set to True, then we drop the slot before starting resync
-    if args.drop_pg_slot:
-        FastSyncTapPostgres.drop_slot(args.tap)
-
     # Create target schemas sequentially, Postgres doesn't like it running in parallel
     postgres_target = FastSyncTargetPostgres(args.target, args.transform)
     postgres_target.create_schemas(args.tables)

--- a/pipelinewise/fastsync/postgres_to_snowflake.py
+++ b/pipelinewise/fastsync/postgres_to_snowflake.py
@@ -99,13 +99,33 @@ def sync_table(table: str, args: Namespace) -> Union[bool, str]:
     )
 
 
+def get_resync_size_errors(tap_config, tables, maximum_table_size):
+    """Check selected FullSync tables before either slot reset or worker loading."""
+    if not maximum_table_size or not tables:
+        return []
+    errors = []
+    tap_obj = FastSyncTapPostgres(tap_config, tap_type_to_target_type)
+    try:
+        for schema in get_schemas_of_tables_set(tables):
+            all_tables_in_this_schema = get_tables_size(schema, tap_obj)
+            only_selected_tables = filter_out_selected_tables(all_tables_in_this_schema, tables)
+            table_with_maximum_size = get_maximum_value_from_list_of_dicts(only_selected_tables, 'table_size')
+            if table_with_maximum_size.get('table_size') > float(maximum_table_size):
+                errors.append(
+                    f're-sync can not be done because size of table '
+                    f'`{table_with_maximum_size["table_name"]}` is greater than `{maximum_table_size}`!'
+                    f' Use --force argument to force fast_sync!')
+    finally:
+        tap_obj.close_connection(silent=True)
+    return errors
+
+
 def main_impl():
     """Main sync logic"""
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     iceberg_routes.validate_route_config(args.target)
     pool_size = utils.get_pool_size(args.tap)
     start_time = datetime.now()
-    table_sync_excs = []
 
     # Log start info
     LOGGER.info(
@@ -123,27 +143,10 @@ def main_impl():
         pool_size,
     )
 
-    can_run_sync = True
-    if args.autoresync_size:
-        schemas = get_schemas_of_tables_set(args.tables)
-        tap_obj = FastSyncTapPostgres(args.tap, tap_type_to_target_type)
-        for schema in schemas:
-            all_tables_in_this_schema = get_tables_size(schema, tap_obj)
-            only_selected_tables = filter_out_selected_tables(all_tables_in_this_schema, args.tables)
-            table_with_maximum_size = get_maximum_value_from_list_of_dicts(only_selected_tables, 'table_size')
-            if table_with_maximum_size.get('table_size') > float(args.autoresync_size):
-                can_run_sync = False
-                table_sync_excs.append(
-                    f're-sync can not be done because size of table '
-                    f'`{table_with_maximum_size["table_name"]}` is greater than `{args.autoresync_size}`!'
-                    f' Use --force argument to force fast_sync!')
-
-    # if internal arg drop_pg_slot is set to True, then we drop the slot before starting resync
-    if args.drop_pg_slot:
-        FastSyncTapPostgres.drop_slot(args.tap)
+    table_sync_excs = get_resync_size_errors(args.tap, args.tables, args.autoresync_size)
 
     # Start loading tables in parallel in spawning processes
-    if can_run_sync:
+    if not table_sync_excs:
         with multiprocessing.Pool(pool_size) as proc:
             table_sync_excs = list(
                 filter(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(name='pipelinewise',
       python_requires='==3.12.*',
-      version='0.85.0',
+      version='0.85.1',
       description='PipelineWise',
       long_description=LONG_DESCRIPTION,
       long_description_content_type='text/markdown',

--- a/tests/end_to_end/helpers/assertions.py
+++ b/tests/end_to_end/helpers/assertions.py
@@ -27,7 +27,7 @@ def assert_run_tap_success(
         command = f'{command} --profiler'
 
     [return_code, stdout, stderr] = tasks.run_command(command)
-    _assert_run_tap_command_success(return_code, stdout, stderr)
+    _assert_sync_command_success(return_code, stdout, stderr)
     tasks.assert_run_tap_log_engines(stdout, sync_engines)
 
     for sync_engine in sync_engines:
@@ -58,7 +58,7 @@ def assert_run_tap_success(
         )
 
 
-def _assert_run_tap_command_success(return_code, stdout, stderr):
+def _assert_sync_command_success(return_code, stdout, stderr):
     """Expose all failed engine logs before asserting the expected engine set."""
     if return_code == 0 and stderr == '':
         return
@@ -95,6 +95,7 @@ def assert_resync_tables_success(
         command = f'{command} --profiler'
 
     [return_code, stdout, stderr] = tasks.run_command(command)
+    _assert_sync_command_success(return_code, stdout, stderr)
     tasks.assert_run_tap_log_engines(stdout, sync_engines)
 
     if expected_state_streams is None and expected_streams is not None:

--- a/tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_with_split_large_files.py
+++ b/tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_with_split_large_files.py
@@ -2,7 +2,7 @@ from pipelinewise.fastsync import postgres_to_snowflake
 from tests.end_to_end.helpers import assertions
 from tests.end_to_end.target_snowflake.tap_postgres import TapPostgres
 
-TAP_ID = 'postgres_to_sf_split_large_files'
+TAP_ID = 'pg_to_sf_split_large_files'
 TARGET_ID = 'snowflake'
 
 

--- a/tests/end_to_end/test-project/tap_postgres_to_sf_split_large_files.yml.template
+++ b/tests/end_to_end/test-project/tap_postgres_to_sf_split_large_files.yml.template
@@ -3,7 +3,8 @@
 # ------------------------------------------------------------------------------
 # General Properties
 # ------------------------------------------------------------------------------
-id: "postgres_to_sf_split_large_files"
+# The database and tap IDs share PostgreSQL's 63-character slot-name limit.
+id: "pg_to_sf_split_large_files"
 name: "PostgreSQL source test database"
 type: "tap-postgres"
 owner: "test-runner"

--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -4,11 +4,12 @@ import re
 import time
 import psutil
 import pidfile
+import psycopg2
 import pytest
 import shutil
 
 from pathlib import Path
-from unittest.mock import patch, call
+from unittest.mock import MagicMock, Mock, patch, call
 from typing import Callable, Optional
 from slack import WebClient
 
@@ -18,6 +19,8 @@ from pipelinewise.cli.constants import ConnectorType
 from pipelinewise.cli.config import Config
 from pipelinewise.cli.fastsync_capabilities import FastSyncCapabilities
 from pipelinewise.cli.pipelinewise import FASTSYNC_PAIRS, PipelineWise
+from pipelinewise.fastsync.commons import utils as fastsync_utils
+from pipelinewise.fastsync import postgres_to_snowflake
 from pipelinewise.cli.errors import (
     DuplicateConfigException,
     InvalidConfigException,
@@ -904,6 +907,357 @@ tap_three  tap-mysql     target_two   target-s3-csv     True       not-configure
         pipelinewise = self._init_for_sync_tables_states_cleanup(
             tables_arg='db_test_mysql.table_one,db_test_mysql.table_two')
         self._assert_calling_sync_tables(pipelinewise)
+
+    @pytest.mark.parametrize(
+        'force, tables, replication_method_only, tap_type, replication_method, expected_reset',
+        [
+            pytest.param(True, None, '*', 'tap-postgres', 'LOG_BASED', True, id='forced-whole-postgres-tap'),
+            pytest.param(True, 'public.one,public.two', '*', 'tap-postgres', 'LOG_BASED', False,
+                         id='forced-explicit-tables'),
+            pytest.param(False, None, '*', 'tap-postgres', 'LOG_BASED', True, id='ordinary-whole-postgres-tap'),
+            pytest.param(True, None, 'LOG_BASED', 'tap-postgres', 'LOG_BASED', False,
+                         id='forced-replication-method-filter'),
+            pytest.param(True, None, '*', 'tap-mysql', 'LOG_BASED', False, id='forced-whole-mysql-tap'),
+            pytest.param(True, None, '*', 'tap-postgres', 'FULL_TABLE', False,
+                         id='postgres-tap-without-log-based-tables'),
+        ],
+    )
+    def test_fast_sync_requests_postgres_slot_reset_only_for_unfiltered_whole_tap(
+        self, force, tables, replication_method_only, tap_type, replication_method, expected_reset,
+    ):
+        """An unfiltered PostgreSQL resync resets its LOG_BASED slot with or without force."""
+        args = CliArgs(
+            target='target_one',
+            tap='tap_one',
+            force=force,
+            tables=tables,
+            replication_method_only=replication_method_only,
+        )
+        pipelinewise = PipelineWise(args, CONFIG_DIR, VIRTUALENVS_DIR)
+        pipelinewise.tap['type'] = tap_type
+
+        with patch('pipelinewise.cli.pipelinewise.pidfile.PIDFile'), patch(
+            'pipelinewise.cli.pipelinewise.utils.load_json',
+            return_value={'selection': [{'replication_method': replication_method}]},
+        ), patch.object(pipelinewise, 'do_sync_tables') as do_sync_tables:
+            pipelinewise.fast_sync()
+
+        do_sync_tables.assert_called_once_with(reset_postgres_slot=expected_reset)
+
+    @pytest.mark.parametrize('force', [False, True])
+    def test_fast_sync_resets_slot_once_before_mixed_workers_with_or_without_force(self, force):
+        """Reset once before workers, preserving sync_start_from regardless of force."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        pipelinewise.tap['type'] = ConnectorType.TAP_POSTGRES.value
+        pipelinewise.args.force = force
+        calls = Mock()
+        with patch('pipelinewise.cli.pipelinewise.pidfile.PIDFile'), patch.object(
+            pipelinewise, '_preflight_postgres_slot_reset', return_value=({'tap': 'config'}, {}),
+        ), patch.object(
+            pipelinewise, '_clear_tap_bookmarks_before_postgres_slot_reset',
+        ) as clear_bookmarks, patch(
+            'pipelinewise.cli.pipelinewise.FastSyncTapPostgres.reset_slot',
+        ) as reset_slot, patch(
+            'pipelinewise.cli.pipelinewise.Process',
+        ) as process:
+            calls.attach_mock(clear_bookmarks, 'clear_bookmarks')
+            calls.attach_mock(reset_slot, 'reset_slot')
+            calls.attach_mock(process, 'process')
+            reset_slot.side_effect = lambda _config, *, before_reset: before_reset()
+            process.return_value.exception = None
+            process.return_value.exitcode = 0
+            pipelinewise.fast_sync()
+
+        reset_slot.assert_called_once_with({'tap': 'config'}, before_reset=clear_bookmarks)
+        assert calls.mock_calls[:2] == [
+            call.reset_slot({'tap': 'config'}, before_reset=clear_bookmarks),
+            call.clear_bookmarks(),
+        ]
+        assert process.call_args_list == [
+            call(target=pipelinewise.sync_tables_partial_sync, args=(
+                {'db_test_mysql.table_one': {'column': 'id', 'value': '5'}},
+            )),
+            call(target=pipelinewise.sync_tables_fast_sync, args=(['db_test_mysql.table_two'],)),
+        ]
+
+    @pytest.mark.parametrize('force', [False, True])
+    def test_slot_reset_preflight_checks_size_limit_before_state_or_source_changes(self, force):
+        """An oversized FullSync blocks the whole resync unless the size guard is overridden."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        pipelinewise.tap['type'] = ConnectorType.TAP_POSTGRES.value
+        pipelinewise.force_fast_sync = force
+        pipelinewise.config['allowed_resync_max_size'] = {'table_mb': 10}
+        tap_config = dict.fromkeys(postgres_to_snowflake.REQUIRED_CONFIG_KEYS['tap'], 'test')
+        target_config = dict.fromkeys(postgres_to_snowflake.REQUIRED_CONFIG_KEYS['target'], 'test')
+        selected = {'full_sync': ['public.full'], 'partial_sync': {'public.partial': {'column': 'id', 'value': '5'}}}
+        state_path = pipelinewise.tap['files']['state']
+        self._make_sample_state_file(state_path)
+        original_state = fastsync_utils.load_json(state_path)
+        with patch.object(pipelinewise, '_check_if_complete_tap_configuration') as check_executable, patch.object(
+            pipelinewise, '_get_sync_tables_setting_from_selection_file', return_value=selected,
+        ), patch.object(
+            pipelinewise, '_load_required_json_object',
+            side_effect=[tap_config, target_config, {}, {'streams': []}],
+        ), patch.object(
+            fastsync_utils, 'get_tables_from_properties', return_value=['public.full', 'public.partial'],
+        ), patch(
+            'pipelinewise.fastsync.postgres_to_snowflake.get_tables_size',
+            return_value=[{'table_name': 'public.full', 'table_size': 11},
+                          {'table_name': 'public.partial', 'table_size': 100}],
+        ) as sizes, patch('pipelinewise.cli.pipelinewise.FastSyncTapPostgres.reset_slot') as reset_slot, patch(
+            'pipelinewise.cli.pipelinewise.Process',
+        ) as process:
+            process.return_value.exception = None
+            process.return_value.exitcode = 0
+            if force:
+                pipelinewise.do_sync_tables(reset_postgres_slot=True)
+                reset_slot.assert_called_once()
+                sizes.assert_not_called()
+                assert process.call_count == 2
+            else:
+                with pytest.raises(PreRunChecksException, match='No source or state changes were made'):
+                    pipelinewise.do_sync_tables(reset_postgres_slot=True)
+                sizes.assert_called_once()
+                reset_slot.assert_not_called()
+                process.assert_not_called()
+                assert fastsync_utils.load_json(state_path) == original_state
+
+        assert check_executable.call_args_list == [
+            call(f'{pipelinewise.venv_dir}pipelinewise/bin/{binary}', 'tap-postgres', 'target-snowflake')
+            for binary in ('partial-postgres-to-snowflake', 'postgres-to-snowflake')
+        ]
+
+    @pytest.mark.parametrize(
+        'failure, invalidated, statement_count',
+        [
+            ('connect', False, 0), ('inspect', False, 1), ('legacy', False, 1),
+            ('active', False, 1), ('backup', False, 1), ('save_state', False, 1),
+            ('drop', True, 2), ('drop_response', True, 2), ('create', True, 3), ('create_response', True, 3),
+        ],
+    )
+    def test_postgres_slot_reset_failures_preserve_safe_state(
+        self, tmp_path, failure, invalidated, statement_count,
+    ):  # pylint: disable=too-many-locals
+        """Run the real reset and state helpers; inject only source/filesystem failures."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        pipelinewise.tap['type'] = ConnectorType.TAP_POSTGRES.value
+        state_path = tmp_path / 'state.json'
+        pipelinewise.tap['files']['state'] = str(state_path)
+        original = {'bookmarks': {'public-table': {'lsn': 123}}, 'currently_syncing': 'public-table'}
+        fastsync_utils.save_dict_to_json(state_path, original)
+        connection = MagicMock()
+        cursor = connection.cursor.return_value.__enter__.return_value
+        cursor.fetchall.return_value = [('pipelinewise_my_db_my_tap', 'my_db', 'wal2json', failure == 'active')]
+        if failure == 'legacy':
+            cursor.fetchall.return_value.append(('pipelinewise_my_db', 'my_db', 'wal2json', False))
+
+        def execute(sql, _params):
+            state = fastsync_utils.load_json(state_path)
+            if 'FROM pg_replication_slots' in sql:
+                assert state == original
+                if failure == 'inspect':
+                    raise psycopg2.OperationalError('source inspection failed')
+            else:
+                assert state == {'bookmarks': {}, 'currently_syncing': None}
+                backups = list(tmp_path.glob('state.json.before-slot-reset-*.bak'))
+                assert len(backups) == 1
+                assert fastsync_utils.load_json(backups[0]) == original
+                if failure == 'drop' and 'pg_drop_' in sql:
+                    raise psycopg2.errors.ObjectInUse('slot became active after preflight')  # pylint: disable=no-member
+                if failure == 'create' and 'pg_create_' in sql:
+                    raise psycopg2.errors.InsufficientPrivilege('creation denied')  # pylint: disable=no-member
+                if failure.removesuffix('_response') in sql and failure.endswith('_response'):
+                    raise psycopg2.OperationalError('server response lost')
+
+        def save_state(path, state):
+            if failure == 'backup' or failure == 'save_state' and path == str(state_path):
+                raise OSError('state persistence failed')
+            save_json(path, state)
+
+        cursor.execute.side_effect = execute
+        save_json = fastsync_utils.save_dict_to_json
+        with patch.object(
+            pipelinewise, '_preflight_postgres_slot_reset',
+            return_value=({'dbname': 'my_db', 'tap_id': 'my_tap'}, {}),
+        ), patch(
+            'pipelinewise.cli.pipelinewise.FastSyncTapPostgres.get_connection', return_value=connection,
+        ) as connect, patch(
+            'pipelinewise.cli.pipelinewise.Process',
+        ) as process, patch.object(fastsync_utils, 'save_dict_to_json', side_effect=save_state):
+            if failure == 'connect':
+                connect.side_effect = psycopg2.OperationalError('connection failed')
+            with pytest.raises((RuntimeError, psycopg2.Error, OSError)) as error:
+                pipelinewise.do_sync_tables(reset_postgres_slot=True)
+
+        process.assert_not_called()
+        assert cursor.execute.call_count == statement_count
+        state = fastsync_utils.load_json(state_path)
+        assert state == ({'bookmarks': {}, 'currently_syncing': None} if invalidated else original)
+        backups = list(tmp_path.glob('state.json.before-slot-reset-*.bak'))
+        assert len(backups) == int(invalidated or failure == 'save_state')
+        if invalidated:
+            assert f'failed during {failure.split("_")[0]}' in str(error.value)
+            assert 'Do not restore old LOG_BASED bookmarks' in str(error.value)
+            assert str(backups[0]) in str(error.value)
+        if failure != 'connect':
+            connection.close.assert_called_once_with()
+
+    def test_do_sync_tables_does_not_reset_slot_when_preflight_fails(self):
+        """A disabled tap fails before Singer state or its source slot changes."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        pipelinewise.tap['type'] = ConnectorType.TAP_POSTGRES.value
+        pipelinewise.tap['enabled'] = False
+
+        with patch.object(
+            pipelinewise, '_clear_tap_bookmarks_before_postgres_slot_reset'
+        ) as clear_bookmarks, patch(
+            'pipelinewise.cli.pipelinewise.FastSyncTapPostgres.reset_slot'
+        ) as reset_slot, patch(
+            'pipelinewise.cli.pipelinewise.Process'
+        ) as process:
+            with pytest.raises(PreRunChecksException):
+                pipelinewise.do_sync_tables(reset_postgres_slot=True)
+
+        clear_bookmarks.assert_not_called()
+        reset_slot.assert_not_called()
+        process.assert_not_called()
+
+    def test_postgres_slot_reset_preflight_rejects_stale_catalog(self):
+        """Every requested table must still be selected in the Singer catalog."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        pipelinewise.tap['type'] = ConnectorType.TAP_POSTGRES.value
+        pipelinewise.target['type'] = ConnectorType.TARGET_POSTGRES.value
+        properties = {'streams': [{
+            'stream': 'other_table',
+            'metadata': [{'breadcrumb': [], 'metadata': {'selected': True, 'schema-name': 'public'}}],
+        }]}
+
+        with patch.object(
+            pipelinewise, '_check_if_complete_tap_configuration'
+        ), patch.object(
+            pipelinewise,
+            '_load_required_json_object',
+            side_effect=[{}, {}, {}, properties],
+        ):
+            with pytest.raises(
+                fastsync_utils.NotSelectedTableException,
+                match='public.table_one',
+            ):
+                pipelinewise._preflight_postgres_slot_reset(  # pylint: disable=protected-access
+                    {'full_sync': ['public.table_one'], 'partial_sync': {}}
+                )
+
+    @pytest.mark.parametrize('pending, manifest_reads, pointer_reads', [
+        ('conversion', 1, 0), ('fastsync', 1, 1), (None, 2, 2),
+    ])
+    def test_do_sync_tables_checks_iceberg_recovery_under_target_locks(self, pending, manifest_reads, pointer_reads):
+        """Lock all targets and check both recovery stores before allowing a reset."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        pipelinewise.tap['type'] = ConnectorType.TAP_POSTGRES.value
+        target_config = {
+            'target_table_format': Config.TABLE_FORMAT_ICEBERG,
+            'dbname': 'target_db',
+            'default_target_schema': 'target_schema',
+        }
+        coordinator = MagicMock()
+        store = coordinator.recovery_store.return_value
+        store.load_locked.return_value = object() if pending == 'conversion' else None
+        store.load_fastsync_target_pointer.return_value = object() if pending == 'fastsync' else None
+        with patch(
+            'pipelinewise.fastsync.commons.snowflake_iceberg_coordination.RecoveryCoordinator',
+            return_value=coordinator,
+        ), patch.object(
+            pipelinewise, '_preflight_postgres_slot_reset', return_value=({}, target_config),
+        ), patch.object(
+            pipelinewise, '_clear_tap_bookmarks_before_postgres_slot_reset'
+        ) as clear_bookmarks, patch(
+            'pipelinewise.cli.pipelinewise.FastSyncTapPostgres.reset_slot'
+        ) as reset_slot, patch('pipelinewise.cli.pipelinewise.Process') as process:
+            process.return_value.exception = None
+            process.return_value.exitcode = 0
+            if pending:
+                with pytest.raises(PreRunChecksException, match='Iceberg publication or conversion attempt is pending'):
+                    pipelinewise.do_sync_tables(reset_postgres_slot=True)
+                clear_bookmarks.assert_not_called()
+                reset_slot.assert_not_called()
+                process.assert_not_called()
+            else:
+                pipelinewise.do_sync_tables(reset_postgres_slot=True)
+                reset_slot.assert_called_once()
+                assert process.call_count == 2
+
+        targets = [lock_call.args[0] for lock_call in coordinator.table_lock.call_args_list]
+        assert [target.key for target in targets] == [
+            'TARGET_DB.TARGET_SCHEMA.TABLE_ONE', 'TARGET_DB.TARGET_SCHEMA.TABLE_TWO',
+        ]
+        assert [entry[0] for entry in coordinator.mock_calls[:4]] == [
+            'table_lock', 'table_lock().__enter__', 'table_lock', 'table_lock().__enter__',
+        ]
+        assert store.load_locked.call_count == manifest_reads
+        assert store.load_fastsync_target_pointer.call_count == pointer_reads
+        assert coordinator.table_lock.return_value.__exit__.call_count == 2
+
+    def test_clear_tap_bookmarks_before_postgres_slot_reset(self):
+        """A failed worker launch cannot leave state pointing before the new slot."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        state_path = pipelinewise.tap['files']['state']
+        self._make_sample_state_file(state_path)
+        original = fastsync_utils.load_json(state_path)
+
+        backup_path = pipelinewise._clear_tap_bookmarks_before_postgres_slot_reset()  # pylint: disable=protected-access
+
+        with open(state_path, encoding='utf-8') as state_file:
+            state = json.load(state_file)
+        assert state == {'bookmarks': {}, 'currently_syncing': None}
+        assert fastsync_utils.load_json(backup_path) == original
+        retry_backup = pipelinewise._clear_tap_bookmarks_before_postgres_slot_reset()  # pylint: disable=protected-access
+        assert retry_backup != backup_path
+        assert fastsync_utils.load_json(backup_path) == original
+        assert fastsync_utils.load_json(retry_backup) == state
+
+    def test_automatic_initial_sync_retains_postgres_slot(self):
+        """Automatic initial FastSync does not request a whole-tap slot reset."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        pipelinewise.tap['type'] = ConnectorType.TAP_POSTGRES.value
+
+        with patch(
+            'pipelinewise.cli.pipelinewise.FastSyncTapPostgres.reset_slot'
+        ) as reset_slot, patch(
+            'pipelinewise.cli.pipelinewise.Process'
+        ) as process:
+            process.return_value.exception = None
+            process.return_value.exitcode = 0
+            pipelinewise.do_sync_tables(
+                fastsync_stream_ids=[
+                    'db_test_mysql-table_one',
+                    'db_test_mysql-table_two',
+                ]
+            )
+
+        reset_slot.assert_not_called()
+
+    def test_partial_sync_retains_postgres_slot(self):
+        """Standalone PartialSync never resets the logical replication slot."""
+        pipelinewise = self._init_for_sync_tables_states_cleanup()
+        pipelinewise.tap['type'] = ConnectorType.TAP_POSTGRES.value
+
+        with patch.object(
+            pipelinewise, '_check_if_complete_tap_configuration'
+        ), patch.object(
+            pipelinewise, 'run_tap_partialsync'
+        ), patch(
+            'pipelinewise.cli.pipelinewise.FastSyncTapPostgres.reset_slot'
+        ) as reset_slot:
+            pipelinewise.sync_tables_partial_sync(
+                {
+                    'db_test_mysql.table_one': {
+                        'column': 'id',
+                        'static_value': '5',
+                    }
+                }
+            )
+
+        reset_slot.assert_not_called()
 
     def test_do_sync_tables_reset_state_file_for_partial_sync(self):
         """Testing if selected partial sync tables are filtered from state file if sync_tables run"""

--- a/tests/units/fastsync/assertions.py
+++ b/tests/units/fastsync/assertions.py
@@ -894,15 +894,12 @@ def assert_main_impl_exit_normally_on_success(
         with patch(objects_to_mock.full_target_class_nm):
             with patch(objects_to_mock.sync_table_fn_nm):
                 with patch(objects_to_mock.multiproc_module_nm) as multiproc_mock:
-                    with patch(objects_to_mock.full_tap_class_nm) as tap_mock:
-                        tap_mock.return_value.drop_slot.side_effect = None
-
+                    with patch(objects_to_mock.full_tap_class_nm):
                         ns = Namespace(
                             **{
                                 'tables': ['table_1', 'table_2', 'table_3', 'table_4'],
                                 'target': {},
                                 'transform': None,
-                                'drop_pg_slot': False,
                                 'tap': {},
                                 'autoresync_size': None
                             }
@@ -934,7 +931,6 @@ def assert_main_impl_exit_normally_on_success(
                         multiproc_mock.Pool.assert_called_once_with(10)
                         assert utils_mock.parse_args.call_count == 1
                         assert mock_enter.return_value.map.call_count == 1
-                        assert tap_mock.return_value.drop_slot.call_count == 0
 
 
 # pylint: disable=missing-function-docstring,unused-variable,invalid-name
@@ -949,15 +945,12 @@ def assert_main_impl_should_exit_with_error_on_failure(
         with patch(objects_to_mock.full_target_class_nm):
             with patch(objects_to_mock.sync_table_fn_nm):
                 with patch(objects_to_mock.multiproc_module_nm) as multiproc_mock:
-                    with patch(objects_to_mock.full_tap_class_nm) as tap_mock:
-                        tap_mock.return_value.drop_slot.side_effect = None
-
+                    with patch(objects_to_mock.full_tap_class_nm):
                         ns = Namespace(
                             **{
                                 'tables': ['table_1', 'table_2', 'table_3', 'table_4'],
                                 'target': {},
                                 'transform': None,
-                                'drop_pg_slot': True,
                                 'tap': {
                                     'fastsync_parallelism': 4,
                                 },
@@ -986,13 +979,12 @@ def assert_main_impl_should_exit_with_error_on_failure(
                         with pytest.raises(SystemExit):
                             main_impl()
 
-                            # assertions
-                            assert utils_mock.parse_args.call_count == 1
-                            assert mock_enter.return_value.map.call_count == 1
-                            assert tap_mock.return_value.drop_slot.call_count == 1
-                            utils_mock.get_pool_size.assert_called_once_with(
-                                {
-                                    'fastsync_parallelism': 4,
-                                }
-                            )
-                            multiproc_mock.Pool.assert_called_once_with(10)
+                        # assertions
+                        assert utils_mock.parse_args.call_count == 1
+                        assert mock_enter.return_value.map.call_count == 1
+                        utils_mock.get_pool_size.assert_called_once_with(
+                            {
+                                'fastsync_parallelism': 4,
+                            }
+                        )
+                        multiproc_mock.Pool.assert_called_once_with(10)

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -3,7 +3,7 @@ import io
 
 from decimal import Decimal
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, PropertyMock, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
 
 from pipelinewise.fastsync.commons.tap_postgres import FastSyncTapPostgres
 from pipelinewise.fastsync.commons import tap_postgres
@@ -349,6 +349,80 @@ class TestFastSyncTapPostgres(TestCase):  # pylint: disable=too-many-public-meth
 
         connect_mock.return_value.close.assert_called_once_with()
         connect_mock.return_value.cursor.assert_not_called()
+
+    def test_reset_slot_drops_only_current_slot_after_state_invalidation(self):
+        """Only the preflighted tap-specific slot is dropped, after state is durable."""
+        connection = MagicMock()
+        cursor = connection.cursor.return_value.__enter__.return_value
+        cursor.fetchall.return_value = [('pipelinewise_my_db_my_tap', 'my_db', 'wal2json', False)]
+        creds = {'dbname': 'my_db', 'tap_id': 'my_tap'}
+        before_reset = MagicMock(return_value='state.backup')
+        calls = MagicMock()
+        calls.attach_mock(cursor.execute, 'execute')
+        calls.attach_mock(before_reset, 'before_reset')
+
+        with patch.object(
+            FastSyncTapPostgres, 'get_connection', return_value=connection
+        ) as get_connection:
+            FastSyncTapPostgres.reset_slot(creds, before_reset=before_reset)
+
+        get_connection.assert_called_once_with(creds, prioritize_primary=True)
+        assert calls.mock_calls == [
+            call.execute(
+                'SELECT slot_name, database, plugin, active FROM pg_replication_slots '
+                'WHERE slot_name IN (%s, %s)',
+                ('pipelinewise_my_db', 'pipelinewise_my_db_my_tap'),
+            ),
+            call.before_reset(),
+            call.execute('SELECT pg_drop_replication_slot(%s)', ('pipelinewise_my_db_my_tap',)),
+            call.execute(
+                'SELECT * FROM pg_create_logical_replication_slot(%s, %s)',
+                ('pipelinewise_my_db_my_tap', 'wal2json'),
+            ),
+        ]
+        connection.close.assert_called_once_with()
+
+    def test_reset_slot_rejects_legacy_active_and_incompatible_slots_before_state_changes(self):
+        """Legacy lookup takes precedence even when an inactive tap-specific slot also exists."""
+        current = ('pipelinewise_my_db_my_tap', 'my_db', 'wal2json', False)
+        cases = [
+            ([('pipelinewise_my_db', 'my_db', 'wal2json', active)] + modern, 'legacy')
+            for active in (False, True) for modern in ([], [current])
+        ] + [
+            ([(current[0], database, plugin, active)], 'must be inactive')
+            for database, plugin, active in (
+                ('my_db', 'wal2json', True), ('other_db', 'wal2json', False), ('my_db', 'pgoutput', False),
+            )
+        ]
+        for rows, message in cases:
+            with self.subTest(rows=rows):
+                connection = MagicMock()
+                cursor = connection.cursor.return_value.__enter__.return_value
+                cursor.fetchall.return_value = rows
+                before_reset = MagicMock()
+                with patch.object(FastSyncTapPostgres, 'get_connection', return_value=connection):
+                    with self.assertRaisesRegex(RuntimeError, message):
+                        FastSyncTapPostgres.reset_slot(
+                            {'dbname': 'my_db', 'tap_id': 'my_tap'}, before_reset=before_reset,
+                        )
+                before_reset.assert_not_called()
+                self.assertEqual(cursor.execute.call_count, 1)
+                connection.close.assert_called_once_with()
+
+    def test_reset_slot_creates_missing_slot_without_dropping_any_slot(self):
+        """A missing slot still requires state invalidation before creation."""
+        connection = MagicMock()
+        cursor = connection.cursor.return_value.__enter__.return_value
+        cursor.fetchall.return_value = []
+        before_reset = MagicMock(return_value=None)
+        with patch.object(FastSyncTapPostgres, 'get_connection', return_value=connection):
+            FastSyncTapPostgres.reset_slot({'dbname': 'my_db', 'tap_id': 'my_tap'}, before_reset=before_reset)
+        before_reset.assert_called_once_with()
+        self.assertEqual(cursor.execute.call_count, 2)
+        cursor.execute.assert_called_with(
+            'SELECT * FROM pg_create_logical_replication_slot(%s, %s)', ('pipelinewise_my_db_my_tap', 'wal2json'),
+        )
+        connection.close.assert_called_once_with()
 
     @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
     def test_get_connection_to_sec(self, connect_mock):

--- a/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_postgres.py
@@ -424,6 +424,31 @@ class TestFastSyncTapPostgres(TestCase):  # pylint: disable=too-many-public-meth
         )
         connection.close.assert_called_once_with()
 
+    def test_reset_slot_name_length_boundary(self):
+        """Accept exactly 63 characters; reject a longer name before SQL or state changes."""
+        slot_prefix = FastSyncTapPostgres.generate_replication_slot_name('my_db') + '_'
+        for length in (63, 64):
+            with self.subTest(length=length):
+                config = {'dbname': 'my_db', 'tap_id': 't' * (length - len(slot_prefix))}
+                connection = MagicMock()
+                cursor = connection.cursor.return_value.__enter__.return_value
+                cursor.fetchall.return_value = []
+                before_reset = MagicMock(return_value=None)
+                with patch.object(FastSyncTapPostgres, 'get_connection', return_value=connection):
+                    if length == 64:
+                        with self.assertRaisesRegex(RuntimeError, 'at most 63 characters'):
+                            FastSyncTapPostgres.reset_slot(config, before_reset=before_reset)
+                        cursor.execute.assert_not_called()
+                        before_reset.assert_not_called()
+                    else:
+                        FastSyncTapPostgres.reset_slot(config, before_reset=before_reset)
+                        before_reset.assert_called_once_with()
+                        cursor.execute.assert_called_with(
+                            'SELECT * FROM pg_create_logical_replication_slot(%s, %s)',
+                            (slot_prefix + config['tap_id'], 'wal2json'),
+                        )
+                connection.close.assert_called_once_with()
+
     @patch('pipelinewise.fastsync.commons.tap_postgres.psycopg2.connect')
     def test_get_connection_to_sec(self, connect_mock):
         """

--- a/tests/units/fastsync/commons/test_fastsync_utils.py
+++ b/tests/units/fastsync/commons/test_fastsync_utils.py
@@ -857,7 +857,6 @@ class TestFastSyncUtils(TestCase):  # pylint: disable=too-many-public-methods
                 'tap': './tap.yml',
                 'properties': './prop.json',
                 'transform': None,
-                'drop_pg_slot': True,
                 'target': './target.yml',
                 'tables': 'schema.table_1,schema.table_2',
                 'temp_dir': './',
@@ -878,7 +877,6 @@ class TestFastSyncUtils(TestCase):  # pylint: disable=too-many-public-methods
             vars(args),
             {
                 'tables': {'schema.table_1', 'schema.table_2'},
-                'drop_pg_slot': True,
                 'tap': {},
                 'target': {},
                 'transform': {},
@@ -896,7 +894,7 @@ class TestFastSyncUtils(TestCase):  # pylint: disable=too-many-public-methods
     ):
         """
         test args parsing:
-            one table is specified out of 2, this should return a drop_pg_slot = False
+            one table is specified out of 2
         """
         mock_args.return_value = argparse.Namespace(
             **{

--- a/tests/units/fastsync/test_postgres_to_snowflake.py
+++ b/tests/units/fastsync/test_postgres_to_snowflake.py
@@ -8,6 +8,7 @@ from pipelinewise.fastsync.postgres_to_snowflake import (
     tap_type_to_target_type,
     sync_table,
     main_impl,
+    get_resync_size_errors,
 )
 from pipelinewise.fastsync.commons.snowflake_iceberg import (
     QueryHistoryLookupError,
@@ -25,6 +26,28 @@ class PostgresToSnowflake(unittest.TestCase):  # pylint: disable=too-many-public
     """
     Unit tests for fastsync postgres to snowflake
     """
+
+    def test_resync_size_check_only_inspects_selected_fullsync_tables(self):
+        with patch(f'{PACKAGE_IN_SCOPE}.get_tables_size', return_value=[
+            {'table_name': 'public.full', 'table_size': 10},
+            {'table_name': 'public.partial', 'table_size': 999},
+        ]) as sizes:
+            self.assertEqual(get_resync_size_errors({}, ['public.full'], 10), [])
+        sizes.assert_called_once()
+
+    def test_resync_size_check_skips_unlimited_or_partial_only_runs(self):
+        with patch(f'{PACKAGE_IN_SCOPE}.get_tables_size') as sizes:
+            self.assertEqual(get_resync_size_errors({}, ['public.full'], None), [])
+            self.assertEqual(get_resync_size_errors({}, [], 10), [])
+        sizes.assert_not_called()
+
+    def test_resync_size_check_closes_source_after_inspection_failure(self):
+        with patch(f'{PACKAGE_IN_SCOPE}.get_tables_size', side_effect=RuntimeError('inspection failed')), patch(
+            f'{PACKAGE_IN_SCOPE}.FastSyncTapPostgres',
+        ) as source:
+            with self.assertRaisesRegex(RuntimeError, 'inspection failed'):
+                get_resync_size_errors({}, ['public.full'], 10)
+        source.return_value.close_connection.assert_called_once_with(silent=True)
 
     def test_tap_type_to_target_type_with_defined_tap_type_returns_equivalent_target_type(
         self,

--- a/tests/units/test_end_to_end_failures.py
+++ b/tests/units/test_end_to_end_failures.py
@@ -1,0 +1,25 @@
+"""E2E diagnostics must expose command failures that occur before workers start."""
+
+from unittest.mock import patch
+
+import pytest
+
+from tests.end_to_end.helpers import assertions
+
+
+@pytest.mark.parametrize('assert_success', [
+    assertions.assert_run_tap_success, assertions.assert_resync_tables_success,
+])
+def test_preflight_error_is_reported(assert_success, capsys):
+    """A pre-worker rejection must expose the CLI error even without engine logs."""
+    with patch.object(
+        assertions.tasks, 'run_command', return_value=[1, 'preflight output', 'slot name is too long'],
+    ), patch.object(assertions.tasks, 'assert_run_tap_log_engines') as check_engines:
+        with pytest.raises(AssertionError):
+            assert_success('postgres_to_sf', 'snowflake', sync_engines=('fastsync',))
+
+    check_engines.assert_not_called()
+    output = capsys.readouterr().out
+    assert 'preflight output' in output
+    assert 'slot name is too long' in output
+    assert 'FAILED LOGS: <none found>' in output


### PR DESCRIPTION
## Context

Whole-tap PostgreSQL FastSync was not resetting its logical replication slot: the old worker flag was derived after `args.tables` had already been populated. This left the existing WAL boundary in place instead of establishing a new one for the resync.

Slot replacement also needs to happen once, before both FullSync and configured PartialSync workers, without deleting a slot shared by another tap or leaving bookmarks pointing to discarded WAL.

## Changes

- Reset the tap-specific slot once for an explicit, unfiltered PostgreSQL `fast_sync` containing LOG_BASED tables, with or without `--force`.
- Retain the slot for any `--tables` argument, non-default `--replication_method_only`, automatic initial loads, standalone PartialSync, and taps without LOG_BASED tables.
- Preflight configuration, selected catalog entries, applicable FullSync size limits, and the source slot before changing state. Reject active, incompatible, and legacy database-wide slots.
- Durably preserve a unique state backup and clear every tap bookmark before dropping and recreating the slot. Report the failed phase and backup path on drop/create errors, including lost responses; never automatically restore stale bookmarks.
- Hold managed-Iceberg target locks and refuse the reset while publication or conversion recovery is pending.
- Keep `--force` as the resync size-limit override; it does not override `sync_start_from` or promote configured PartialSync into FullSync.
- Remove the obsolete worker-level `--drop_pg_slot` plumbing, share the size-limit check, consolidate regression tests, and centralize operator guidance.
- Keep the split-file E2E fixture within PostgreSQL's 63-character slot-name limit, surface pre-worker command errors, and add unit coverage for the 63/64-character boundary and failure diagnostics.
- Bump PipelineWise to 0.85.1. See the [0.85.1 CHANGELOG entry](https://github.com/transferwise/pipelinewise/blob/0b8c1975a75744ab62a123efa23697fcb5c2ddec/CHANGELOG.md#0851-2026-09-12).

## Type of change

- [x] Bug fix
- [x] Maintenance, dependency, or CI
- [x] Documentation

## Compatibility and operations

No backend schema migration or Singer state-format change is required. Deleted-tap slot cleanup during `import_config` is unchanged.

An unfiltered PostgreSQL `fast_sync` now actually replaces the tap-specific slot. Omit `--tables` and leave `--replication_method_only` at its default `*` to request this; explicitly listing every table still retains the slot. The deprecated `sync_tables` alias has the same behavior. The internal worker option `--drop_pg_slot` is removed; use the public CLI to coordinate resets.

Slot replacement is not atomic. PipelineWise keeps unique `state.json.before-slot-reset-<id>.bak` files, but these backups cannot recover discarded WAL. If reset or subsequent loading fails, keep scheduled replication stopped, resolve the failure, and complete an unfiltered whole-tap resync. Do not restore old LOG_BASED bookmarks after a completed or uncertain drop, including during rollback.

Legacy database-wide slots require coordinated DBA migration before a reset is allowed. Pending managed-Iceberg publication/conversion recovery must be completed through the corresponding filtered FastSync or conversion command first.

Configured `sync_start_from` ranges remain effective even with `--force`. Ensure those ranges cover the changes that need rebuilding: retained rows outside the range are not refreshed by the slot reset.

## Validation

Checks ran in the existing, ready dev-project Docker environment. After GitHub's second attempt reproduced the split-file fixture failure, it was reproduced locally, fixed, and the full affected E2E group plus root lint/unit, configuration, and documentation gates were rerun before pushing. Rows marked **initial commit** were not repeated for the test-only follow-up.

| Command or check | Result |
|---|---|
| `ruff check pipelinewise tests` | Passed |
| `pylint pipelinewise tests` | Passed — 10.00/10 |
| `flake8 pipelinewise --count --select=E9,F63,F7,F82 --show-source --statistics` | Passed — 0 findings |
| `flake8 pipelinewise --count --max-complexity=15 --max-line-length=120 --statistics` | Passed — 0 findings |
| `pytest --cov=pipelinewise --cov-fail-under=77 -v tests/units` | 1,366 passed, 154 subtests passed, 0 failed, 0 skipped; 91 warnings; coverage gate passed |
| `pipelinewise validate --dir dev-project/pipelinewise-config` | Passed |
| `cd docs && make check` | 6 reference checks passed; strict Sphinx build passed |
| Previously failing E2E group below | 9 passed, 0 failed, 0 skipped (490.52s) |
| Split-file E2E test alone (same path below) | 1 passed, 0 failed, 0 skipped (41.91s) |
| PostgreSQL E2E group below — **initial commit** | 14 passed, 0 failed, 1 skipped; 1 warning |
| Snowflake resync E2E group below — **initial commit** | 8 passed, 0 failed, 0 skipped |
| Isolated PostgreSQL source smoke checks — **initial commit** | 3 passed — exact tap-slot replacement, active-slot rejection, and legacy-slot isolation; temporary database and slots removed |
| Generated dev-project tap CLI smoke checks — **initial commit** | 7 passed — ordinary Singer run, whole-tap resync with/without force, explicit all-table selection with/without force, method filter, and Singer handover |
| `git diff --check origin/master...HEAD` | Passed |
| Credential-like addition scan and diff review | No credential/private-key patterns or production source records found |
| GitHub commit signature verification | Verified — valid |
| [GitHub E2E run 34714698187](https://github.com/transferwise/pipelinewise/actions/runs/34714698187) on `0b8c1975` | All 9 groups passed: 65 tests passed, 0 failed, 0 skipped; 2 warnings |

The S3-to-PostgreSQL test was skipped because dedicated tap-S3 credentials were not configured. Local validation covers the three listed E2E groups across the initial commit and follow-up, not the complete nine-group matrix. The source/CLI smoke checks used temporary session scripts and are not new committed E2E tests.

Both original GitHub E2E attempts had 8 passes and 1 failure in the affected group. Local reproduction revealed that the fixture generated a 64-character slot name; the application correctly rejects names above 63 before mutation. Only the test fixture and diagnostics were changed for this follow-up; the slot safety guard is unchanged.

An earlier unit run exposed three assertions tied to how `ExitStack` passes the mock context manager to `__enter__`. The assertions were corrected to verify lock order without that implementation detail; the complete final unit run above passed.

<details>
<summary>Exact E2E and session smoke commands</summary>

E2E groups ran serially because local fixtures share configuration and databases.

```bash
# Follow-up: complete group that failed on both GitHub attempts.
docker exec pipelinewise pytest \
  tests/end_to_end/target_snowflake/tap_mariadb/test_partial_sync_mariadb_to_sf.py \
  tests/end_to_end/target_snowflake/tap_postgres/test_defined_partial_sync_pg_to_sf.py \
  tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_with_split_large_files.py \
  -vx --timer-top-n 10

# Initial commit validation:
docker exec pipelinewise pytest \
  tests/end_to_end/test_target_postgres.py \
  tests/end_to_end/test_postgres_stream_buffer_recovery.py \
  tests/end_to_end/data_diff/test_postgres_to_postgres.py \
  tests/end_to_end/data_diff/test_mysql_to_postgres.py \
  -vx --timer-top-n 10

docker exec pipelinewise pytest \
  tests/end_to_end/target_snowflake/tap_mysql/test_iceberg_v3_mysql_to_sf.py \
  tests/end_to_end/target_snowflake/tap_postgres/test_resync_pg_to_sf_table_size_check.py \
  tests/end_to_end/target_snowflake/tap_mariadb/test_resync_mariadb_to_sf.py \
  tests/end_to_end/target_snowflake/tap_postgres/test_replicate_pg_to_sf_with_archive_load_files.py \
  -vx --timer-top-n 10

# Session-local smoke scripts, not repository test entry points:
docker exec -i pipelinewise python < /private/tmp/ap3335_slot_safety_smoke.py
docker exec -i pipelinewise python < /private/tmp/ap3335_cli_slot_smoke.py
```

</details>

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] This pull request is focused and can be reviewed and reverted independently.
- [x] Behavioural changes have regression tests, or I explained why tests are not applicable.
- [x] Relevant documentation and changelog entries are updated, or I explained why they are not applicable.
- [x] Applicable local checks pass; failures, skips, and unavailable checks are documented above.
- [x] The change contains no credentials, private keys, production identifiers, or source records.
- [x] Breaking and compatibility impacts are identified above.
